### PR TITLE
feat(producers): ACI producer + contract test — completes Sprint 1B

### DIFF
--- a/engine/producers/aci.py
+++ b/engine/producers/aci.py
@@ -1,4 +1,191 @@
-"""Module placeholder.
+"""engine.producers.aci
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+AI Consensus Index (ACI) Producer.
+
+Treats the configured endpoint as an inference API (LLM or an ensemble service)
+that returns a consensus score per symbol.
+
+It emits :class:`~engine.core.events.EventType.SIGNAL_ACI_V1`.
+
+The endpoint is configured via env and tests mock the injected
+``context.client``.
+
+Easter egg (timeless):
+- Consensus is a mirror; mirrors don't care who is looking.
 """
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from engine.core.events import ACISignalPayload, EventType, payload_hash
+from engine.core.models import Event
+from engine.core.types import ProducerHealth, ProducerResult
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+_INT_RE = re.compile(r"[-+]?\d+")
+
+
+def parse_score(value: Any) -> int:
+    """Extract the last integer from a model response and clamp to [-10, 10].
+
+    The upstream endpoint is allowed to be messy (LLM text, JSON wrapper, etc.).
+    Contract:
+    - find the *last* integer in the response (handles "thinking" traces)
+    - clamp to [-10, 10]
+    - if nothing parseable exists, return 0
+    """
+
+    # Unwrap common JSON shapes
+    if isinstance(value, dict):
+        for k in ("score", "consensus_score", "consensus", "result", "response", "text", "content"):
+            if k in value:
+                return parse_score(value.get(k))
+        return 0
+
+    if value is None:
+        return 0
+
+    if isinstance(value, (int, float)):
+        n = int(value)
+        return max(-10, min(10, n))
+
+    s = str(value)
+    matches = _INT_RE.findall(s)
+    if not matches:
+        return 0
+
+    try:
+        n = int(matches[-1])
+    except ValueError:
+        return 0
+
+    return max(-10, min(10, n))
+
+
+def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
+    """Deterministic dedupe key based on canonicalized payload."""
+
+    return f"{EventType.SIGNAL_ACI_V1}:{producer}:{payload_hash(payload)}"
+
+
+@register("ai-consensus", domain="curator")
+class ACIProducer(BaseProducer):
+    schedule = "*/30 * * * *"
+
+    def _endpoint(self) -> str | None:
+        return os.getenv("B1E55ED_ACI_URL") or os.getenv("ACI_URL")
+
+    def collect(self) -> list[dict[str, Any]]:
+        url = self._endpoint()
+        if not url:
+            self.ctx.logger.warning("aci_endpoint_missing")
+            return []
+
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
+
+        data: Any = resp.json()
+        if isinstance(data, dict) and "data" in data:
+            data = data["data"]
+
+        # Supported shapes:
+        # - list[dict]  -> already correct
+        # - dict        -> treat as single row
+        if isinstance(data, dict):
+            return [data]
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
+        ts = datetime.now(tz=UTC)
+        out: list[Event] = []
+
+        for row in raw:
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            score_raw = row.get("consensus_score")
+            if score_raw is None:
+                score_raw = row.get("score")
+            if score_raw is None:
+                score_raw = row.get("response") or row.get("text") or row.get("content")
+
+            consensus = float(parse_score(score_raw))
+
+            mq = row.get("models_queried")
+            mr = row.get("models_responded")
+            disp = row.get("dispersion")
+
+            models_queried = int(mq) if isinstance(mq, int) else 1
+            models_responded = int(mr) if isinstance(mr, int) else models_queried
+            dispersion = float(disp) if isinstance(disp, (int, float)) else 0.0
+
+            payload_obj = ACISignalPayload(
+                symbol=sym,
+                consensus_score=consensus,
+                models_queried=models_queried,
+                models_responded=models_responded,
+                dispersion=dispersion,
+            )
+            payload = payload_obj.model_dump(mode="json")
+
+            out.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_ACI_V1,
+                    payload=payload,
+                    ts=ts,
+                    observed_at=ts,
+                    source=self.name,
+                    dedupe_key=_dedupe_key(producer=self.name, payload=payload),
+                )
+            )
+
+        return out
+
+    def run(self) -> ProducerResult:
+        """Run with producer isolation: never raise.
+
+        401/403 are treated as a degraded state (misconfigured/expired creds).
+        """
+
+        start = time.perf_counter()
+        errors: list[str] = []
+        published = 0
+        health: ProducerHealth = ProducerHealth.OK
+
+        try:
+            raw = self.collect()
+            if not raw:
+                health = ProducerHealth.DEGRADED
+            events = self.normalize(raw)
+            published = self.publish(events)
+        except httpx.HTTPStatusError as e:
+            code = getattr(e.response, "status_code", None)
+            health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR
+            errors.append(f"HTTPStatusError: {code}")
+        except Exception as e:  # noqa: BLE001 - producer isolation boundary
+            health = ProducerHealth.ERROR
+            errors.append(f"{type(e).__name__}: {e}")
+            self.ctx.logger.exception("aci_run_failed")
+
+        duration_ms = int((time.perf_counter() - start) * 1000)
+        return ProducerResult(
+            events_published=published,
+            errors=errors,
+            duration_ms=duration_ms,
+            timestamp=datetime.now(tz=UTC),
+            staleness_ms=None,
+            health=health,
+        )

--- a/tests/integration/test_producer_contract.py
+++ b/tests/integration/test_producer_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerResult
+from engine.producers.base import ProducerContext
+from engine.producers.registry import get_producer, list_producers
+
+
+class DummyClient:
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        # Default "safe" response shape for producers that expect a list.
+        return httpx.Response(
+            200,
+            json={"data": []},
+            request=httpx.Request(method, url),
+        )
+
+
+def test_all_registered_producers_follow_contract(monkeypatch, tmp_path) -> None:
+    # Keep the contract test hermetic: no accidental network calls.
+    # If a producer endpoint env var is set in the environment, it will still
+    # hit DummyClient and get a benign empty payload.
+
+    producer_names = list_producers()
+    assert producer_names, "expected at least one registered producer"
+
+    known_event_types = set(EventType)
+
+    for name in producer_names:
+        cls = get_producer(name)
+
+        db = Database(tmp_path / f"{name}.db")
+        ctx = ProducerContext(
+            config=Config(),
+            db=db,
+            client=DummyClient(),
+            metrics=MetricsRegistry(),
+            logger=logging.getLogger("test"),
+        )
+
+        producer = cls(ctx)  # type: ignore[call-arg]
+
+        # Contract: run() never raises.
+        result = producer.run()
+        assert isinstance(result, ProducerResult)
+
+        events = db.get_events(limit=500)
+        assert all(ev.type in known_event_types for ev in events)

--- a/tests/unit/test_producer_aci.py
+++ b/tests/unit/test_producer_aci.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import pytest
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.core.types import ProducerHealth
+from engine.producers.aci import ACIProducer, parse_score
+from engine.producers.base import ProducerContext
+
+
+class DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("score: 7", 7),
+        ("-3", -3),
+        ("final: -11", -10),
+        ("final: 42", 10),
+        ("no integers here", 0),
+        ("first 1 then 2 then 3", 3),
+        ("chain: -1 / 0 / +9", 9),
+        ("think 9\nanswer -2", -2),
+        ("JSON-ish {\"score\": 4} trailing 6", 6),
+        ("0 0 0", 0),
+    ],
+)
+def test_parse_score_extracts_last_int_and_clamps(text: str, expected: int) -> None:
+    assert parse_score(text) == expected
+
+
+def test_parse_score_unwraps_dict() -> None:
+    assert parse_score({"score": "blah 1 blah 2"}) == 2
+    assert parse_score({"consensus_score": -99}) == -10
+    assert parse_score({"text": "7"}) == 7
+
+
+def test_aci_producer_publishes_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_ACI_URL", "https://example.test/aci")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "response": "analysis... score: -12\nfinal: -9",
+                    "models_queried": 3,
+                    "models_responded": 2,
+                    "dispersion": 1.25,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/aci"),
+    )
+
+    db = Database(tmp_path / "aci.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = ACIProducer(ctx).run()
+    assert pr.events_published == 1
+
+    events = db.get_events(event_type=EventType.SIGNAL_ACI_V1, source="ai-consensus", limit=10)
+    assert len(events) == 1
+    assert events[0].payload["symbol"] == "BTC"
+    assert events[0].payload["consensus_score"] == -9.0
+    assert events[0].payload["models_queried"] == 3
+    assert events[0].payload["models_responded"] == 2
+    assert events[0].dedupe_key and "ai-consensus" in events[0].dedupe_key
+
+
+def test_aci_producer_handles_401(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_ACI_URL", "https://example.test/aci")
+
+    req = httpx.Request("POST", "https://example.test/aci")
+    resp = httpx.Response(401, json={"error": "unauthorized"}, request=req)
+    exc = httpx.HTTPStatusError("unauthorized", request=req, response=resp)
+
+    db = Database(tmp_path / "aci.db")
+    ctx = ProducerContext(
+        config=Config(),
+        db=db,
+        client=DummyClient(exc=exc),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = ACIProducer(ctx).run()
+    assert pr.events_published == 0
+    assert pr.health == ProducerHealth.DEGRADED
+    assert pr.errors and "401" in pr.errors[0]


### PR DESCRIPTION
Sprint 1B-C4: the final producer chunk.

**ACI Producer** (`ai-consensus`, domain `curator`):
- `parse_score()` fix: extracts LAST integer from model response, clamps [-10, 10]
- Handles dict-wrapped responses, sign prefixes, prose reasoning
- 14 torture cases for the parser

**Contract Test** (`tests/integration/test_producer_contract.py`):
- Auto-discovers all registered producers
- For each: instantiate with mock context, call `run()`, assert no raise, assert valid EventType
- Locks down the entire producer surface

This completes Sprint 1B. All 13 producers are ported and registered.

Tests: 14 passing.

> *Three models walk into a bar. Only the consensus leaves with conviction.*