### PR TITLE
Phase 2 Sprint 2A: OMS + Paper Trading

### DIFF
--- a/engine/execution/__init__.py
+++ b/engine/execution/__init__.py
@@ -1,6 +1,37 @@
-"""b1e55ed package boundary.
+"""engine.execution
 
-0xb1e55ed = "blessed". The name is the first easter egg.
+Execution layer: convert TradeIntents into Orders/Fills/Positions.
 
-A grimoire is not a textbook. It is a book of names, invocations, and hard-won procedures.
+Sprint 2A ships the OMS + paper trading plumbing. Only two execution modes exist:
+- ``paper``: simulated fills, persists to DB
+- ``live``: adapter boundary (implemented in Sprint 2B)
+
+No ``dry_run`` mode (DECISIONS_V3 #4).
 """
+
+from __future__ import annotations
+
+from engine.execution.circuit_breaker import CircuitBreaker, CircuitBreakerError, TokenBucket
+from engine.execution.oms import OMS, OMSResult
+from engine.execution.paper import PaperBroker, PaperFill
+from engine.execution.pnl import PnLTracker, PnLSnapshot
+from engine.execution.position_sizer import CorrelationAwareSizer, KellyParams, PositionSizer
+from engine.execution.preflight import Preflight, PreflightError, PreflightResult
+
+__all__ = [
+    "OMS",
+    "OMSResult",
+    "PaperBroker",
+    "PaperFill",
+    "Preflight",
+    "PreflightError",
+    "PreflightResult",
+    "PositionSizer",
+    "KellyParams",
+    "CorrelationAwareSizer",
+    "PnLTracker",
+    "PnLSnapshot",
+    "TokenBucket",
+    "CircuitBreaker",
+    "CircuitBreakerError",
+]

--- a/engine/execution/circuit_breaker.py
+++ b/engine/execution/circuit_breaker.py
@@ -1,4 +1,141 @@
-"""Module placeholder.
+"""engine.execution.circuit_breaker
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Sprint 2A requires:
+- token bucket rate limiting
+- exponential backoff after failures
+
+This module is intentionally small and dependency-free.
 """
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class CircuitBreakerError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class TokenBucket:
+    """A simple token bucket.
+
+    Tokens refill continuously at ``refill_rate_per_s`` up to ``capacity``.
+    """
+
+    capacity: float
+    refill_rate_per_s: float
+    tokens: float | None = None
+    updated_at: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.capacity <= 0:
+            raise ValueError("capacity must be > 0")
+        if self.refill_rate_per_s <= 0:
+            raise ValueError("refill_rate_per_s must be > 0")
+        if self.tokens is None:
+            self.tokens = float(self.capacity)
+        if self.updated_at is None:
+            self.updated_at = time.monotonic()
+
+    def _refill(self, now: float) -> None:
+        assert self.tokens is not None
+        assert self.updated_at is not None
+        dt = max(0.0, now - self.updated_at)
+        self.tokens = min(self.capacity, self.tokens + dt * self.refill_rate_per_s)
+        self.updated_at = now
+
+    def try_take(self, amount: float = 1.0, *, now: float | None = None) -> bool:
+        if amount <= 0:
+            return True
+        n = time.monotonic() if now is None else float(now)
+        self._refill(n)
+        assert self.tokens is not None
+        if self.tokens + 1e-12 < amount:
+            return False
+        self.tokens -= amount
+        return True
+
+    def wait_time_s(self, amount: float = 1.0, *, now: float | None = None) -> float:
+        """Return how many seconds until ``amount`` tokens are available."""
+
+        if amount <= 0:
+            return 0.0
+        n = time.monotonic() if now is None else float(now)
+        self._refill(n)
+        assert self.tokens is not None
+        if self.tokens >= amount:
+            return 0.0
+        missing = amount - self.tokens
+        return float(missing / self.refill_rate_per_s)
+
+
+@dataclass(slots=True)
+class CircuitBreaker:
+    """Token-bucket limiter + exponential backoff.
+
+    Conceptually:
+    - token bucket limits steady-state request rate
+    - failures push the circuit into a backoff window
+
+    This is *per venue* (or per external dependency).
+    """
+
+    name: str
+    bucket: TokenBucket
+    failure_threshold: int = 3
+    backoff_base_s: float = 1.0
+    backoff_max_s: float = 60.0
+
+    failures: int = 0
+    blocked_until: float = 0.0
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def can_call(self, *, now: float | None = None) -> bool:
+        n = self._now() if now is None else float(now)
+        if n < self.blocked_until:
+            return False
+        return self.bucket.try_take(1.0, now=n)
+
+    def backoff_remaining_s(self, *, now: float | None = None) -> float:
+        n = self._now() if now is None else float(now)
+        return max(0.0, self.blocked_until - n)
+
+    def record_success(self) -> None:
+        self.failures = 0
+        self.blocked_until = 0.0
+
+    def record_failure(self) -> None:
+        self.failures += 1
+        if self.failures < self.failure_threshold:
+            return
+
+        # Exponential backoff: base * 2^(k), capped
+        k = self.failures - self.failure_threshold
+        delay = min(self.backoff_max_s, self.backoff_base_s * (2.0**k))
+        self.blocked_until = self._now() + float(delay)
+
+    def call(self, fn: Callable[[], T]) -> T:
+        """Call ``fn`` if allowed, else raise CircuitBreakerError."""
+
+        if not self.can_call():
+            wait = self.backoff_remaining_s()
+            if wait > 0:
+                raise CircuitBreakerError(f"{self.name}: circuit open for {wait:.2f}s")
+            wait_bucket = self.bucket.wait_time_s(1.0)
+            raise CircuitBreakerError(f"{self.name}: rate limited, retry in {wait_bucket:.2f}s")
+
+        try:
+            out = fn()
+        except Exception:
+            self.record_failure()
+            raise
+        else:
+            self.record_success()
+            return out

--- a/engine/execution/oms.py
+++ b/engine/execution/oms.py
@@ -1,4 +1,201 @@
-"""Module placeholder.
+"""engine.execution.oms
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Order Management System (OMS).
+
+Responsibilities (Sprint 2A):
+- accept TradeIntent
+- enforce preflight gates (policy, kill switch, etc.)
+- size the position
+- route to paper or live broker
+- persist canonical state to DB via orders/positions tables and execution events
+
+Modes:
+- paper: implemented (PaperBroker)
+- live: adapter boundary only (Sprint 2B)
+
+No dry_run mode (DECISIONS_V3 #4).
 """
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType, TradeIntentPayload
+from engine.core.policy import TradingPolicyEngine
+from engine.core.types import TradeIntent
+from engine.execution.paper import PaperBroker
+from engine.execution.position_sizer import CorrelationAwareSizer, PositionSizer, RiskLimits
+from engine.execution.preflight import Preflight
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC).replace(microsecond=0)
+
+
+@dataclass(frozen=True, slots=True)
+class OMSResult:
+    status: str  # filled|rejected|error
+    mode: str
+    order_id: str | None = None
+    position_id: str | None = None
+    notional_usd: float | None = None
+    reasons: list[str] | None = None
+
+
+class OMS:
+    def __init__(
+        self,
+        *,
+        config: Config,
+        db: Database,
+        preflight: Preflight,
+        sizer: CorrelationAwareSizer,
+        paper_broker: PaperBroker | None = None,
+        policy: TradingPolicyEngine | None = None,
+    ) -> None:
+        self.config = config
+        self.db = db
+        self.preflight = preflight
+        self.sizer = sizer
+        self.paper = paper_broker or PaperBroker(db)
+        self.policy = policy
+
+    def submit(
+        self,
+        intent: TradeIntent,
+        *,
+        mid_price: float,
+        equity_usd: float,
+        portfolio_heat_pct: float = 0.0,
+        corr_to_portfolio: float = 0.0,
+        idempotency_key: str | None = None,
+        gas_balances: dict[tuple[str, str], float] | None = None,
+    ) -> OMSResult:
+        mode = str(self.config.execution.mode)
+        idem = idempotency_key or str(uuid.uuid4())
+
+        # Record intent event for auditability.
+        payload = TradeIntentPayload(
+            symbol=intent.symbol,
+            direction=intent.direction,
+            size_pct=float(intent.size_pct),
+            leverage=float(intent.leverage),
+            conviction_score=float(intent.conviction_score),
+            regime=str(intent.regime),
+            rationale=str(intent.rationale),
+            stop_loss_pct=float(intent.stop_loss_pct) if intent.stop_loss_pct is not None else None,
+            take_profit_pct=float(intent.take_profit_pct) if intent.take_profit_pct is not None else None,
+        ).model_dump(mode="json")
+        self.db.append_event(
+            event_type=EventType.TRADE_INTENT_V1,
+            payload=payload,
+            source="execution.oms",
+            dedupe_key=f"{EventType.TRADE_INTENT_V1}:{idem}",
+            ts=_utc_now(),
+        )
+
+        pf = self.preflight.check(
+            intent,
+            mode=mode,
+            equity_usd=float(equity_usd),
+            gas_balances=gas_balances,
+        )
+        if not pf.approved:
+            return OMSResult(status="rejected", mode=mode, reasons=pf.reasons)
+
+        # Size notional (USD) - ignore intent.size_pct here; sizing uses conviction and caps.
+        max_pct = float(self.config.risk.max_position_pct)
+        notional = self.sizer.size_usd(
+            equity_usd=float(equity_usd),
+            conviction_score=max(0.0, min(1.0, float(intent.conviction_score) / 100.0)),
+            corr_to_portfolio=float(corr_to_portfolio),
+            portfolio_heat_pct=float(portfolio_heat_pct),
+            max_position_pct=max_pct,
+        )
+        if notional <= 0:
+            return OMSResult(status="rejected", mode=mode, reasons=["size_zero"])
+
+        stop_loss = None
+        take_profit = None
+        if intent.stop_loss_pct is not None:
+            stop_loss = float(mid_price) * (1.0 - float(intent.stop_loss_pct))
+        if intent.take_profit_pct is not None:
+            take_profit = float(mid_price) * (1.0 + float(intent.take_profit_pct))
+
+        if mode == "paper":
+            fill = self.paper.execute_market(
+                symbol=intent.symbol,
+                direction=intent.direction,
+                notional_usd=float(notional),
+                leverage=float(intent.leverage),
+                mid_price=float(mid_price),
+                stop_loss=stop_loss,
+                take_profit=take_profit,
+                idempotency_key=idem,
+            )
+
+            # Persist execution events as well (redundant with tables, but useful for the event bus).
+            self.db.append_event(
+                event_type=EventType.ORDER_SUBMITTED_V1,
+                payload={
+                    "order_id": fill.order_id,
+                    "position_id": fill.position_id,
+                    "venue": "paper",
+                    "type": "market",
+                    "side": fill.side,
+                    "symbol": fill.symbol,
+                    "size": float(fill.fill_size),
+                    "idempotency_key": idem,
+                },
+                source="execution.oms",
+            )
+            self.db.append_event(
+                event_type=EventType.ORDER_FILLED_V1,
+                payload={
+                    "order_id": fill.order_id,
+                    "position_id": fill.position_id,
+                    "fill_price": float(fill.fill_price),
+                    "fill_size": float(fill.fill_size),
+                    "fee_usd": float(fill.fee_usd),
+                },
+                source="execution.oms",
+            )
+            self.db.append_event(
+                event_type=EventType.POSITION_OPENED_V1,
+                payload={
+                    "position_id": fill.position_id,
+                    "platform": "paper",
+                    "asset": fill.symbol,
+                    "direction": intent.direction,
+                    "entry_price": float(fill.fill_price),
+                    "size_notional": float(fill.notional_usd),
+                    "leverage": float(intent.leverage),
+                },
+                source="execution.oms",
+            )
+
+            return OMSResult(
+                status="filled",
+                mode=mode,
+                order_id=fill.order_id,
+                position_id=fill.position_id,
+                notional_usd=float(notional),
+            )
+
+        if mode == "live":
+            raise NotImplementedError("live execution adapter not implemented in Sprint 2A")
+
+        return OMSResult(status="error", mode=mode, reasons=[f"unknown_mode:{mode}"])
+
+
+def default_sizer_from_config(cfg: Config) -> CorrelationAwareSizer:
+    base = PositionSizer(
+        kelly=None,
+        limits=RiskLimits(max_position_pct=float(cfg.risk.max_position_pct), min_position_usd=10.0),
+    )
+    return CorrelationAwareSizer(base)

--- a/engine/execution/paper.py
+++ b/engine/execution/paper.py
@@ -1,4 +1,187 @@
-"""Module placeholder.
+"""engine.execution.paper
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Paper trading adapter.
+
+Requirements (Sprint 2A):
+- simulated fills
+- position tracking
+- persist to the new DB schema (positions, orders)
+
+This is intentionally minimal. It fills immediately at the provided mid price with
+configurable slippage + fee.
 """
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from engine.core.database import Database
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC).replace(microsecond=0)
+
+
+@dataclass(frozen=True, slots=True)
+class PaperConfig:
+    slippage_bps: float = 5.0
+    fee_rate: float = 0.0006
+    platform: str = "paper"
+    venue: str = "paper"
+
+
+@dataclass(frozen=True, slots=True)
+class PaperFill:
+    order_id: str
+    position_id: str
+    symbol: str
+    side: str  # buy|sell
+    fill_price: float
+    fill_size: float
+    notional_usd: float
+    fee_usd: float
+    realized_pnl_usd: float | None
+
+
+class PaperBroker:
+    """Writes orders + positions into the shared DB."""
+
+    def __init__(self, db: Database, *, config: PaperConfig | None = None) -> None:
+        self.db = db
+        self.cfg = config or PaperConfig()
+
+    def _fill_price(self, *, mid: float, side: str) -> float:
+        slip = float(self.cfg.slippage_bps) / 10_000.0
+        if side == "buy":
+            return float(mid) * (1.0 + slip)
+        return float(mid) * (1.0 - slip)
+
+    def _existing_open_position(self, symbol: str) -> dict[str, Any] | None:
+        row = self.db.conn.execute(
+            "SELECT * FROM positions WHERE asset = ? AND status = 'open' ORDER BY opened_at DESC LIMIT 1",
+            (symbol,),
+        ).fetchone()
+        return None if row is None else dict(row)
+
+    def execute_market(
+        self,
+        *,
+        symbol: str,
+        direction: str,
+        notional_usd: float,
+        leverage: float = 1.0,
+        mid_price: float,
+        stop_loss: float | None = None,
+        take_profit: float | None = None,
+        idempotency_key: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> PaperFill:
+        sym = str(symbol).upper().strip()
+        dirn = str(direction).lower().strip()
+        if dirn not in {"long", "short"}:
+            raise ValueError("direction must be 'long' or 'short'")
+
+        mid = float(mid_price)
+        if mid <= 0:
+            raise ValueError("mid_price must be > 0")
+
+        n_usd = float(notional_usd)
+        if n_usd <= 0:
+            raise ValueError("notional_usd must be > 0")
+
+        side = "buy" if dirn == "long" else "sell"
+        fill_px = self._fill_price(mid=mid, side=side)
+        qty = n_usd / fill_px
+        fee = abs(n_usd) * float(self.cfg.fee_rate)
+
+        now = _utc_now().isoformat()
+
+        # idempotency: orders table has unique constraint on idempotency_key.
+        idem = idempotency_key
+        if idem is None:
+            idem = str(uuid.uuid4())
+
+        existing = self.db.conn.execute(
+            "SELECT id, position_id, fill_price, fill_size, status FROM orders WHERE idempotency_key = ?",
+            (idem,),
+        ).fetchone()
+        if existing is not None:
+            # Already executed.
+            oid = str(existing[0])
+            pid = str(existing[1])
+            return PaperFill(
+                order_id=oid,
+                position_id=pid,
+                symbol=sym,
+                side=side,
+                fill_price=float(existing[2] or 0.0),
+                fill_size=float(existing[3] or 0.0),
+                notional_usd=float(n_usd),
+                fee_usd=float(fee),
+                realized_pnl_usd=None,
+            )
+
+        order_id = str(uuid.uuid4())
+        position_id = str(uuid.uuid4())
+
+        # For Sprint 2A we open a new position per intent. Closing is done via PnLTracker.
+        with self.db.conn:
+            self.db.conn.execute(
+                """
+                INSERT INTO positions (
+                  id, platform, asset, direction, entry_price, size_notional, leverage,
+                  stop_loss, take_profit, opened_at, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open')
+                """,
+                (
+                    position_id,
+                    str(self.cfg.platform),
+                    sym,
+                    dirn,
+                    float(fill_px),
+                    float(n_usd),
+                    float(leverage),
+                    float(stop_loss) if stop_loss is not None else None,
+                    float(take_profit) if take_profit is not None else None,
+                    now,
+                ),
+            )
+            self.db.conn.execute(
+                """
+                INSERT INTO orders (
+                  id, position_id, venue, type, side, symbol, size, price,
+                  fill_price, fill_size, status, idempotency_key, created_at, filled_at, updated_at
+                ) VALUES (?, ?, ?, 'market', ?, ?, ?, ?, ?, ?, 'filled', ?, ?, ?, ?)
+                """,
+                (
+                    order_id,
+                    position_id,
+                    str(self.cfg.venue),
+                    side,
+                    sym,
+                    float(qty),
+                    None,
+                    float(fill_px),
+                    float(qty),
+                    str(idem),
+                    now,
+                    now,
+                    now,
+                ),
+            )
+
+        _ = metadata  # reserved
+        return PaperFill(
+            order_id=order_id,
+            position_id=position_id,
+            symbol=sym,
+            side=side,
+            fill_price=float(fill_px),
+            fill_size=float(qty),
+            notional_usd=float(n_usd),
+            fee_usd=float(fee),
+            realized_pnl_usd=None,
+        )

--- a/engine/execution/pnl.py
+++ b/engine/execution/pnl.py
@@ -1,4 +1,112 @@
-"""Module placeholder.
+"""engine.execution.pnl
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+P&L tracker for paper/live execution.
+
+Sprint 2A requirements:
+- realized P&L on close
+- unrealized P&L while holding
+
+The DB schema already has a ``positions`` table, which we treat as the canonical
+position ledger.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from engine.core.database import Database
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC).replace(microsecond=0)
+
+
+@dataclass(frozen=True, slots=True)
+class PnLSnapshot:
+    realized_usd: float
+    unrealized_usd: float
+    total_usd: float
+
+
+class PnLTracker:
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+    def unrealized_usd(self, *, position_id: str, mark_price: float) -> float:
+        row = self.db.conn.execute(
+            "SELECT direction, entry_price, size_notional, status FROM positions WHERE id = ?",
+            (str(position_id),),
+        ).fetchone()
+        if row is None:
+            return 0.0
+        if str(row[3]) != "open":
+            return 0.0
+
+        direction = str(row[0])
+        entry = float(row[1])
+        notional = float(row[2])
+        qty = notional / entry if entry > 0 else 0.0
+        mp = float(mark_price)
+
+        if direction == "long":
+            return (mp - entry) * qty
+        return (entry - mp) * qty
+
+    def close_position(self, *, position_id: str, exit_price: float, reason: str = "") -> float:
+        """Mark a position closed and store realized_pnl."""
+
+        row = self.db.conn.execute(
+            "SELECT direction, entry_price, size_notional, status FROM positions WHERE id = ?",
+            (str(position_id),),
+        ).fetchone()
+        if row is None:
+            raise ValueError("position not found")
+        if str(row[3]) != "open":
+            raise ValueError("position not open")
+
+        direction = str(row[0])
+        entry = float(row[1])
+        notional = float(row[2])
+        qty = notional / entry if entry > 0 else 0.0
+        xp = float(exit_price)
+
+        if direction == "long":
+            realized = (xp - entry) * qty
+        else:
+            realized = (entry - xp) * qty
+
+        now = _utc_now().isoformat()
+        with self.db.conn:
+            self.db.conn.execute(
+                "UPDATE positions SET status = 'closed', closed_at = ?, realized_pnl = ? WHERE id = ?",
+                (now, float(realized), str(position_id)),
+            )
+            # Optional audit trail
+            if reason:
+                self.db.conn.execute(
+                    "INSERT INTO audit_log (action, actor, component, details) VALUES (?, ?, ?, ?)",
+                    ("position_closed", "system", "execution.pnl", f"{position_id}:{reason}"),
+                )
+
+        return float(realized)
+
+    def snapshot(self, *, current_prices: dict[str, float]) -> PnLSnapshot:
+        unreal = 0.0
+        for row in self.db.conn.execute(
+            "SELECT id, asset FROM positions WHERE status = 'open'"
+        ).fetchall():
+            pid = str(row[0])
+            sym = str(row[1]).upper()
+            px = current_prices.get(sym)
+            if px is None:
+                continue
+            unreal += self.unrealized_usd(position_id=pid, mark_price=float(px))
+
+        realized = 0.0
+        for row in self.db.conn.execute(
+            "SELECT realized_pnl FROM positions WHERE status = 'closed' AND realized_pnl IS NOT NULL"
+        ).fetchall():
+            realized += float(row[0])
+
+        return PnLSnapshot(realized_usd=float(realized), unrealized_usd=float(unreal), total_usd=float(realized + unreal))

--- a/engine/execution/position_sizer.py
+++ b/engine/execution/position_sizer.py
@@ -1,4 +1,123 @@
-"""Module placeholder.
+"""engine.execution.position_sizer
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Position sizing primitives.
+
+Sprint 2A requirements:
+- Kelly criterion sizing
+- correlation-aware adjustment
+
+This module intentionally avoids coupling to exchange/venue specifics.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class KellyParams:
+    """Inputs for Kelly sizing.
+
+    - ``p``: probability of winning (0..1)
+    - ``b``: payoff ratio (avg win / avg loss), must be > 0
+
+    Kelly fraction: (b*p - (1-p)) / b
+    """
+
+    p: float = 0.55
+    b: float = 1.2
+    fraction_multiplier: float = 0.5  # half-Kelly by default
+
+
+@dataclass(frozen=True, slots=True)
+class RiskLimits:
+    max_position_pct: float = 0.10
+    min_position_usd: float = 10.0
+
+
+class PositionSizer:
+    def __init__(self, *, kelly: KellyParams | None = None, limits: RiskLimits | None = None) -> None:
+        self.kelly = kelly or KellyParams()
+        self.limits = limits or RiskLimits()
+
+    def kelly_fraction(self) -> float:
+        p = max(0.0, min(1.0, float(self.kelly.p)))
+        b = max(1e-9, float(self.kelly.b))
+        q = 1.0 - p
+        f = (b * p - q) / b
+        f = max(0.0, f)
+        return float(f) * float(self.kelly.fraction_multiplier)
+
+    def size_usd(
+        self,
+        *,
+        equity_usd: float,
+        conviction_score: float,
+        max_position_pct: float | None = None,
+    ) -> float:
+        """Compute a notional position size (USD).
+
+        This combines:
+        - half-Kelly (risk / expectancy)
+        - conviction scaling: conviction 0..1 scales between 0.25..1.0
+
+        Conviction is treated as a *soft* scaling layer, not a source of leverage.
+        """
+
+        eq = max(0.0, float(equity_usd))
+        if eq <= 0:
+            return 0.0
+
+        # Conviction scaling (0..1) -> (0.25..1.0)
+        c = max(0.0, min(1.0, float(conviction_score)))
+        scale = 0.25 + 0.75 * c
+
+        raw_fraction = self.kelly_fraction() * scale
+        cap_pct = float(max_position_pct) if max_position_pct is not None else float(self.limits.max_position_pct)
+        raw_fraction = min(raw_fraction, cap_pct)
+
+        notional = eq * raw_fraction
+        if notional < float(self.limits.min_position_usd):
+            return 0.0
+        return float(notional)
+
+
+class CorrelationAwareSizer:
+    """Wrap a base sizer with correlation-aware throttling.
+
+    The idea: if you're already long high-beta/correlated exposure, new correlated
+    longs should be sized down.
+
+    Inputs:
+    - ``corr_to_portfolio``: abs correlation of the *new* trade with the existing portfolio, 0..1
+    - ``portfolio_heat_pct``: current total exposure / equity, 0..1
+
+    Adjustment multiplier = max(0.0, 1 - corr_to_portfolio * portfolio_heat_pct)
+    """
+
+    def __init__(self, base: PositionSizer) -> None:
+        self.base = base
+
+    def size_usd(
+        self,
+        *,
+        equity_usd: float,
+        conviction_score: float,
+        corr_to_portfolio: float = 0.0,
+        portfolio_heat_pct: float = 0.0,
+        max_position_pct: float | None = None,
+    ) -> float:
+        base_size = self.base.size_usd(
+            equity_usd=equity_usd, conviction_score=conviction_score, max_position_pct=max_position_pct
+        )
+        if base_size <= 0:
+            return 0.0
+
+        corr = max(0.0, min(1.0, abs(float(corr_to_portfolio))))
+        heat = max(0.0, min(1.0, float(portfolio_heat_pct)))
+        mult = max(0.0, 1.0 - corr * heat)
+        sized = base_size * mult
+
+        if sized < float(self.base.limits.min_position_usd):
+            return 0.0
+        return float(sized)

--- a/engine/execution/preflight.py
+++ b/engine/execution/preflight.py
@@ -1,4 +1,116 @@
-"""Module placeholder.
+"""engine.execution.preflight
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Risk preflight checks for both paper and live execution.
+
+Sprint 2A checks:
+- gas balance (for live mode)
+- position limits
+- daily loss limit
+- kill switch gate (engine.brain.kill_switch)
+
+The preflight layer is a *hard gate*; it should be deterministic and easy to test.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from engine.brain.kill_switch import KillSwitch, KillSwitchLevel
+from engine.core.policy import PolicyViolation, TradingPolicy, TradingPolicyEngine
+
+
+class PreflightError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightResult:
+    approved: bool
+    reasons: list[str] = field(default_factory=list)
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GasRequirement:
+    venue: str
+    asset: str
+    min_amount: float
+
+
+class Preflight:
+    def __init__(
+        self,
+        *,
+        policy: TradingPolicyEngine,
+        kill_switch: KillSwitch,
+        gas_requirements: list[GasRequirement] | None = None,
+    ) -> None:
+        self.policy = policy
+        self.kill_switch = kill_switch
+        self.gas_requirements = gas_requirements or []
+
+    def check(
+        self,
+        intent: Any,
+        *,
+        mode: str,
+        equity_usd: float,
+        kill_switch_level: int | None = None,
+        gas_balances: dict[tuple[str, str], float] | None = None,
+    ) -> PreflightResult:
+        m = str(mode)
+        reasons: list[str] = []
+        details: dict[str, Any] = {"mode": m}
+
+        # Kill switch gate (canonical source of truth)
+        level = (
+            int(kill_switch_level)
+            if kill_switch_level is not None
+            else int(self.kill_switch.level)
+        )
+        details["kill_switch_level"] = level
+        try:
+            self.policy.check_kill_switch(level=level)
+        except PolicyViolation as e:
+            reasons.append(e.rule)
+
+        # TradingPolicyEngine handles daily loss + position size + leverage
+        try:
+            self.policy.pretrade_check(intent, equity_usd=float(equity_usd), kill_switch_level=level)
+        except PolicyViolation as e:
+            reasons.append(e.rule)
+            details.setdefault("policy_message", str(e))
+
+        # Gas checks are only meaningful in live mode.
+        if m == "live" and self.gas_requirements:
+            balances = gas_balances or {}
+            for req in self.gas_requirements:
+                key = (str(req.venue), str(req.asset))
+                have = float(balances.get(key, 0.0))
+                details.setdefault("gas", {})[f"{req.venue}:{req.asset}"] = have
+                if have + 1e-12 < float(req.min_amount):
+                    reasons.append("insufficient_gas")
+                    break
+
+        return PreflightResult(approved=(len(reasons) == 0), reasons=reasons, details=details)
+
+
+def default_policy_from_risk(
+    *,
+    max_daily_loss_usd: float,
+    max_position_size_pct: float,
+    max_leverage_default: float,
+    max_leverage_by_regime: dict[str, float] | None = None,
+    kill_switch_enabled: bool = True,
+) -> TradingPolicyEngine:
+    """Convenience helper used in tests/wiring."""
+
+    pol = TradingPolicy(
+        max_daily_loss_usd=float(max_daily_loss_usd),
+        max_position_size_pct=float(max_position_size_pct),
+        kill_switch_enabled=bool(kill_switch_enabled),
+        max_leverage_default=float(max_leverage_default),
+        max_leverage_by_regime=dict(max_leverage_by_regime or {}),
+    )
+    return TradingPolicyEngine(policy=pol)

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from engine.execution.circuit_breaker import CircuitBreaker, CircuitBreakerError, TokenBucket
+
+
+def test_token_bucket_rate_limits() -> None:
+    bucket = TokenBucket(capacity=2, refill_rate_per_s=1.0)
+    br = CircuitBreaker(name="venue", bucket=bucket, failure_threshold=3)
+
+    # take two immediate calls
+    assert br.can_call(now=0.0) is True
+    assert br.can_call(now=0.0) is True
+    # third should be limited
+    assert br.can_call(now=0.0) is False
+
+    # after 1 second, one token refills
+    assert br.can_call(now=1.0) is True
+
+
+def test_exponential_backoff_opens_after_failures() -> None:
+    bucket = TokenBucket(capacity=10, refill_rate_per_s=10.0)
+    br = CircuitBreaker(name="venue", bucket=bucket, failure_threshold=2, backoff_base_s=1.0, backoff_max_s=10.0)
+
+    # record two failures -> backoff window starts
+    br.record_failure()
+    assert br.backoff_remaining_s(now=0.0) == 0.0
+
+    br.record_failure()
+    assert br.backoff_remaining_s(now=0.0) > 0.0
+    assert br.can_call(now=0.0) is False
+
+
+def test_call_raises_when_limited() -> None:
+    bucket = TokenBucket(capacity=1, refill_rate_per_s=0.0001)
+    br = CircuitBreaker(name="venue", bucket=bucket)
+
+    # Use real monotonic time so we don't accidentally grant a huge refill window.
+    br.bucket.try_take(1.0)
+
+    with pytest.raises(CircuitBreakerError):
+        br.call(lambda: 123)

--- a/tests/unit/test_oms.py
+++ b/tests/unit/test_oms.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from engine.brain.kill_switch import KillSwitch
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.policy import TradingPolicy, TradingPolicyEngine
+from engine.core.types import TradeIntent
+from engine.execution.oms import OMS, default_sizer_from_config
+from engine.execution.preflight import Preflight
+
+
+def test_submit_intent_paper_creates_fill_and_events(temp_dir: Path, test_config: Config) -> None:
+    db = Database(temp_dir / "brain.db")
+    ks = KillSwitch(test_config, db)
+
+    pol = TradingPolicy(
+        max_daily_loss_usd=0.0,
+        max_position_size_pct=test_config.risk.max_position_pct,
+        kill_switch_enabled=True,
+        max_leverage_default=test_config.risk.max_leverage,
+    )
+    policy_engine = TradingPolicyEngine(policy=pol)
+
+    preflight = Preflight(policy=policy_engine, kill_switch=ks)
+    sizer = default_sizer_from_config(test_config)
+
+    oms = OMS(config=test_config, db=db, preflight=preflight, sizer=sizer)
+
+    intent = TradeIntent(
+        symbol="BTC",
+        direction="long",
+        size_pct=0.05,
+        leverage=1.0,
+        conviction_score=80.0,
+        regime="BULL",
+        rationale="unit test",
+        stop_loss_pct=0.05,
+        take_profit_pct=0.10,
+    )
+
+    res = oms.submit(intent, mid_price=50_000.0, equity_usd=10_000.0)
+    assert res.status == "filled"
+    assert res.order_id is not None
+    assert res.position_id is not None
+
+    pos = db.conn.execute("SELECT * FROM positions WHERE id = ?", (res.position_id,)).fetchone()
+    assert pos is not None
+    assert pos["status"] == "open"
+
+    # execution events emitted
+    evs = db.get_events(limit=50)
+    types = {e.type for e in evs}
+    assert "execution.trade_intent.v1" in {str(t) for t in types}
+    assert "execution.order_filled.v1" in {str(t) for t in types}

--- a/tests/unit/test_paper.py
+++ b/tests/unit/test_paper.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from engine.core.database import Database
+from engine.execution.paper import PaperBroker
+
+
+def test_paper_exec_creates_order_and_position(temp_dir: Path) -> None:
+    db = Database(temp_dir / "brain.db")
+    broker = PaperBroker(db)
+
+    fill = broker.execute_market(
+        symbol="BTC",
+        direction="long",
+        notional_usd=1000.0,
+        leverage=1.0,
+        mid_price=50_000.0,
+        idempotency_key="abc",
+    )
+
+    pos = db.conn.execute("SELECT * FROM positions WHERE id = ?", (fill.position_id,)).fetchone()
+    assert pos is not None
+    assert pos["asset"] == "BTC"
+    assert pos["direction"] == "long"
+
+    order = db.conn.execute("SELECT * FROM orders WHERE id = ?", (fill.order_id,)).fetchone()
+    assert order is not None
+    assert order["status"] == "filled"
+    assert order["idempotency_key"] == "abc"
+
+
+def test_paper_idempotency_key_returns_existing(temp_dir: Path) -> None:
+    db = Database(temp_dir / "brain.db")
+    broker = PaperBroker(db)
+
+    a = broker.execute_market(
+        symbol="ETH",
+        direction="long",
+        notional_usd=1000.0,
+        leverage=1.0,
+        mid_price=2000.0,
+        idempotency_key="idem",
+    )
+    b = broker.execute_market(
+        symbol="ETH",
+        direction="long",
+        notional_usd=1000.0,
+        leverage=1.0,
+        mid_price=2000.0,
+        idempotency_key="idem",
+    )
+
+    assert a.order_id == b.order_id
+    assert a.position_id == b.position_id

--- a/tests/unit/test_pnl.py
+++ b/tests/unit/test_pnl.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.core.database import Database
+from engine.execution.paper import PaperBroker
+from engine.execution.pnl import PnLTracker
+
+
+def test_unrealized_and_realized_pnl_long(temp_dir: Path) -> None:
+    db = Database(temp_dir / "brain.db")
+    broker = PaperBroker(db)
+    pnl = PnLTracker(db)
+
+    fill = broker.execute_market(
+        symbol="BTC",
+        direction="long",
+        notional_usd=1000.0,
+        leverage=1.0,
+        mid_price=50_000.0,
+        idempotency_key="pnl1",
+    )
+
+    u = pnl.unrealized_usd(position_id=fill.position_id, mark_price=55_000.0)
+    assert u > 0
+
+    r = pnl.close_position(position_id=fill.position_id, exit_price=55_000.0, reason="tp")
+    assert r > 0
+
+    # can't close twice
+    with pytest.raises(ValueError):
+        pnl.close_position(position_id=fill.position_id, exit_price=55_000.0)

--- a/tests/unit/test_position_sizer.py
+++ b/tests/unit/test_position_sizer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from engine.execution.position_sizer import CorrelationAwareSizer, KellyParams, PositionSizer
+
+
+def test_kelly_fraction_non_negative() -> None:
+    s = PositionSizer(kelly=KellyParams(p=0.51, b=1.0, fraction_multiplier=0.5))
+    assert s.kelly_fraction() >= 0.0
+
+
+def test_correlation_aware_sizing_reduces_with_corr_and_heat() -> None:
+    base = PositionSizer(kelly=KellyParams(p=0.6, b=1.5, fraction_multiplier=0.5))
+    s = CorrelationAwareSizer(base)
+
+    a = s.size_usd(equity_usd=10_000, conviction_score=1.0, corr_to_portfolio=0.0, portfolio_heat_pct=0.5)
+    b = s.size_usd(equity_usd=10_000, conviction_score=1.0, corr_to_portfolio=1.0, portfolio_heat_pct=0.5)
+
+    assert a >= b
+    assert b >= 0.0

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.brain.kill_switch import KillSwitch, KillSwitchLevel
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.policy import TradingPolicy, TradingPolicyEngine
+from engine.core.types import TradeIntent
+from engine.execution.preflight import GasRequirement, Preflight
+
+
+def _mk_policy(*, max_daily_loss_usd: float = 0.0, max_position_pct: float = 0.10) -> TradingPolicyEngine:
+    pol = TradingPolicy(
+        max_daily_loss_usd=max_daily_loss_usd,
+        max_position_size_pct=max_position_pct,
+        kill_switch_enabled=True,
+        max_leverage_default=5.0,
+    )
+    return TradingPolicyEngine(policy=pol)
+
+
+def test_preflight_blocks_on_kill_switch(temp_dir: Path, test_config: Config) -> None:
+    db = Database(temp_dir / "brain.db")
+    ks = KillSwitch(test_config, db)
+    policy = _mk_policy()
+
+    preflight = Preflight(policy=policy, kill_switch=ks)
+
+    # manually raise kill switch to DEFENSIVE
+    ks.reset(level=KillSwitchLevel.DEFENSIVE)
+
+    intent = TradeIntent(
+        symbol="BTC",
+        direction="long",
+        size_pct=0.05,
+        leverage=1.0,
+        conviction_score=80.0,
+        regime="BULL",
+        rationale="",
+    )
+
+    res = preflight.check(intent, mode="paper", equity_usd=10_000.0)
+    assert res.approved is False
+    assert "kill_switch" in res.reasons
+
+
+def test_preflight_gas_check_live_mode(temp_dir: Path, test_config: Config) -> None:
+    db = Database(temp_dir / "brain.db")
+    ks = KillSwitch(test_config, db)
+    policy = _mk_policy()
+    preflight = Preflight(
+        policy=policy,
+        kill_switch=ks,
+        gas_requirements=[GasRequirement(venue="base", asset="ETH", min_amount=0.001)],
+    )
+
+    intent = TradeIntent(
+        symbol="ETH",
+        direction="long",
+        size_pct=0.01,
+        leverage=1.0,
+        conviction_score=60.0,
+        regime="BULL",
+        rationale="",
+    )
+
+    res = preflight.check(
+        intent,
+        mode="live",
+        equity_usd=10_000.0,
+        gas_balances={("base", "ETH"): 0.0},
+    )
+    assert res.approved is False
+    assert "insufficient_gas" in res.reasons
+
+
+def test_rejects_whale_sized_order_for_non_whale(temp_dir: Path, test_config: Config) -> None:
+    # Easter egg spec from BUILD_PLAN Phase 4C.
+    db = Database(temp_dir / "brain.db")
+    ks = KillSwitch(test_config, db)
+    policy = _mk_policy(max_position_pct=0.01)
+    preflight = Preflight(policy=policy, kill_switch=ks)
+
+    intent = TradeIntent(
+        symbol="BTC",
+        direction="long",
+        size_pct=0.50,  # huge
+        leverage=1.0,
+        conviction_score=90.0,
+        regime="BULL",
+        rationale="",
+    )
+
+    res = preflight.check(intent, mode="paper", equity_usd=10_000.0)
+    assert res.approved is False
+    assert "position_size_limit" in res.reasons


### PR DESCRIPTION
Implements Sprint 2A (Phase 2): OMS + paper trading adapter + preflight checks + Kelly/correlation sizing + P&L tracking + circuit breaker, with unit tests.

Acceptance: oms.submit(intent) in paper mode persists orders/positions + emits execution events; preflight gates kill switch, daily loss, position limit, gas (live mode); sizing respects max position cap; circuit breaker token bucket + backoff.