### PR TITLE
feat(producers): TA + orderbook producers

### DIFF
--- a/engine/producers/orderbook.py
+++ b/engine/producers/orderbook.py
@@ -1,4 +1,118 @@
-"""Module placeholder.
+"""engine.producers.orderbook
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Orderbook Depth Producer.
+
+Fetches orderbook depth / liquidity-at-top metrics from a configured HTTP endpoint
+and emits :class:`~engine.core.events.EventType.SIGNAL_ORDERBOOK_V1`.
+
+The endpoint is configured via env and unit tests mock the injected
+``context.client``.
+
+Easter egg:
+- Liquidity is a mirage until you touch it.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, OrderbookSignalPayload
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
+    return f"{EventType.SIGNAL_ORDERBOOK_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
+
+
+@register("orderbook-depth", domain="technical")
+class OrderbookDepthProducer(BaseProducer):
+    schedule = "*/5 * * * *"
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_ORDERBOOK_URL") or os.getenv("ORDERBOOK_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("orderbook_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = OrderbookSignalPayload(
+                symbol=sym,
+                bid_depth_usd=row.get("bid_depth_usd"),
+                ask_depth_usd=row.get("ask_depth_usd"),
+                imbalance=row.get("imbalance"),
+                lod_score=row.get("lod_score"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_ORDERBOOK_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, symbol=sym, ts=ts),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("orderbook_depth_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/engine/producers/ta.py
+++ b/engine/producers/ta.py
@@ -1,4 +1,128 @@
-"""Module placeholder.
+"""engine.producers.ta
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Technical Analysis (TA) Producer.
+
+Fetches pre-computed TA indicators from a configured HTTP endpoint and emits
+:class:`~engine.core.events.EventType.SIGNAL_TA_V1`.
+
+The endpoint is configured via env and unit tests mock the injected
+``context.client``.
+
+Easter egg:
+- Charts change; patience doesn't.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, TASignalPayload
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
+    """Symbol + timestamp (+ producer) dedupe key."""
+
+    return f"{EventType.SIGNAL_TA_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
+
+
+@register("technical-analysis", domain="technical")
+class TechnicalAnalysisProducer(BaseProducer):
+    schedule = "*/15 * * * *"
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_TA_URL") or os.getenv("TA_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("ta_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = TASignalPayload(
+                symbol=sym,
+                rsi_14=row.get("rsi_14"),
+                ema_20=row.get("ema_20"),
+                ema_50=row.get("ema_50"),
+                ema_200=row.get("ema_200"),
+                bb_position=row.get("bb_position"),
+                volume_ratio=row.get("volume_ratio"),
+                trend=row.get("trend"),
+                trend_strength=row.get("trend_strength"),
+                support_distance=row.get("support_distance"),
+                resistance_distance=row.get("resistance_distance"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_TA_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, symbol=sym, ts=ts),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("ta_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/tests/unit/test_producer_orderbook.py
+++ b/tests/unit/test_producer_orderbook.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.orderbook import OrderbookDepthProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_orderbook_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_ORDERBOOK_URL", "https://example.test/orderbook")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "ETH",
+                    "bid_depth_usd": 1_000_000.0,
+                    "ask_depth_usd": 900_000.0,
+                    "imbalance": 0.0526,
+                    "lod_score": 0.7,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/orderbook"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = OrderbookDepthProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(
+        event_type=EventType.SIGNAL_ORDERBOOK_V1,
+        source="orderbook-depth",
+        limit=10,
+    )
+    assert len(events) == 1
+    assert events[0].payload["symbol"] == "ETH"
+    assert events[0].dedupe_key and "orderbook-depth" in events[0].dedupe_key
+
+
+def test_orderbook_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_ORDERBOOK_URL", "https://example.test/orderbook")
+
+    req = httpx.Request("POST", "https://example.test/orderbook")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = OrderbookDepthProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]

--- a/tests/unit/test_producer_ta.py
+++ b/tests/unit/test_producer_ta.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.ta import TechnicalAnalysisProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_ta_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_TA_URL", "https://example.test/ta")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "rsi_14": 52.1,
+                    "ema_20": 100.0,
+                    "ema_50": 99.0,
+                    "ema_200": 80.0,
+                    "bb_position": 0.4,
+                    "volume_ratio": 1.1,
+                    "trend": "neutral",
+                    "trend_strength": 0.2,
+                    "support_distance": 0.03,
+                    "resistance_distance": 0.05,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/ta"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = TechnicalAnalysisProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_TA_V1, source="technical-analysis", limit=10)
+    assert len(events) == 1
+    assert events[0].payload["symbol"] == "BTC"
+    assert events[0].dedupe_key and "technical-analysis" in events[0].dedupe_key
+
+
+def test_ta_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_TA_URL", "https://example.test/ta")
+
+    req = httpx.Request("POST", "https://example.test/ta")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = TechnicalAnalysisProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-A1: first small chunk of technical producers.

- `technical-analysis` → `signal.ta.v1`
- `orderbook-depth` → `signal.orderbook.v1`

Deterministic dedupe keys, `run()` never raises, unit tests included (4 passing).