### PR TITLE
feat(producers): framework — protocol, registry, template, context

### DIFF
--- a/engine/producers/base.py
+++ b/engine/producers/base.py
@@ -1,4 +1,163 @@
-"""Module placeholder.
+"""engine.producers.base
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Producers are the sensory organs of the system.
+
+They observe the world, distill observations into events, and hand those events to the
+rest of the pipeline. The brain cannot reason about what the producers cannot see.
+
+Observation protocol:
+- collect raw facts
+- normalize into the event contract
+- publish into the hash-chained journal
 """
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
+
+from engine.core.client import DataClient
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.metrics import MetricsRegistry
+from engine.core.models import Event, compute_event_hash
+from engine.core.types import ProducerHealth, ProducerResult
+
+
+@dataclass(frozen=True, slots=True)
+class ProducerContext:
+    """Shared context injected into every producer."""
+
+    config: Config
+    db: Database
+    client: DataClient
+    metrics: MetricsRegistry
+    logger: logging.Logger
+
+
+@runtime_checkable
+class Producer(Protocol):
+    name: str
+    domain: str  # "technical" | "onchain" | "tradfi" | "social" | "events" | "curator"
+    schedule: str  # Cron expression or "continuous"
+
+    def collect(self) -> list[dict]: ...
+
+    def normalize(self, raw: list[dict]) -> list[Event]: ...
+
+    def publish(self, events: list[Event]) -> int: ...
+
+    def run(self) -> ProducerResult: ...
+
+
+class BaseProducer(ABC):
+    """Template-method base class.
+
+    Subclasses typically implement:
+    - collect()
+    - normalize()
+
+    and inherit:
+    - publish() (default: append to the event store)
+    - run() (collect → normalize → publish)
+    """
+
+    name: str
+    domain: str
+    schedule: str
+
+    def __init__(self, ctx: ProducerContext) -> None:
+        self.ctx = ctx
+
+    @abstractmethod
+    def collect(self) -> list[dict]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def normalize(self, raw: list[dict]) -> list[Event]:
+        raise NotImplementedError
+
+    def publish(self, events: list[Event]) -> int:
+        """Default publisher: append events to the database.
+
+        Producers may return "draft" Event objects (placeholder id/hash). The database
+        remains the source of truth for ids + the hash chain.
+        """
+
+        published = 0
+        for ev in events:
+            self.ctx.db.append_event(
+                event_type=ev.type,
+                payload=ev.payload,
+                ts=ev.ts,
+                observed_at=ev.observed_at,
+                source=ev.source or self.name,
+                trace_id=ev.trace_id,
+                schema_version=ev.schema_version,
+                dedupe_key=ev.dedupe_key,
+            )
+            published += 1
+        return published
+
+    def run(self) -> ProducerResult:
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+        staleness_ms: int | None = None
+
+        try:
+            raw = self.collect()
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except Exception as e:  # noqa: BLE001 - producer isolation boundary
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("producer_run_failed", extra={"producer": self.name})
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=staleness_ms,
+            health=health,
+        )
+
+    def draft_event(
+        self,
+        *,
+        event_type,
+        payload: dict,
+        ts: datetime | None = None,
+        observed_at: datetime | None = None,
+        source: str | None = None,
+        trace_id: str | None = None,
+        dedupe_key: str | None = None,
+    ) -> Event:
+        """Create a minimal Event suitable for passing to publish()."""
+
+        ts_ = ts or datetime.now(tz=UTC)
+        if ts_.tzinfo is None:
+            ts_ = ts_.replace(tzinfo=UTC)
+
+        h = compute_event_hash(prev_hash=None, event_type=event_type, payload=payload)
+        return Event(
+            id=str(uuid.uuid4()),
+            type=event_type,
+            ts=ts_,
+            observed_at=observed_at,
+            source=source or self.name,
+            trace_id=trace_id,
+            schema_version="v1",
+            dedupe_key=dedupe_key,
+            payload=payload,
+            prev_hash=None,
+            hash=h,
+        )

--- a/engine/producers/registry.py
+++ b/engine/producers/registry.py
@@ -1,4 +1,88 @@
-"""Module placeholder.
+"""engine.producers.registry
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+All producers report for duty.
+
+Registry responsibilities:
+- @register("name", domain="...") decorator
+- lookup/list helpers
+- module auto-discovery (import engine.producers.* to trigger decorators)
+
+Discovery is intentionally simple. The contract lives in events; this is just plumbing.
 """
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from collections.abc import Callable
+from typing import Any
+
+from engine.producers.base import Producer
+
+
+_REGISTRY: dict[str, type[Producer]] = {}
+_DISCOVERED = False
+
+
+def register(name: str, *, domain: str) -> Callable[[type[Any]], type[Any]]:
+    def _decorator(cls: type[Any]) -> type[Any]:
+        if name in _REGISTRY and _REGISTRY[name] is not cls:
+            raise ValueError(f"producer already registered: {name}")
+
+        setattr(cls, "name", name)
+        setattr(cls, "domain", domain)
+        _REGISTRY[name] = cls  # type: ignore[assignment]
+        return cls
+
+    return _decorator
+
+
+def discover() -> None:
+    global _DISCOVERED
+    if _DISCOVERED:
+        return
+
+    pkg_name = "engine.producers"
+    pkg = importlib.import_module(pkg_name)
+
+    for m in pkgutil.iter_modules(pkg.__path__, prefix=f"{pkg_name}."):
+        modname = m.name
+        if modname.endswith(".base") or modname.endswith(".registry"):
+            continue
+        importlib.import_module(modname)
+
+    _DISCOVERED = True
+
+
+def get_producer(name: str) -> type[Producer]:
+    discover()
+    if name not in _REGISTRY:
+        raise KeyError(f"unknown producer: {name}")
+    return _REGISTRY[name]
+
+
+def list_producers() -> list[str]:
+    discover()
+    return sorted(_REGISTRY.keys())
+
+
+def list_by_domain(domain: str) -> list[str]:
+    discover()
+    return sorted([n for n, cls in _REGISTRY.items() if getattr(cls, "domain", None) == domain])
+
+
+def _reset_for_tests() -> None:
+    """Clear registry and unload producer modules so decorators can re-run."""
+
+    import sys
+
+    global _DISCOVERED
+    _REGISTRY.clear()
+    _DISCOVERED = False
+
+    for key in list(sys.modules.keys()):
+        if not key.startswith("engine.producers."):
+            continue
+        if key.endswith(".registry") or key.endswith(".base"):
+            continue
+        sys.modules.pop(key, None)

