### PR TITLE
feat(producers): price alerts producer

### DIFF
--- a/engine/core/events.py
+++ b/engine/core/events.py
@@ -38,6 +38,7 @@ class EventType(StrEnum):
     SIGNAL_CURATOR_V1 = "signal.curator.v1"
     SIGNAL_ACI_V1 = "signal.aci.v1"
     SIGNAL_PRICE_ALERT_V1 = "signal.price_alert.v1"
+    SIGNAL_PRICE_WS_V1 = "signal.price_ws.v1"
 
     # Brain events
     BRAIN_CYCLE_V1 = "brain.cycle.v1"
@@ -161,6 +162,19 @@ class OrderbookSignalPayload(BaseModel):
     ask_depth_usd: float | None = None
     imbalance: float | None = None
     lod_score: float | None = None
+
+
+class PriceWSSignalPayload(BaseModel):
+    """Payload for :pydata:`~engine.core.events.EventType.SIGNAL_PRICE_WS_V1`.
+
+    Polling placeholder for a future websocket feed.
+    """
+
+    symbol: str
+    price: float | None = None
+    bid: float | None = None
+    ask: float | None = None
+    venue: str | None = None
 
 
 class CuratorSignalPayload(BaseModel):

--- a/engine/producers/price_ws.py
+++ b/engine/producers/price_ws.py
@@ -1,4 +1,123 @@
-"""Module placeholder.
+"""engine.producers.price_ws
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Price Alerts Producer (polling placeholder).
+
+This producer is intentionally implemented as a polling loop (HTTP request) even
+though the intended long-term interface is a websocket price stream.
+
+It emits :class:`~engine.core.events.EventType.SIGNAL_PRICE_WS_V1` events.
+
+Easter egg:
+- There is no "real-time"—only smaller intervals.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, PriceWSSignalPayload
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
+    """Deterministic dedupe key: event-type + producer + symbol + epoch-seconds."""
+
+    return f"{EventType.SIGNAL_PRICE_WS_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
+
+
+@register("price-alerts", domain="technical")
+class PriceAlertsProducer(BaseProducer):
+    """Polling producer that mimics a websocket price feed."""
+
+    schedule = "*/1 * * * *"
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_PRICE_WS_URL") or os.getenv("PRICE_WS_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("price_ws_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = PriceWSSignalPayload(
+                symbol=sym,
+                price=row.get("price") or row.get("last") or row.get("last_price"),
+                bid=row.get("bid"),
+                ask=row.get("ask"),
+                venue=row.get("venue") or row.get("exchange"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_PRICE_WS_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, symbol=sym, ts=ts),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("price_ws_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/tests/unit/test_producer_price_ws.py
+++ b/tests/unit/test_producer_price_ws.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.price_ws import PriceAlertsProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_price_ws_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_PRICE_WS_URL", "https://example.test/prices")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "price": 42000.0,
+                    "bid": 41999.5,
+                    "ask": 42000.5,
+                    "venue": "paper",
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/prices"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = PriceAlertsProducer(ctx).run()
+    assert pr.events_published == 1
+    assert pr.health == ProducerHealth.OK
+
+    events = db.get_events(event_type=EventType.SIGNAL_PRICE_WS_V1, source="price-alerts", limit=10)
+    assert len(events) == 1
+    assert events[0].type == EventType.SIGNAL_PRICE_WS_V1
+    assert events[0].payload["symbol"] == "BTC"
+    assert events[0].payload["price"] == 42000.0
+    assert events[0].dedupe_key and "price-alerts" in events[0].dedupe_key
+
+
+def test_price_ws_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_PRICE_WS_URL", "https://example.test/prices")
+
+    req = httpx.Request("POST", "https://example.test/prices")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = PriceAlertsProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-A2: `price-alerts` producer (polling placeholder).

- Emits `signal.price_ws.v1`
- Deterministic dedupe keys
- 401 handling degrades gracefully

Also adds `EventType.SIGNAL_PRICE_WS_V1` + typed payload model.

Tests: 2 passing.