### PR TITLE
feat(producers): market events producer

### DIFF
--- a/engine/producers/events.py
+++ b/engine/producers/events.py
@@ -1,4 +1,135 @@
-"""Module placeholder.
+"""engine.producers.events
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Market Events Producer.
+
+Treats the configured endpoint as a simple HTTP poller that returns a list of
+"events" / catalysts per symbol, then emits
+:class:`~engine.core.events.EventType.SIGNAL_EVENTS_V1`.
+
+The endpoint is configured via env and unit tests mock the injected
+``context.client``.
+
+Easter egg:
+- News is noise; catalysts are structure.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, EventsSignalPayload, payload_hash
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
+    """Deterministic dedupe key based on canonicalized payload."""
+
+    return f"{EventType.SIGNAL_EVENTS_V1}:{producer}:{payload_hash(payload)}"
+
+
+@register("market-events", domain="events")
+class MarketEventsProducer(BaseProducer):
+    schedule = "*/30 * * * *"
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_EVENTS_URL") or os.getenv("EVENTS_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("events_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            catalysts_raw = row.get("catalysts") or row.get("events") or []
+            catalysts: list[str] = []
+            if isinstance(catalysts_raw, list):
+                catalysts = [str(x) for x in catalysts_raw if x is not None and str(x).strip()]
+            elif isinstance(catalysts_raw, str) and catalysts_raw.strip():
+                catalysts = [catalysts_raw.strip()]
+
+            event_count = row.get("event_count")
+            if not isinstance(event_count, int):
+                event_count = len(catalysts)
+
+            payload_obj = EventsSignalPayload(
+                symbol=sym,
+                headline_sentiment=row.get("headline_sentiment"),
+                impact_score=row.get("impact_score"),
+                event_count=event_count,
+                catalysts=catalysts,
+            )
+            payload = payload_obj.model_dump(mode="json")
+
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_EVENTS_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, payload=payload),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("events_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/tests/unit/test_producer_events.py
+++ b/tests/unit/test_producer_events.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.events import MarketEventsProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_events_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_EVENTS_URL", "https://example.test/events")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "headline_sentiment": 0.25,
+                    "impact_score": 0.9,
+                    "event_count": 2,
+                    "catalysts": ["ETF flow", "FOMC"],
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/events"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = MarketEventsProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_EVENTS_V1, source="market-events", limit=10)
+    assert len(events) == 1
+    assert events[0].payload["symbol"] == "BTC"
+    assert events[0].payload["event_count"] == 2
+    assert events[0].payload["catalysts"] == ["ETF flow", "FOMC"]
+    assert events[0].dedupe_key and "market-events" in events[0].dedupe_key
+
+
+def test_events_producer_handles_403(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_EVENTS_URL", "https://example.test/events")
+
+    req = httpx.Request("POST", "https://example.test/events")
+    resp = httpx.Response(403, json={"error": "forbidden"}, request=req)
+    exc = httpx.HTTPStatusError("forbidden", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = MarketEventsProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "403" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-C1: `market-events` producer (mockable HTTP poller).

- Emits `signal.events.v1`
- Deterministic dedupe keys (payload hash)
- 403 handling degrades gracefully

Tests: 2 passing.