--- a/engine/producers/template.py
+++ b/engine/producers/template.py
@@ -1,4 +1,52 @@
-"""Module placeholder.
+"""engine.producers.template
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Copy-this producer.
+
+This is the "add a new producer in five minutes" experience.
+
+TODO (new contributor):
+- rename TemplateProducer
+- pick a real domain
+- replace the dummy payload with your real observation
+- add a second event if the world is complicated (it is)
+
+Precision is the tone. Not hype.
 """
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from engine.core.events import EventType
+from engine.core.models import Event
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+@register("template", domain="events")
+class TemplateProducer(BaseProducer):
+    """A small, working example used by unit tests."""
+
+    schedule = "continuous"
+
+    def collect(self) -> list[dict]:
+        now = datetime.now(tz=UTC)
+        return [{"ts": now.isoformat()}]
+
+    def normalize(self, raw: list[dict]) -> list[Event]:
+        ts = datetime.fromisoformat(raw[0]["ts"]).astimezone(UTC)
+        payload = {
+            "symbol": "BTC",
+            "headline_sentiment": None,
+            "impact_score": None,
+            "event_count": 0,
+            "catalysts": ["template"],
+        }
+        return [
+            self.draft_event(
+                event_type=EventType.SIGNAL_EVENTS_V1,
+                payload=payload,
+                ts=ts,
+                source=self.name,
+            )
+        ]

--- a/tests/unit/test_producer_base.py
+++ b/tests/unit/test_producer_base.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+from datetime import UTC, datetime
+
+from engine.core.client import DataClient
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.producers.base import BaseProducer, Producer, ProducerContext, ProducerHealth, ProducerResult
+
+
+class _GoodProducer:
+    name = "good"
+    domain = "events"
+    schedule = "continuous"
+
+    def collect(self) -> list[dict]:
+        return []
+
+    def normalize(self, raw: list[dict]):  # type: ignore[no-untyped-def]
+        return []
+
+    def publish(self, events):  # type: ignore[no-untyped-def]
+        return 0
+
+    def run(self) -> ProducerResult:
+        return ProducerResult(
+            events_published=0,
+            errors=[],
+            duration_ms=0,
+            timestamp=datetime.now(tz=UTC),
+        )
+
+
+class _BadProducer:
+    name = "bad"
+    domain = "events"
+    schedule = "continuous"
+
+    def collect(self) -> list[dict]:
+        return []
+
+
+def test_protocol_runtime_checkable() -> None:
+    assert isinstance(_GoodProducer(), Producer)
+    assert not isinstance(_BadProducer(), Producer)
+
+
+def test_producer_result_is_dataclass_and_serializable() -> None:
+    pr = ProducerResult(
+        events_published=3,
+        errors=["x"],
+        duration_ms=12,
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        staleness_ms=500,
+        health=ProducerHealth.DEGRADED,
+    )
+    assert dataclasses.is_dataclass(pr)
+    d = dataclasses.asdict(pr)
+    assert d["events_published"] == 3
+    assert d["health"] == ProducerHealth.DEGRADED
+
+
+def test_producer_health_enum_values() -> None:
+    assert ProducerHealth.OK.value == "ok"
+    assert ProducerHealth.ERROR.value == "error"
+
+
+def test_base_producer_run_template_method_publishes(tmp_path) -> None:
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DataClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    class P(BaseProducer):
+        name = "p"
+        domain = "events"
+        schedule = "continuous"
+
+        def collect(self) -> list[dict]:
+            return [{"x": 1}]
+
+        def normalize(self, raw: list[dict]):
+            assert raw == [{"x": 1}]
+            return [
+                self.draft_event(
+                    event_type=EventType.SIGNAL_EVENTS_V1,
+                    payload={
+                        "symbol": "BTC",
+                        "headline_sentiment": None,
+                        "impact_score": None,
+                        "event_count": 0,
+                        "catalysts": ["unit"],
+                    },
+                )
+            ]
+
+    pr = P(ctx).run()
+    assert pr.events_published == 1
+    assert pr.errors == []
+
+    events = db.get_events(event_type=EventType.SIGNAL_EVENTS_V1, source="p", limit=10)
+    assert len(events) == 1
+    assert db.verify_hash_chain(fast=False)
+
+
+def test_base_producer_run_handles_exceptions(tmp_path) -> None:
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DataClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    class P(BaseProducer):
+        name = "broken"
+        domain = "events"
+        schedule = "continuous"
+
+        def collect(self) -> list[dict]:
+            raise RuntimeError("boom")
+
+        def normalize(self, raw: list[dict]):  # pragma: no cover
+            return []
+
+    pr = P(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.ERROR
+    assert pr.errors and "RuntimeError" in pr.errors[0]

--- a/tests/unit/test_producer_registry.py
+++ b/tests/unit/test_producer_registry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from engine.producers.base import BaseProducer
+from engine.producers.registry import (
+    _reset_for_tests,
+    get_producer,
+    list_by_domain,
+    list_producers,
+    register,
+)
+
+
+def test_register_and_get_producer() -> None:
+    _reset_for_tests()
+
+    @register("x", domain="technical")
+    class X(BaseProducer):
+        schedule = "continuous"
+
+        def collect(self) -> list[dict]:
+            return []
+
+        def normalize(self, raw: list[dict]):
+            return []
+
+    assert get_producer("x") is X
+    assert "x" in list_producers()
+    assert list_by_domain("technical") == ["x"]
+
+
+def test_duplicate_name_rejected() -> None:
+    _reset_for_tests()
+
+    @register("dup", domain="events")
+    class A(BaseProducer):
+        schedule = "continuous"
+
+        def collect(self) -> list[dict]:
+            return []
+
+        def normalize(self, raw: list[dict]):
+            return []
+
+    with pytest.raises(ValueError):
+
+        @register("dup", domain="events")
+        class B(BaseProducer):
+            schedule = "continuous"
+
+            def collect(self) -> list[dict]:
+                return []
+
+            def normalize(self, raw: list[dict]):
+                return []
+
+
+def test_discovery_registers_template_producer() -> None:
+    _reset_for_tests()
+    names = list_producers()
+    assert "template" in names
+    assert "template" in list_by_domain("events")

--- a/tests/unit/test_producer_template.py
+++ b/tests/unit/test_producer_template.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+
+from engine.core.client import DataClient
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.producers.base import ProducerContext
+from engine.producers.template import TemplateProducer
+
+
+def test_template_producer_runs_end_to_end(tmp_path) -> None:
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DataClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = TemplateProducer(ctx).run()
+    assert pr.events_published == 1
+    assert pr.errors == []
+
+    events = db.get_events(event_type=EventType.SIGNAL_EVENTS_V1, source="template", limit=10)
+    assert len(events) == 1
+    assert events[0].payload["catalysts"] == ["template"]
+    assert db.verify_hash_chain(fast=False)


### PR DESCRIPTION
Sprint 1A: Producer Framework.

**Producer Protocol** — `@runtime_checkable` with `collect → normalize → publish → run` contract

**BaseProducer** — Template method pattern. Implement `collect()` and `normalize()`, get `run()` for free. Events auto-append to hash-chained event store.

**ProducerContext** — Shared context (config, db, HTTP client, metrics, logger) injected into every producer

**Registry** — `@register("name", domain="technical")` decorator with auto-discovery scan

**Template** — Copy-this working example with TODO markers. New producer in 5 minutes.

**Tests:** 9 passing

> *Producers are the sensory organs of the system.*