### PR TITLE
feat(producers): social + curator producers

### DIFF
--- a/engine/producers/curator.py
+++ b/engine/producers/curator.py
@@ -1,4 +1,144 @@
-"""Module placeholder.
+"""engine.producers.curator
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Curator Intel Producer.
+
+Ingests operator/curator intel from a configured endpoint or local file, then
+emits :class:`~engine.core.events.EventType.SIGNAL_CURATOR_V1`.
+
+Configuration (env):
+- ``B1E55ED_CURATOR_URL`` / ``CURATOR_URL``  (HTTP endpoint)
+- ``B1E55ED_CURATOR_FILE`` / ``CURATOR_FILE`` (JSON file)
+
+The endpoint/file is intentionally simple so unit tests can mock the injected
+``context.client`` or write a temp file.
+
+Easter egg:
+- Human priors are a feature, not a bug.
 """
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from engine.core.events import CuratorSignalPayload, EventType, payload_hash
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
+    return f"{EventType.SIGNAL_CURATOR_V1}:{producer}:{payload_hash(payload)}"
+
+
+@register("curator-intel", domain="curator")
+class CuratorIntelProducer(BaseProducer):
+    schedule = "*/10 * * * *"  # 10m
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_CURATOR_URL") or os.getenv("CURATOR_URL")
+
+    def _file_path(self) -> str | None:
+        return os.getenv("B1E55ED_CURATOR_FILE") or os.getenv("CURATOR_FILE")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        fp = self._file_path()
+
+        data: Any = None
+
+        if url:
+            # Endpoint can be mocked in tests via ctx.client
+            resp = asyncio.run(self.ctx.client.request("GET", url))
+            data = resp.json()
+        elif fp:
+            p = Path(fp)
+            if not p.exists():
+                self.ctx.logger.warning("curator_file_missing", extra={"path": fp})
+                return []
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                self.ctx.logger.warning("curator_file_invalid_json", extra={"path": fp})
+                return []
+        else:
+            self.ctx.logger.warning("curator_source_missing")
+            return []
+
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = CuratorSignalPayload(
+                symbol=sym,
+                direction=(row.get("direction") or "neutral"),
+                conviction=float(row.get("conviction") or 0.0),
+                rationale=str(row.get("rationale") or ""),
+                source=str(row.get("source") or "operator"),
+            )
+            payload = payload_obj.model_dump(mode="json")
+
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_CURATOR_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, payload=payload),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("curator_intel_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/engine/producers/social.py
+++ b/engine/producers/social.py
@@ -1,4 +1,108 @@
-"""Module placeholder.
+"""engine.producers.social
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Social Intel Producer.
+
+Delegates to :mod:`engine.social.pipeline` to collect and score social data,
+then emits :class:`~engine.core.events.EventType.SIGNAL_SOCIAL_V1`.
+
+The social pipeline is intentionally isolated behind a single call so tests can
+mock it easily.
+
+Easter egg:
+- Social is the memetic surface of positioning.
 """
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import EventType, SocialSignalPayload, payload_hash
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+from engine.social import pipeline
+
+
+def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
+    return f"{EventType.SIGNAL_SOCIAL_V1}:{producer}:{payload_hash(payload)}"
+
+
+@register("social-intel", domain="social")
+class SocialIntelProducer(BaseProducer):
+    schedule = "*/15 * * * *"  # 15m
+
+    def collect(self) -> list[dict[str, Any]]:
+        rows = pipeline.run(ctx=self.ctx)
+        if not isinstance(rows, list):
+            return []
+        return [r for r in rows if isinstance(r, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            payload_obj = SocialSignalPayload(
+                symbol=sym,
+                score=float(row.get("score")) if row.get("score") is not None else 0.0,
+                direction=(row.get("direction") or "neutral"),
+                source_count=int(row.get("source_count") or 0),
+                contrarian_flag=bool(row.get("contrarian_flag") or False),
+                echo_chamber_flag=bool(row.get("echo_chamber_flag") or False),
+            )
+            payload = payload_obj.model_dump(mode="json")
+
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_SOCIAL_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, payload=payload),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise."""
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("social_intel_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/engine/social/pipeline.py
+++ b/engine/social/pipeline.py
@@ -1,4 +1,35 @@
-"""Module placeholder.
+"""engine.social.pipeline
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Social intel pipeline.
+
+This module is intentionally tiny (for now) so it can be mocked in unit tests.
+The real social ingestion/scoring stack will live under ``engine.social.*``.
+
+The producer calls :func:`run` and expects a list of dict payloads compatible
+with :class:`engine.core.events.SocialSignalPayload`.
+
+Easter egg:
+- The map is not the territory.
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+from engine.producers.base import ProducerContext
+
+
+def run(*, ctx: ProducerContext) -> list[dict[str, Any]]:
+    """Run the social pipeline and return normalized rows.
+
+    This default implementation is a no-op and exists mainly to provide a stable
+    seam for mocking.
+
+    Returns
+    -------
+    list[dict]
+        Each dict should contain keys compatible with SocialSignalPayload.
+    """
+
+    _ = ctx
+    return []

--- a/tests/unit/test_producer_curator.py
+++ b/tests/unit/test_producer_curator.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.curator import CuratorIntelProducer
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+def test_curator_intel_producer_publishes_events_from_url(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_CURATOR_URL", "https://example.test/curator")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "ETH",
+                    "direction": "bearish",
+                    "conviction": 0.66,
+                    "rationale": "ETF flows fading",
+                    "source": "operator",
+                }
+            ]
+        },
+        request=httpx.Request("GET", "https://example.test/curator"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = CuratorIntelProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_CURATOR_V1, source="curator-intel", limit=10)
+    assert len(events) == 1
+
+    ev = events[0]
+    assert ev.payload["symbol"] == "ETH"
+    assert ev.payload["direction"] == "bearish"
+    assert ev.payload["conviction"] == 0.66
+    assert ev.payload["rationale"] == "ETF flows fading"
+    assert ev.payload["source"] == "operator"
+    assert ev.dedupe_key and "curator-intel" in ev.dedupe_key
+
+
+def test_curator_intel_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_CURATOR_URL", "https://example.test/curator")
+
+    req = httpx.Request("GET", "https://example.test/curator")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = CuratorIntelProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]

--- a/tests/unit/test_producer_social.py
+++ b/tests/unit/test_producer_social.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.base import ProducerContext
+from engine.producers.social import SocialIntelProducer
+
+
+class DummyClient:
+    async def request(self, method: str, url: str, **kwargs):  # pragma: no cover
+        raise AssertionError("social producer should not call ctx.client directly")
+
+
+def test_social_intel_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    def fake_run(*, ctx):
+        _ = ctx
+        return [
+            {
+                "symbol": "BTC",
+                "score": 0.75,
+                "direction": "bullish",
+                "source_count": 12,
+                "contrarian_flag": False,
+                "echo_chamber_flag": True,
+            }
+        ]
+
+    monkeypatch.setattr("engine.social.pipeline.run", fake_run)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = SocialIntelProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_SOCIAL_V1, source="social-intel", limit=10)
+    assert len(events) == 1
+
+    ev = events[0]
+    assert ev.payload["symbol"] == "BTC"
+    assert ev.payload["score"] == 0.75
+    assert ev.payload["direction"] == "bullish"
+    assert ev.payload["source_count"] == 12
+    assert ev.payload["echo_chamber_flag"] is True
+    assert ev.dedupe_key and "social-intel" in ev.dedupe_key
+
+
+def test_social_intel_producer_handles_403(monkeypatch, tmp_path) -> None:
+    req = httpx.Request("GET", "https://example.test/social")
+    resp = httpx.Response(403, json={"error": "forbidden"}, request=req)
+    exc = httpx.HTTPStatusError("forbidden", request=req, response=resp)
+
+    def fake_run(*, ctx):
+        _ = ctx
+        raise exc
+
+    monkeypatch.setattr("engine.social.pipeline.run", fake_run)
+
+    db = Database(tmp_path / "events.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = SocialIntelProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "403" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-C3: social + curator.

- `social-intel` → `signal.social.v1` (delegates to `engine.social.pipeline` seam)
- `curator-intel` → `signal.curator.v1` (ingest via URL or JSON file)

Deterministic payload-hash dedupe keys. 401/403 degrade gracefully.

Tests: 4 passing.