### PR TITLE
feat(producers): market sentiment producer

### DIFF
--- a/engine/producers/sentiment.py
+++ b/engine/producers/sentiment.py
@@ -1,4 +1,124 @@
-"""Module placeholder.
+"""engine.producers.sentiment
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Market Sentiment Producer.
+
+Fetches market sentiment metrics (fear/greed style indices, 7d change, and
+optionally coarse CT sentiment) from a configured HTTP endpoint and emits
+:class:`~engine.core.events.EventType.SIGNAL_SENTIMENT_V1`.
+
+The endpoint is configured via env and unit tests mock the injected
+``context.client``.
+
+Easter egg:
+- Sentiment is the shadow of positioning.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, SentimentSignalPayload
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
+    """Symbol + timestamp (+ producer) dedupe key."""
+
+    return f"{EventType.SIGNAL_SENTIMENT_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
+
+
+@register("market-sentiment", domain="social")
+class MarketSentimentProducer(BaseProducer):
+    """Produce market sentiment signals for the configured universe."""
+
+    schedule = "0 */1 * * *"  # hourly
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_SENTIMENT_URL") or os.getenv("SENTIMENT_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("sentiment_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = SentimentSignalPayload(
+                symbol=sym,
+                fear_greed=row.get("fear_greed"),
+                fear_greed_change_7d=row.get("fear_greed_change_7d"),
+                ct_sentiment=row.get("ct_sentiment"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_SENTIMENT_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, symbol=sym, ts=ts),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("market_sentiment_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/tests/unit/test_producer_sentiment.py
+++ b/tests/unit/test_producer_sentiment.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.sentiment import MarketSentimentProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_market_sentiment_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_SENTIMENT_URL", "https://example.test/sentiment")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "fear_greed": 62.0,
+                    "fear_greed_change_7d": -4.0,
+                    "ct_sentiment": "neutral",
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/sentiment"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = MarketSentimentProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(
+        event_type=EventType.SIGNAL_SENTIMENT_V1, source="market-sentiment", limit=10
+    )
+    assert len(events) == 1
+
+    ev = events[0]
+    assert ev.payload["symbol"] == "BTC"
+    assert ev.payload["fear_greed"] == 62.0
+    assert ev.payload["fear_greed_change_7d"] == -4.0
+    assert ev.payload["ct_sentiment"] == "neutral"
+    assert ev.dedupe_key and "market-sentiment" in ev.dedupe_key
+
+
+def test_market_sentiment_producer_handles_403(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_SENTIMENT_URL", "https://example.test/sentiment")
+
+    req = httpx.Request("POST", "https://example.test/sentiment")
+    resp = httpx.Response(403, json={"error": "forbidden"}, request=req)
+    exc = httpx.HTTPStatusError("forbidden", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = MarketSentimentProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "403" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-C2: `market-sentiment` producer.

- Emits `signal.sentiment.v1`
- Mockable HTTP poller (`B1E55ED_SENTIMENT_URL` / `SENTIMENT_URL`)
- Deterministic dedupe keys
- 401/403 degrades gracefully

Tests: 2 passing.