### PR TITLE
feat(security): keystore, identity, audit, redaction — Tier 0-2

### DIFF
--- a/engine/security/__init__.py
+++ b/engine/security/__init__.py
@@ -1,6 +1,26 @@
-"""b1e55ed package boundary.
+"""engine.security
 
-0xb1e55ed = "blessed". The name is the first easter egg.
+Security + identity primitives.
 
-A grimoire is not a textbook. It is a book of names, invocations, and hard-won procedures.
+Tier model (v1.0):
+- Tier 0: environment variables
+- Tier 1: encrypted vault file (Fernet)
+- Tier 2: OS keyring (optional)
+
+The chain remembers.
 """
+
+from engine.security.audit import AuditLogger
+from engine.security.identity import NodeIdentity, generate_node_identity
+from engine.security.keystore import Keystore, KeystoreTier
+from engine.security.redaction import redact_secrets, sanitize_for_log
+
+__all__ = [
+    "AuditLogger",
+    "NodeIdentity",
+    "generate_node_identity",
+    "Keystore",
+    "KeystoreTier",
+    "redact_secrets",
+    "sanitize_for_log",
+]

--- a/engine/security/audit.py
+++ b/engine/security/audit.py
@@ -1,4 +1,74 @@
-"""Module placeholder.
+"""engine.security.audit
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Database-backed audit logger.
+
+The goal is not theatrics — it's forensic usability.
+The chain remembers.
 """
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from engine.core.database import Database
+
+
+def _dt_to_iso(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).isoformat()
+
+
+@dataclass
+class AuditLogger:
+    """Writes security-relevant actions to the `audit_log` table."""
+
+    db: Database
+    component: str = "security"
+
+    def log_action(self, action: str, actor: str | None, details: dict[str, Any] | None = None) -> None:
+        payload = json.dumps(details or {}, sort_keys=True)
+        with self.db.conn:  # type: ignore[attr-defined]
+            self.db.conn.execute(  # type: ignore[attr-defined]
+                "INSERT INTO audit_log (action, actor, component, details) VALUES (?, ?, ?, ?)",
+                (action, actor, self.component, payload),
+            )
+
+    def query(
+        self,
+        action_type: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        q = "SELECT ts, action, actor, component, details FROM audit_log WHERE 1=1"
+        params: list[Any] = []
+
+        if action_type is not None:
+            q += " AND action = ?"
+            params.append(action_type)
+
+        if since is not None:
+            q += " AND ts >= ?"
+            params.append(_dt_to_iso(since))
+
+        q += " ORDER BY ts DESC LIMIT ?"
+        params.append(limit)
+
+        rows = self.db.conn.execute(q, tuple(params)).fetchall()  # type: ignore[attr-defined]
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            out.append(
+                {
+                    "ts": r[0],
+                    "action": r[1],
+                    "actor": r[2],
+                    "component": r[3],
+                    "details": json.loads(r[4]) if r[4] else {},
+                }
+            )
+        return out

--- a/engine/security/identity.py
+++ b/engine/security/identity.py
@@ -1,4 +1,155 @@
-"""Module placeholder.
+"""engine.security.identity
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Ed25519 node identity.
+
+DECISIONS_V3 #11: generate silently during setup; prompt for backup on first
+network use (or after 7 days). The prompting is handled by higher layers.
+
+Easter egg: node_id is prefixed with `b1e55ed-`.
 """
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+
+_ITERATIONS = 480_000
+
+
+def _derive_fernet_key(password: str, salt: bytes) -> bytes:
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=_ITERATIONS,
+    )
+    return base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+
+
+def _password() -> str:
+    pw = os.environ.get("B1E55ED_MASTER_PASSWORD") or os.environ.get("B1E55ED_IDENTITY_PASSWORD")
+    if pw:
+        return pw
+    raise ValueError(
+        "Missing identity encryption password. Set B1E55ED_MASTER_PASSWORD (preferred) "
+        "or B1E55ED_IDENTITY_PASSWORD."
+    )
+
+
+@dataclass
+class NodeIdentity:
+    node_id: str
+    public_key: str  # hex
+    private_key: str  # hex (in-memory). At rest: encrypted.
+    created_at: str
+
+    @property
+    def public_key_hex(self) -> str:
+        return self.public_key
+
+    def _private_obj(self) -> Ed25519PrivateKey:
+        raw = bytes.fromhex(self.private_key)
+        return Ed25519PrivateKey.from_private_bytes(raw)
+
+    def _public_obj(self) -> Ed25519PublicKey:
+        raw = bytes.fromhex(self.public_key)
+        return Ed25519PublicKey.from_public_bytes(raw)
+
+    def sign(self, data: bytes) -> bytes:
+        return self._private_obj().sign(data)
+
+    def verify(self, sig: bytes, data: bytes) -> bool:
+        try:
+            self._public_obj().verify(sig, data)
+            return True
+        except Exception:
+            return False
+
+    def save(self, path: str | Path) -> None:
+        """Save identity to JSON, with encrypted private key."""
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        salt = os.urandom(16)
+        f = Fernet(_derive_fernet_key(_password(), salt))
+
+        encrypted_priv = f.encrypt(bytes.fromhex(self.private_key))
+        blob = {
+            "node_id": self.node_id,
+            "created_at": self.created_at,
+            "public_key": self.public_key,
+            "private_key_enc": base64.b64encode(encrypted_priv).decode("ascii"),
+            "kdf": {
+                "name": "pbkdf2_hmac_sha256",
+                "iterations": _ITERATIONS,
+                "salt_b64": base64.b64encode(salt).decode("ascii"),
+            },
+            "alg": "ed25519",
+        }
+
+        path.write_text(json.dumps(blob, indent=2, sort_keys=True), encoding="utf-8")
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+    @classmethod
+    def load(cls, path: str | Path) -> "NodeIdentity":
+        path = Path(path)
+        blob = json.loads(path.read_text(encoding="utf-8"))
+
+        if blob.get("alg") != "ed25519":
+            raise ValueError("Unsupported identity alg")
+
+        salt = base64.b64decode(blob["kdf"]["salt_b64"])
+        f = Fernet(_derive_fernet_key(_password(), salt))
+
+        try:
+            priv_raw = f.decrypt(base64.b64decode(blob["private_key_enc"]))
+        except InvalidToken as e:
+            raise ValueError("Invalid password or corrupted identity file") from e
+
+        return cls(
+            node_id=str(blob["node_id"]),
+            public_key=str(blob["public_key"]),
+            private_key=priv_raw.hex(),
+            created_at=str(blob["created_at"]),
+        )
+
+
+def generate_node_identity() -> NodeIdentity:
+    """Generate a new Ed25519 identity."""
+
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+
+    pub_raw = pub.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    priv_raw = priv.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    node_id = f"b1e55ed-{pub_raw.hex()[:8]}"
+    created_at = datetime.now(tz=UTC).isoformat()
+
+    return NodeIdentity(
+        node_id=node_id,
+        public_key=pub_raw.hex(),
+        private_key=priv_raw.hex(),
+        created_at=created_at,
+    )

--- a/engine/security/keystore.py
+++ b/engine/security/keystore.py
@@ -1,4 +1,374 @@
-"""Module placeholder.
+"""engine.security.keystore
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Flattened keystore with Tier 0-2 backends.
+
+"Keys to the kingdom" live here — store them like you intend to keep them.
+
+Tiering (DECISIONS_V3 #8):
+- Tier 0: environment variables (read-only)
+- Tier 1: encrypted vault file (Fernet)
+- Tier 2: OS keyring via `keyring` (optional)
+
+Tier 3 (YubiKey/MPC) is explicitly Phase 2.
 """
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Any
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+
+class KeystoreTier(IntEnum):
+    ENV = 0
+    ENCRYPTED_FILE = 1
+    KEYRING = 2
+
+
+_ITERATIONS = 480_000
+_SALT_SIZE = 32
+_DEFAULT_DIR = Path.home() / ".b1e55ed" / "secrets"
+_DEFAULT_VAULT = _DEFAULT_DIR / "vault.enc"
+_DEFAULT_SALT = _DEFAULT_DIR / "vault.salt"
+_DEFAULT_METADATA = _DEFAULT_DIR / "key_metadata.json"
+_SERVICE_NAME = "b1e55ed"
+
+
+def _derive_fernet_key(password: str, salt: bytes) -> bytes:
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=_ITERATIONS,
+    )
+    return base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+
+
+def _require_password(env_var: str = "B1E55ED_MASTER_PASSWORD") -> str:
+    pw = os.environ.get(env_var)
+    if pw:
+        return pw
+    raise ValueError(
+        f"Missing master password. Set {env_var} or pass password explicitly when constructing Keystore."
+    )
+
+
+@dataclass(frozen=True)
+class KeyHealth:
+    name: str
+    tier: KeystoreTier
+    status: str  # healthy|warning|critical|missing
+    issues: list[str]
+
+
+class _EnvBackend:
+    def __init__(self, prefix: str | None = None):
+        self.prefix = prefix
+
+    def get(self, name: str) -> str:
+        v = os.environ.get(name)
+        if v is None:
+            raise KeyError(name)
+        return v
+
+    def set(self, name: str, value: str) -> None:
+        raise PermissionError("Tier 0 env store is read-only")
+
+    def list_keys(self) -> list[str]:
+        if self.prefix is None:
+            return sorted(os.environ.keys())
+        return sorted(k for k in os.environ.keys() if k.startswith(self.prefix))
+
+    def has(self, name: str) -> bool:
+        return os.environ.get(name) is not None
+
+
+class _EncryptedFileBackend:
+    def __init__(
+        self,
+        *,
+        password: str,
+        vault_path: Path = _DEFAULT_VAULT,
+        salt_path: Path = _DEFAULT_SALT,
+        auto_create: bool = True,
+    ):
+        self.vault_path = Path(vault_path)
+        self.salt_path = Path(salt_path)
+        self.auto_create = auto_create
+        self._password = password
+        self._secrets: dict[str, str] = {}
+        self._load()
+
+    def _ensure_dir(self) -> None:
+        self.vault_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(self.vault_path.parent, 0o700)
+        except OSError:
+            pass
+
+    def _get_or_create_salt(self) -> bytes:
+        if self.salt_path.exists():
+            return self.salt_path.read_bytes()
+        if not self.auto_create:
+            raise FileNotFoundError(str(self.salt_path))
+        self._ensure_dir()
+        salt = os.urandom(_SALT_SIZE)
+        self.salt_path.write_bytes(salt)
+        try:
+            os.chmod(self.salt_path, 0o600)
+        except OSError:
+            pass
+        return salt
+
+    def _fernet(self) -> Fernet:
+        salt = self._get_or_create_salt()
+        return Fernet(_derive_fernet_key(self._password, salt))
+
+    def _load(self) -> None:
+        if not self.vault_path.exists():
+            self._secrets = {}
+            return
+        encrypted = self.vault_path.read_bytes()
+        try:
+            data = self._fernet().decrypt(encrypted)
+        except InvalidToken as e:
+            raise ValueError("Invalid password or corrupted vault") from e
+        self._secrets = json.loads(data.decode("utf-8"))
+
+    def _save(self) -> None:
+        self._ensure_dir()
+        data = json.dumps(self._secrets, sort_keys=True, indent=2).encode("utf-8")
+        encrypted = self._fernet().encrypt(data)
+        self.vault_path.write_bytes(encrypted)
+        try:
+            os.chmod(self.vault_path, 0o600)
+        except OSError:
+            pass
+
+    def get(self, name: str) -> str:
+        if name not in self._secrets:
+            raise KeyError(name)
+        return self._secrets[name]
+
+    def set(self, name: str, value: str) -> None:
+        self._secrets[name] = value
+        self._save()
+
+    def list_keys(self) -> list[str]:
+        return sorted(self._secrets.keys())
+
+    def has(self, name: str) -> bool:
+        return name in self._secrets
+
+
+class _KeyringBackend:
+    def __init__(self, *, service_name: str = _SERVICE_NAME):
+        try:
+            import keyring
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError("keyring library not installed") from e
+
+        self.keyring = keyring
+        self.service_name = service_name
+        self.registry_key = "__keyring_registry__"
+
+        # best-effort sanity check
+        backend = keyring.get_keyring()
+        name = type(backend).__name__.lower()
+        if "fail" in name or "null" in name:
+            raise RuntimeError("No usable keyring backend available")
+
+    def _load_registry(self) -> list[str]:
+        try:
+            data = self.keyring.get_password(self.service_name, self.registry_key)
+            if not data:
+                return []
+            return json.loads(data)
+        except Exception:
+            return []
+
+    def _save_registry(self, keys: list[str]) -> None:
+        self.keyring.set_password(self.service_name, self.registry_key, json.dumps(sorted(set(keys))))
+
+    def _add_registry(self, name: str) -> None:
+        keys = self._load_registry()
+        if name not in keys:
+            keys.append(name)
+            self._save_registry(keys)
+
+    def get(self, name: str) -> str:
+        v = self.keyring.get_password(self.service_name, name)
+        if v is None:
+            raise KeyError(name)
+        return v
+
+    def set(self, name: str, value: str) -> None:
+        self.keyring.set_password(self.service_name, name, value)
+        self._add_registry(name)
+
+    def list_keys(self) -> list[str]:
+        return self._load_registry()
+
+    def has(self, name: str) -> bool:
+        return self.keyring.get_password(self.service_name, name) is not None
+
+
+class Keystore:
+    """Unified keystore facade.
+
+    Lookup order is Tier 0 → Tier 1 → Tier 2 by default (env overrides are convenient).
+
+    Note: Tier 0 is read-only by design.
+    """
+
+    def __init__(
+        self,
+        *,
+        env_prefix: str | None = None,
+        vault_path: Path = _DEFAULT_VAULT,
+        salt_path: Path = _DEFAULT_SALT,
+        password: str | None = None,
+        enable_keyring: bool = True,
+        keyring_service: str = _SERVICE_NAME,
+        metadata_path: Path = _DEFAULT_METADATA,
+    ):
+        self._env = _EnvBackend(prefix=env_prefix)
+        self._password = password
+        self._vault_path = Path(vault_path)
+        self._salt_path = Path(salt_path)
+        self._metadata_path = Path(metadata_path)
+
+        self._tier1: _EncryptedFileBackend | None = None
+        if password is not None or os.environ.get("B1E55ED_MASTER_PASSWORD"):
+            self._tier1 = _EncryptedFileBackend(
+                password=password or _require_password(),
+                vault_path=self._vault_path,
+                salt_path=self._salt_path,
+            )
+
+        self._tier2: _KeyringBackend | None = None
+        if enable_keyring:
+            try:
+                self._tier2 = _KeyringBackend(service_name=keyring_service)
+            except Exception:
+                self._tier2 = None
+
+        self._metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._metadata_path.exists():
+            self._metadata_path.write_text("{}", encoding="utf-8")
+            try:
+                os.chmod(self._metadata_path, 0o600)
+            except OSError:
+                pass
+
+    def store_key(self, name: str, value: str, tier: KeystoreTier) -> None:
+        if tier == KeystoreTier.ENV:
+            raise PermissionError("Cannot write to Tier 0 env")
+        if tier == KeystoreTier.ENCRYPTED_FILE:
+            if self._tier1 is None:
+                self._tier1 = _EncryptedFileBackend(
+                    password=self._password or _require_password(),
+                    vault_path=self._vault_path,
+                    salt_path=self._salt_path,
+                )
+            self._tier1.set(name, value)
+        elif tier == KeystoreTier.KEYRING:
+            if self._tier2 is None:
+                raise RuntimeError("Tier 2 keyring not available")
+            self._tier2.set(name, value)
+        else:
+            raise ValueError(f"Unknown tier: {tier}")
+
+        self._register_metadata(name=name, tier=tier)
+
+    def get_key(self, name: str) -> str:
+        if self._env.has(name):
+            return self._env.get(name)
+        if self._tier1 is not None and self._tier1.has(name):
+            return self._tier1.get(name)
+        if self._tier2 is not None and self._tier2.has(name):
+            return self._tier2.get(name)
+        raise KeyError(name)
+
+    def list_keys(self) -> list[str]:
+        keys: set[str] = set()
+        keys.update(self._env.list_keys())
+        if self._tier1 is not None:
+            keys.update(self._tier1.list_keys())
+        if self._tier2 is not None:
+            keys.update(self._tier2.list_keys())
+        return sorted(keys)
+
+    def key_health(self) -> dict[str, Any]:
+        """Return a lightweight health view.
+
+        The legacy implementation tracked age and permissions. Here we keep a minimal
+        metadata registry and report per-key tier availability.
+        """
+
+        meta = self._load_metadata()
+        out: dict[str, Any] = {"overall": "healthy", "keys": {}}
+
+        overall = "healthy"
+        for name, info in meta.items():
+            tier = KeystoreTier(int(info.get("tier", 1)))
+            present = False
+            if tier == KeystoreTier.ENV:
+                present = self._env.has(name)
+            elif tier == KeystoreTier.ENCRYPTED_FILE:
+                # For health, "present" means it exists at rest (not just in-memory).
+                present = (
+                    self._tier1 is not None
+                    and self._vault_path.exists()
+                    and self._tier1.has(name)
+                )
+            elif tier == KeystoreTier.KEYRING:
+                present = self._tier2 is not None and self._tier2.has(name)
+
+            status = "healthy" if present else "missing"
+            if status != "healthy":
+                overall = "warning" if overall == "healthy" else overall
+
+            out["keys"][name] = {
+                "tier": int(tier),
+                "status": status,
+                "created_at": info.get("created_at"),
+            }
+
+        out["overall"] = overall
+        out["tier2_available"] = self._tier2 is not None
+        out["tier1_configured"] = self._tier1 is not None
+        return out
+
+    # --- metadata ---
+
+    def _load_metadata(self) -> dict[str, Any]:
+        try:
+            return json.loads(self._metadata_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def _save_metadata(self, data: dict[str, Any]) -> None:
+        self._metadata_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        try:
+            os.chmod(self._metadata_path, 0o600)
+        except OSError:
+            pass
+
+    def _register_metadata(self, *, name: str, tier: KeystoreTier) -> None:
+        data = self._load_metadata()
+        if name not in data:
+            from datetime import datetime, UTC
+
+            data[name] = {"tier": int(tier), "created_at": datetime.now(tz=UTC).isoformat()}
+        else:
+            data[name]["tier"] = int(tier)
+        self._save_metadata(data)

--- a/engine/security/redaction.py
+++ b/engine/security/redaction.py
@@ -1,4 +1,76 @@
-"""Module placeholder.
+"""engine.security.redaction
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Secret redaction helpers.
+
+These are deliberately pragmatic: redact likely secrets before anything hits logs.
 """
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+
+_REDACTION_PATTERNS: list[tuple[str, str]] = [
+    # Generic key/value
+    (r"(?i)(api[_-]?key|secret|password)\s*[:=]\s*[^\s\"']+", "[REDACTED]"),
+    # OpenAI
+    (r"sk-proj-[a-zA-Z0-9]{20,}", "[REDACTED]"),
+    (r"sk-[a-zA-Z0-9]{20,}", "[REDACTED]"),
+    # Anthropic
+    (r"sk-ant-api\d+-[a-zA-Z0-9]+", "[REDACTED]"),
+    # xAI
+    (r"xai-[a-zA-Z0-9]{20,}", "[REDACTED]"),
+    # JWT
+    (r"eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+", "[REDACTED]"),
+    # Private key / secret hex
+    (r"0x[a-fA-F0-9]{64}", "[REDACTED]"),
+    # Solana base58-ish addresses (very rough, avoids false positives by requiring length)
+    (r"\b[1-9A-HJ-NP-Za-km-z]{32,44}\b", "[REDACTED]"),
+    # ETH address (not secret, but treated as sensitive in logs)
+    (r"\b0x[a-fA-F0-9]{40}\b", "[REDACTED]"),
+]
+
+_SENSITIVE_FIELD_NAMES = {
+    "api_key",
+    "apikey",
+    "secret",
+    "password",
+    "token",
+    "private_key",
+    "seed",
+    "mnemonic",
+    "auth",
+    "authorization",
+}
+
+
+def redact_secrets(text: str) -> str:
+    out = text
+    for pattern, repl in _REDACTION_PATTERNS:
+        out = re.sub(pattern, repl, out)
+    return out
+
+
+def sanitize_for_log(data: dict[str, Any]) -> dict[str, Any]:
+    """Deep-copy and redact sensitive fields + embedded secrets."""
+
+    def _walk(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            new: dict[str, Any] = {}
+            for k, v in obj.items():
+                if str(k).lower() in _SENSITIVE_FIELD_NAMES:
+                    new[k] = "[REDACTED]"
+                else:
+                    new[k] = _walk(v)
+            return new
+        if isinstance(obj, list):
+            return [_walk(v) for v in obj]
+        if isinstance(obj, tuple):
+            return [_walk(v) for v in obj]
+        if isinstance(obj, str):
+            return redact_secrets(obj)
+        return obj
+
+    return _walk(copy.deepcopy(data))

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from engine.core.database import Database
+from engine.security.audit import AuditLogger
+
+
+def test_audit_log_writes_and_queries(temp_dir: Path) -> None:
+    db = Database(temp_dir / "test.db")
+    audit = AuditLogger(db, component="unit")
+
+    audit.log_action("KEY_ACCESS", actor="tester", details={"name": "X"})
+    audit.log_action("CONFIG_CHANGE", actor="tester", details={"k": "v"})
+
+    rows = audit.query(action_type="KEY_ACCESS")
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "tester"
+    assert rows[0]["details"]["name"] == "X"
+
+    since = datetime.now(tz=UTC) - timedelta(days=1)
+    rows2 = audit.query(since=since)
+    assert len(rows2) >= 2
+
+    db.close()

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.security.identity import NodeIdentity, generate_node_identity
+
+
+def test_generate_node_identity_format_and_sign_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    ident = generate_node_identity()
+
+    assert ident.node_id.startswith("b1e55ed-")
+    assert len(ident.node_id) == len("b1e55ed-") + 8
+
+    msg = b"hello"
+    sig = ident.sign(msg)
+    assert ident.verify(sig, msg) is True
+    assert ident.verify(sig, b"tampered") is False
+
+
+def test_identity_save_load_roundtrip(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test-password")
+
+    ident = generate_node_identity()
+    path = temp_dir / "identity.json"
+    ident.save(path)
+
+    loaded = NodeIdentity.load(path)
+    assert loaded.node_id == ident.node_id
+    assert loaded.public_key == ident.public_key
+
+    # signing still works after load
+    data = b"roundtrip"
+    sig = loaded.sign(data)
+    assert loaded.verify(sig, data) is True

--- a/tests/unit/test_keystore.py
+++ b/tests/unit/test_keystore.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from engine.security.keystore import Keystore, KeystoreTier
+
+
+def test_keystore_tier1_encrypts_at_rest(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test-password")
+
+    vault = temp_dir / "vault.enc"
+    salt = temp_dir / "vault.salt"
+    meta = temp_dir / "key_metadata.json"
+
+    ks = Keystore(vault_path=vault, salt_path=salt, metadata_path=meta, enable_keyring=False)
+    ks.store_key("TEST_API_KEY", "supersecret", KeystoreTier.ENCRYPTED_FILE)
+
+    # file exists and doesn't contain plaintext
+    raw = vault.read_bytes()
+    assert b"supersecret" not in raw
+
+    assert ks.get_key("TEST_API_KEY") == "supersecret"
+
+
+def test_keystore_tier0_env_readonly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENV_ONLY_KEY", "v")
+    ks = Keystore(enable_keyring=False)
+    assert ks.get_key("ENV_ONLY_KEY") == "v"
+
+    with pytest.raises(PermissionError):
+        ks.store_key("X", "y", KeystoreTier.ENV)
+
+
+def test_keystore_list_keys_unions_sources(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test-password")
+    monkeypatch.setenv("ENV_ONLY_KEY", "env")
+
+    ks = Keystore(
+        vault_path=temp_dir / "vault.enc",
+        salt_path=temp_dir / "vault.salt",
+        metadata_path=temp_dir / "key_metadata.json",
+        enable_keyring=False,
+    )
+    ks.store_key("FILE_KEY", "file", KeystoreTier.ENCRYPTED_FILE)
+
+    keys = ks.list_keys()
+    assert "ENV_ONLY_KEY" in keys
+    assert "FILE_KEY" in keys
+
+
+def test_key_health_reports_missing(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test-password")
+
+    vault = temp_dir / "vault.enc"
+    salt = temp_dir / "vault.salt"
+    meta = temp_dir / "key_metadata.json"
+
+    ks = Keystore(vault_path=vault, salt_path=salt, metadata_path=meta, enable_keyring=False)
+    ks.store_key("A", "1", KeystoreTier.ENCRYPTED_FILE)
+
+    # simulate missing key by deleting vault
+    os.remove(vault)
+
+    report = ks.key_health()
+    assert report["overall"] in {"healthy", "warning"}
+    assert report["keys"]["A"]["status"] == "missing"

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from engine.security.redaction import redact_secrets, sanitize_for_log
+
+
+def test_redact_secrets_api_keys_and_wallets() -> None:
+    text = "openai=sk-proj-abcdefghijklmnopqrstuv1234567890 and eth=0x" + "a" * 40
+    out = redact_secrets(text)
+    assert "sk-proj-" not in out
+    assert "0x" + "a" * 40 not in out
+    assert "[REDACTED]" in out
+
+
+def test_sanitize_for_log_nested() -> None:
+    payload = {
+        "api_key": "secret123",
+        "nested": {"token": "eyJabc.eyJdef.ghi", "notes": "ok"},
+        "list": ["xai-abcdefghijklmnopqrstuv12345"],
+    }
+
+    clean = sanitize_for_log(payload)
+    assert clean["api_key"] == "[REDACTED]"
+    assert clean["nested"]["token"] == "[REDACTED]"
+    assert clean["nested"]["notes"] == "ok"
+    assert clean["list"][0] == "[REDACTED]"


### PR DESCRIPTION
Sprint 0B: Security + Identity module.

**Keystore** — Unified 3-tier key storage:
- Tier 0: env vars (read-only)
- Tier 1: Fernet-encrypted vault file (PBKDF2)
- Tier 2: OS keyring (optional)

**Identity** — Ed25519 node identity:
- `generate_node_identity()` creates keypair silently
- `node_id = b1e55ed-{pubkey_hex[:8]}`
- Sign/verify, save/load with encrypted private key

**Audit** — SQLite audit trail for all sensitive operations

**Redaction** — Pattern-based secret scrubbing for logs

**Tests:** 9 passing

> *The keys to the kingdom are not the kingdom.*