### PR TITLE
feat(producers): tradfi basis + ETF flows producers

### DIFF
--- a/engine/producers/etf.py
+++ b/engine/producers/etf.py
@@ -1,4 +1,123 @@
-"""Module placeholder.
+"""engine.producers.etf
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+ETF Flows Producer.
+
+Fetches ETF flow metrics (typically for BTC/ETH spot ETFs) from a configured
+HTTP endpoint and emits :class:`~engine.core.events.EventType.SIGNAL_ETF_V1`.
+
+The endpoint is configured via env and unit tests mock the injected
+``context.client``.
+
+Easter egg:
+- Even in an index, someone chose the weights.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import ETFFlowPayload, EventType
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
+    """Symbol + timestamp (+ producer) dedupe key."""
+
+    return f"{EventType.SIGNAL_ETF_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
+
+
+@register("etf-flows", domain="tradfi")
+class ETFFlowsProducer(BaseProducer):
+    """Produce ETF flow signals for the configured universe."""
+
+    schedule = "0 */1 * * *"  # hourly
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_ETF_FLOWS_URL") or os.getenv("ETF_FLOWS_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("etf_flows_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = ETFFlowPayload(
+                symbol=sym,
+                daily_flow_usd=row.get("daily_flow_usd"),
+                streak_days=int(row.get("streak_days") or 0),
+                cumulative_7d=row.get("cumulative_7d"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_ETF_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, symbol=sym, ts=ts),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("etf_flows_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -1,4 +1,125 @@
-"""Module placeholder.
+"""engine.producers.tradfi
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+TradFi Basis Producer.
+
+Fetches carry/basis-style metrics (spot vs futures, funding proxy, OI changes)
+from a configured HTTP endpoint and emits
+:class:`~engine.core.events.EventType.SIGNAL_TRADFI_V1`.
+
+The endpoint is configured via env and unit tests mock the injected
+``context.client``.
+
+Easter egg:
+- Markets rhyme; basis keeps the meter.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, TradFiSignalPayload
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
+    """Symbol + timestamp (+ producer) dedupe key."""
+
+    return f"{EventType.SIGNAL_TRADFI_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
+
+
+@register("tradfi-basis", domain="tradfi")
+class TradFiBasisProducer(BaseProducer):
+    """Produce basis/carry signals for the configured universe."""
+
+    schedule = "*/30 * * * *"
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_TRADFI_BASIS_URL") or os.getenv("TRADFI_BASIS_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("tradfi_basis_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = TradFiSignalPayload(
+                symbol=sym,
+                basis_annualized=row.get("basis_annualized"),
+                funding_annualized=row.get("funding_annualized"),
+                oi_change_pct=row.get("oi_change_pct"),
+                meltup_score=row.get("meltup_score"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_TRADFI_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, symbol=sym, ts=ts),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("tradfi_basis_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/tests/unit/test_producer_etf.py
+++ b/tests/unit/test_producer_etf.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.etf import ETFFlowsProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_etf_flows_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_ETF_FLOWS_URL", "https://example.test/etf")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "daily_flow_usd": 123_000_000.0,
+                    "streak_days": 3,
+                    "cumulative_7d": 250_000_000.0,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/etf"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = ETFFlowsProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_ETF_V1, source="etf-flows", limit=10)
+    assert len(events) == 1
+
+    ev = events[0]
+    assert ev.payload["symbol"] == "BTC"
+    assert ev.payload["daily_flow_usd"] == 123_000_000.0
+    assert ev.payload["streak_days"] == 3
+    assert ev.dedupe_key and "etf-flows" in ev.dedupe_key
+
+
+def test_etf_flows_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_ETF_FLOWS_URL", "https://example.test/etf")
+
+    req = httpx.Request("POST", "https://example.test/etf")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = ETFFlowsProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]

--- a/tests/unit/test_producer_tradfi.py
+++ b/tests/unit/test_producer_tradfi.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.tradfi import TradFiBasisProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_tradfi_basis_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_TRADFI_BASIS_URL", "https://example.test/basis")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "basis_annualized": 0.06,
+                    "funding_annualized": 0.02,
+                    "oi_change_pct": 1.5,
+                    "meltup_score": 0.1,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/basis"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = TradFiBasisProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_TRADFI_V1, source="tradfi-basis", limit=10)
+    assert len(events) == 1
+
+    ev = events[0]
+    assert ev.payload["symbol"] == "BTC"
+    assert ev.payload["basis_annualized"] == 0.06
+    assert ev.dedupe_key and "tradfi-basis" in ev.dedupe_key
+
+
+def test_tradfi_basis_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_TRADFI_BASIS_URL", "https://example.test/basis")
+
+    req = httpx.Request("POST", "https://example.test/basis")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = TradFiBasisProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-A3: TradFi producers.

- `tradfi-basis` → `signal.tradfi.v1`
- `etf-flows` → `signal.etf.v1`

Deterministic dedupe keys, graceful 401 handling, unit tests included (4 passing).