### PR TITLE
Sprint 2B — Karma engine + Hyperliquid adapter + e2e test

### DIFF
--- a/engine/execution/hyperliquid.py
+++ b/engine/execution/hyperliquid.py
@@ -1,4 +1,108 @@
-"""Module placeholder.
+"""engine.execution.hyperliquid
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Hyperliquid execution adapter.
+
+This module provides a small, testable boundary for order placement.
+In production we can swap the underlying implementation (SDK vs HTTP) without
+changing callers.
+
+The unit tests in Sprint 2B rely on an injected API object.
 """
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class HLOrder:
+    id: str
+    symbol: str
+    side: str  # "buy" | "sell"
+    size: float
+    price: float | None
+    status: str  # "open" | "filled" | "canceled" | "rejected"
+    filled_price: float | None = None
+
+
+class HyperliquidApi(Protocol):
+    def place_order(
+        self, *, symbol: str, side: str, size: float, price: float | None = None
+    ) -> HLOrder: ...
+
+    def cancel_order(self, *, order_id: str) -> bool: ...
+
+    def get_order(self, *, order_id: str) -> HLOrder | None: ...
+
+
+class HyperliquidAdapter:
+    """Thin adapter that delegates to an injected API implementation."""
+
+    def __init__(self, *, api: HyperliquidApi) -> None:
+        self._api = api
+
+    def place(
+        self, *, symbol: str, side: str, size: float, price: float | None = None
+    ) -> HLOrder:
+        sym = str(symbol).upper().strip()
+        if side not in {"buy", "sell"}:
+            raise ValueError("side must be 'buy' or 'sell'")
+        if size <= 0:
+            raise ValueError("size must be > 0")
+        return self._api.place_order(symbol=sym, side=side, size=float(size), price=price)
+
+    def cancel(self, *, order_id: str) -> bool:
+        return bool(self._api.cancel_order(order_id=str(order_id)))
+
+    def status(self, *, order_id: str) -> HLOrder | None:
+        return self._api.get_order(order_id=str(order_id))
+
+
+class InMemoryHyperliquidApi:
+    """Test-double API: minimal in-memory orderbook."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, HLOrder] = {}
+
+    def place_order(
+        self, *, symbol: str, side: str, size: float, price: float | None = None
+    ) -> HLOrder:
+        oid = str(uuid.uuid4())
+        o = HLOrder(id=oid, symbol=symbol, side=side, size=float(size), price=price, status="open")
+        self._orders[oid] = o
+        return o
+
+    def cancel_order(self, *, order_id: str) -> bool:
+        o = self._orders.get(order_id)
+        if o is None:
+            return False
+        if o.status == "filled":
+            return False
+        self._orders[order_id] = HLOrder(
+            id=o.id,
+            symbol=o.symbol,
+            side=o.side,
+            size=o.size,
+            price=o.price,
+            status="canceled",
+            filled_price=o.filled_price,
+        )
+        return True
+
+    def get_order(self, *, order_id: str) -> HLOrder | None:
+        return self._orders.get(order_id)
+
+    def fill_order(self, *, order_id: str, fill_price: float) -> HLOrder:
+        o = self._orders[order_id]
+        self._orders[order_id] = HLOrder(
+            id=o.id,
+            symbol=o.symbol,
+            side=o.side,
+            size=o.size,
+            price=o.price,
+            status="filled",
+            filled_price=float(fill_price),
+        )
+        return self._orders[order_id]

--- a/engine/execution/karma.py
+++ b/engine/execution/karma.py
@@ -1,4 +1,350 @@
-"""Module placeholder.
+"""engine.execution.karma
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Karma v2.0 (PRD v3 §18)
+
+This mechanism is simple on purpose.
+
+- Realized profit only. Never losses.
+- Default-on, operator-controlled.
+- Two-phase flow:
+  A) Intent (local, automatic): record what *would* be contributed.
+  B) Settlement (explicit): operator chooses when to actually pay.
+- Non-blocking: karma failure must never break execution.
+
+The point is not moral accounting. It is infrastructure funding.
+A compounding commons is a defensible advantage: shared inputs improve the engine,
+which improves outcomes, which funds better shared inputs.
+
+Tone constraint: builders, conviction, pride. No shame language.
 """
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Callable
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType, canonical_json
+from engine.security.identity import NodeIdentity
+
+
+@dataclass(frozen=True)
+class KarmaIntent:
+    id: str
+    trade_id: str
+    realized_pnl_usd: float
+    karma_percentage: float
+    karma_amount_usd: float
+    node_id: str
+    signature_b64: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class KarmaReceipt:
+    id: str
+    intent_ids: list[str]
+    total_usd: float
+    destination_wallet: str
+    tx_hash: str | None
+    status: str
+    signature_b64: str
+    created_at: str
+
+
+def _utc_now_iso(now_fn: Callable[[], datetime] | None = None) -> str:
+    n = (now_fn or (lambda: datetime.now(tz=UTC)))()
+    if n.tzinfo is None:
+        n = n.replace(tzinfo=UTC)
+    return n.astimezone(UTC).isoformat()
+
+
+def _sign_payload(identity: NodeIdentity, payload: dict) -> str:
+    """Return base64 signature for canonical-json payload."""
+
+    data = canonical_json(payload).encode("utf-8")
+    sig = identity.sign(data)
+    import base64
+
+    return base64.b64encode(sig).decode("ascii")
+
+
+class KarmaEngine:
+    """Records karma intents on profitable trade close; batches settlements.
+
+    Fail-open contract:
+    - record_intent() never raises
+    - settle() never raises
+
+    The operator controls when a settlement occurs.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        db: Database,
+        identity: NodeIdentity,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._config = config
+        self._db = db
+        self._identity = identity
+        self._now_fn = now_fn
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._config.karma.enabled) and float(self._config.karma.percentage) > 0.0
+
+    def record_intent(self, *, trade_id: str, realized_pnl_usd: float) -> KarmaIntent | None:
+        """Record a signed intent for a profitable trade.
+
+        Returns intent if recorded, else None.
+        """
+
+        try:
+            if not self.enabled:
+                return None
+            if not self._config.karma.treasury_address:
+                # PRD: intent recording is gated on treasury configuration.
+                return None
+            pnl = float(realized_pnl_usd)
+            if pnl <= 0.0:
+                return None
+
+            pct = float(self._config.karma.percentage)
+            amount = pnl * pct
+
+            intent_id = str(uuid.uuid4())
+            created_at = _utc_now_iso(self._now_fn)
+
+            payload = {
+                "id": intent_id,
+                "trade_id": str(trade_id),
+                "realized_pnl_usd": pnl,
+                "karma_percentage": pct,
+                "karma_amount_usd": amount,
+                "node_id": self._identity.node_id,
+                "created_at": created_at,
+            }
+            sig_b64 = _sign_payload(self._identity, payload)
+
+            with self._db.conn:
+                self._db.conn.execute(
+                    """
+                    INSERT INTO karma_intents (
+                        id, trade_id, realized_pnl_usd, karma_percentage, karma_amount_usd,
+                        node_id, signature, settled, batch_id, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, datetime('now'))
+                    """,
+                    (
+                        intent_id,
+                        str(trade_id),
+                        pnl,
+                        pct,
+                        amount,
+                        self._identity.node_id,
+                        sig_b64,
+                    ),
+                )
+
+            # Emit an event as well (append-only memory)
+            self._db.append_event(
+                event_type=EventType.KARMA_INTENT_V1,
+                payload={
+                    "trade_id": str(trade_id),
+                    "realized_pnl_usd": pnl,
+                    "karma_percentage": pct,
+                    "karma_amount_usd": amount,
+                    "node_id": self._identity.node_id,
+                    "signature_b64": sig_b64,
+                    "intent_id": intent_id,
+                },
+                dedupe_key=f"karma.intent:{intent_id}",
+                source="karma",
+            )
+
+            return KarmaIntent(
+                id=intent_id,
+                trade_id=str(trade_id),
+                realized_pnl_usd=pnl,
+                karma_percentage=pct,
+                karma_amount_usd=amount,
+                node_id=self._identity.node_id,
+                signature_b64=sig_b64,
+                created_at=created_at,
+            )
+        except Exception:
+            # Non-blocking guarantee: never break execution for karma.
+            return None
+
+    def get_pending_intents(self) -> list[KarmaIntent]:
+        rows = self._db.conn.execute(
+            """
+            SELECT id, trade_id, realized_pnl_usd, karma_percentage, karma_amount_usd,
+                   node_id, signature, created_at
+            FROM karma_intents
+            WHERE settled = 0
+            ORDER BY created_at ASC
+            """
+        ).fetchall()
+        out: list[KarmaIntent] = []
+        for r in rows:
+            out.append(
+                KarmaIntent(
+                    id=str(r[0]),
+                    trade_id=str(r[1]),
+                    realized_pnl_usd=float(r[2]),
+                    karma_percentage=float(r[3]),
+                    karma_amount_usd=float(r[4]),
+                    node_id=str(r[5]),
+                    signature_b64=str(r[6]) if r[6] is not None else "",
+                    created_at=str(r[7]) if r[7] is not None else "",
+                )
+            )
+        return out
+
+    def settle(self, *, intent_ids: list[str], tx_hash: str | None = None) -> KarmaReceipt | None:
+        """Batch-settle intents.
+
+        This records a local receipt; it does not actually transfer funds.
+        (On-chain settlement is a future adapter / operator action.)
+
+        Returns a receipt if settlement recorded, else None.
+        """
+
+        try:
+            if not intent_ids:
+                return None
+            if not self.enabled:
+                return None
+            destination = str(self._config.karma.treasury_address)
+            if not destination:
+                return None
+
+            # Load intents
+            q_marks = ",".join(["?"] * len(intent_ids))
+            rows = self._db.conn.execute(
+                f"""
+                SELECT id, karma_amount_usd
+                FROM karma_intents
+                WHERE id IN ({q_marks}) AND settled = 0
+                """,
+                tuple(intent_ids),
+            ).fetchall()
+
+            if not rows:
+                return None
+
+            settled_ids = [str(r[0]) for r in rows]
+            total = sum(float(r[1]) for r in rows)
+
+            receipt_id = str(uuid.uuid4())
+            created_at = _utc_now_iso(self._now_fn)
+            status = "pending" if tx_hash is None else "submitted"
+
+            receipt_payload = {
+                "id": receipt_id,
+                "intent_ids": settled_ids,
+                "total_usd": total,
+                "destination_wallet": destination,
+                "tx_hash": tx_hash,
+                "status": status,
+                "node_id": self._identity.node_id,
+                "created_at": created_at,
+            }
+            sig_b64 = _sign_payload(self._identity, receipt_payload)
+
+            with self._db.conn:
+                self._db.conn.execute(
+                    """
+                    INSERT INTO karma_settlements (
+                        id, intent_ids, total_usd, destination_wallet, tx_hash, status, signature, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                    """,
+                    (
+                        receipt_id,
+                        json.dumps(settled_ids, sort_keys=True),
+                        total,
+                        destination,
+                        tx_hash,
+                        status,
+                        sig_b64,
+                    ),
+                )
+                self._db.conn.execute(
+                    f"""UPDATE karma_intents SET settled = 1, batch_id = ? WHERE id IN ({q_marks})""",
+                    (receipt_id, *settled_ids),
+                )
+
+            self._db.append_event(
+                event_type=EventType.KARMA_SETTLEMENT_V1,
+                payload={
+                    "receipt_id": receipt_id,
+                    "intent_ids": settled_ids,
+                    "total_usd": total,
+                    "destination_wallet": destination,
+                    "tx_hash": tx_hash,
+                    "status": status,
+                    "signature_b64": sig_b64,
+                },
+                dedupe_key=f"karma.settlement:{receipt_id}",
+                source="karma",
+            )
+            self._db.append_event(
+                event_type=EventType.KARMA_RECEIPT_V1,
+                payload={
+                    "receipt_id": receipt_id,
+                    "intent_ids": settled_ids,
+                    "total_usd": total,
+                    "destination_wallet": destination,
+                    "tx_hash": tx_hash,
+                    "status": status,
+                    "signature_b64": sig_b64,
+                },
+                dedupe_key=f"karma.receipt:{receipt_id}",
+                source="karma",
+            )
+
+            return KarmaReceipt(
+                id=receipt_id,
+                intent_ids=settled_ids,
+                total_usd=total,
+                destination_wallet=destination,
+                tx_hash=tx_hash,
+                status=status,
+                signature_b64=sig_b64,
+                created_at=created_at,
+            )
+        except Exception:
+            return None
+
+    def get_receipts(self) -> list[KarmaReceipt]:
+        rows = self._db.conn.execute(
+            """
+            SELECT id, intent_ids, total_usd, destination_wallet, tx_hash, status, signature, created_at
+            FROM karma_settlements
+            ORDER BY created_at DESC
+            """
+        ).fetchall()
+
+        out: list[KarmaReceipt] = []
+        for r in rows:
+            intent_ids = json.loads(str(r[1])) if r[1] is not None else []
+            out.append(
+                KarmaReceipt(
+                    id=str(r[0]),
+                    intent_ids=[str(x) for x in intent_ids],
+                    total_usd=float(r[2]),
+                    destination_wallet=str(r[3]),
+                    tx_hash=str(r[4]) if r[4] is not None else None,
+                    status=str(r[5]),
+                    signature_b64=str(r[6]) if r[6] is not None else "",
+                    created_at=str(r[7]) if r[7] is not None else "",
+                )
+            )
+        return out

--- a/tests/integration/test_execution_e2e.py
+++ b/tests/integration/test_execution_e2e.py
@@ -1,0 +1,77 @@
+"""End-to-end execution pipeline: intent → preflight → paper fill → karma intent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from engine.brain.kill_switch import KillSwitch
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.types import TradeIntent
+from engine.execution.karma import KarmaEngine
+from engine.execution.oms import OMS, default_sizer_from_config
+from engine.execution.paper import PaperBroker
+from engine.execution.position_sizer import CorrelationAwareSizer
+from engine.core.policy import TradingPolicyEngine
+from engine.execution.preflight import Preflight
+from engine.security.identity import generate_node_identity
+
+
+def test_execution_pipeline_intent_to_karma(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    base = Config.from_repo_defaults(repo_root=repo_root)
+    cfg = base.model_copy(
+        update={
+            "data_dir": tmp_path / "data",
+            "execution": base.execution.model_copy(update={"mode": "paper"}),
+            "karma": base.karma.model_copy(update={"treasury_address": "0xTEST"}),
+        }
+    )
+
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+    ks = KillSwitch(config=cfg, db=db)
+    from engine.core.policy import TradingPolicy
+    policy_engine = TradingPolicyEngine(policy=TradingPolicy())
+
+    paper = PaperBroker(db=db)
+    preflight = Preflight(policy=policy_engine, kill_switch=ks)
+    sizer = default_sizer_from_config(cfg)
+    karma = KarmaEngine(config=cfg, db=db, identity=ident)
+    oms = OMS(config=cfg, db=db, preflight=preflight, sizer=sizer, paper_broker=paper)
+
+    intent = TradeIntent(
+        symbol="BTC",
+        direction="long",
+        size_pct=0.05,
+        leverage=1.0,
+        conviction_score=8.0,
+        regime="risk_on",
+        rationale="test",
+    )
+
+    res = oms.submit(
+        intent=intent,
+        mid_price=100.0,
+        equity_usd=10000.0,
+    )
+
+    assert res.status == "filled"
+    assert res.position_id is not None
+
+    # Simulate a profitable close and record karma
+    realized_pnl = 50.0
+    karma_intent = karma.record_intent(
+        trade_id=res.order_id or "test",
+        realized_pnl_usd=realized_pnl,
+    )
+
+    assert karma_intent is not None
+    assert karma_intent.karma_amount_usd > 0
+
+    pending = karma.get_pending_intents()
+    assert len(pending) >= 1
+
+    # Losing trade → no karma
+    no_karma = karma.record_intent(trade_id="loser", realized_pnl_usd=-20.0)
+    assert no_karma is None

--- a/tests/unit/test_hyperliquid.py
+++ b/tests/unit/test_hyperliquid.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from engine.execution.hyperliquid import HyperliquidAdapter, InMemoryHyperliquidApi
+
+
+def test_place_and_fill_and_cancel() -> None:
+    api = InMemoryHyperliquidApi()
+    hl = HyperliquidAdapter(api=api)
+
+    o = hl.place(symbol="HYPE", side="buy", size=1.25, price=10.0)
+    assert o.status == "open"
+
+    filled = api.fill_order(order_id=o.id, fill_price=10.1)
+    assert filled.status == "filled"
+    assert filled.filled_price == 10.1
+
+    # cannot cancel filled
+    assert hl.cancel(order_id=o.id) is False
+
+    # place another order and cancel
+    o2 = hl.place(symbol="HYPE", side="sell", size=0.5, price=10.2)
+    assert hl.cancel(order_id=o2.id) is True
+    assert hl.status(order_id=o2.id) is not None
+    assert hl.status(order_id=o2.id).status == "canceled"

--- a/tests/unit/test_karma.py
+++ b/tests/unit/test_karma.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.execution.karma import KarmaEngine
+from engine.security.identity import generate_node_identity
+
+
+def _cfg(tmp_path: Path) -> Config:
+    c = Config.from_repo_defaults(repo_root=Path(__file__).resolve().parents[2])
+    karma = c.karma.model_copy(
+        update={
+            "enabled": True,
+            "percentage": 0.005,
+            "settlement_mode": "manual",
+            "threshold_usd": 50.0,
+            "treasury_address": "0xPUC_TREASURY_PLACEHOLDER",
+        }
+    )
+    return c.model_copy(update={"data_dir": tmp_path / "data", "karma": karma})
+
+
+def test_intent_on_profit(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+
+    k = KarmaEngine(config=cfg, db=db, identity=ident)
+    intent = k.record_intent(trade_id="t1", realized_pnl_usd=100.0)
+
+    assert intent is not None
+    assert intent.trade_id == "t1"
+    assert intent.realized_pnl_usd == 100.0
+    assert abs(intent.karma_amount_usd - 0.5) < 1e-9
+
+    # signature is valid base64
+    base64.b64decode(intent.signature_b64)
+
+
+def test_no_intent_on_loss(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+
+    k = KarmaEngine(config=cfg, db=db, identity=ident)
+
+    assert k.record_intent(trade_id="t2", realized_pnl_usd=-10.0) is None
+    assert k.record_intent(trade_id="t2", realized_pnl_usd=0.0) is None
+
+
+def test_percentage_calc(tmp_path: Path) -> None:
+    base = _cfg(tmp_path)
+    cfg = base.model_copy(update={"karma": base.karma.model_copy(update={"percentage": 0.01, "treasury_address": "0xT"})})
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+
+    k = KarmaEngine(config=cfg, db=db, identity=ident)
+    intent = k.record_intent(trade_id="t3", realized_pnl_usd=250.0)
+    assert intent is not None
+    assert abs(intent.karma_amount_usd - 2.5) < 1e-9
+
+
+def test_signing_round_trip(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+
+    k = KarmaEngine(config=cfg, db=db, identity=ident)
+    intent = k.record_intent(trade_id="t4", realized_pnl_usd=10.0)
+    assert intent is not None
+
+    # Verify signature against canonical json payload
+    payload = {
+        "id": intent.id,
+        "trade_id": intent.trade_id,
+        "realized_pnl_usd": intent.realized_pnl_usd,
+        "karma_percentage": intent.karma_percentage,
+        "karma_amount_usd": intent.karma_amount_usd,
+        "node_id": intent.node_id,
+        "created_at": intent.created_at,
+    }
+    # Canonical json lives in engine.core.events
+    from engine.core.events import canonical_json
+
+    msg = canonical_json(payload).encode("utf-8")
+    sig = base64.b64decode(intent.signature_b64)
+    assert ident.verify(sig, msg) is True
+
+
+def test_non_blocking_on_db_failure(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+
+    k = KarmaEngine(config=cfg, db=db, identity=ident)
+
+    # Break the table to force an exception
+    with db.conn:
+        db.conn.execute("DROP TABLE karma_intents")
+
+    # Must not raise
+    assert k.record_intent(trade_id="t5", realized_pnl_usd=100.0) is None
+
+
+def test_settlement_batch_and_receipt(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    db = Database(tmp_path / "db.sqlite")
+    ident = generate_node_identity()
+
+    k = KarmaEngine(config=cfg, db=db, identity=ident)
+    i1 = k.record_intent(trade_id="a", realized_pnl_usd=100.0)
+    i2 = k.record_intent(trade_id="b", realized_pnl_usd=200.0)
+    assert i1 is not None and i2 is not None
+
+    pending = k.get_pending_intents()
+    assert {p.id for p in pending} == {i1.id, i2.id}
+
+    receipt = k.settle(intent_ids=[i1.id, i2.id], tx_hash=None)
+    assert receipt is not None
+    assert set(receipt.intent_ids) == {i1.id, i2.id}
+    assert abs(receipt.total_usd - (i1.karma_amount_usd + i2.karma_amount_usd)) < 1e-9
+
+    # Pending should now be empty
+    assert k.get_pending_intents() == []
+
+    receipts = k.get_receipts()
+    assert len(receipts) == 1
+    assert receipts[0].id == receipt.id


### PR DESCRIPTION
## Sprint 2B — Karma + Hyperliquid

Supersedes #22 (had merge conflicts with 2A).

### New files
- `engine/execution/karma.py` — Karma engine (0.5% on profit, signed intents, non-blocking, settlement batching)
- `engine/execution/hyperliquid.py` — Hyperliquid exchange adapter (place/cancel/check orders)

### Tests
- `tests/unit/test_karma.py` — 6 tests (intent on profit, no intent on loss, percentage calc, signing, non-blocking, settlement)
- `tests/unit/test_hyperliquid.py` — 1 test (mock exchange: place, fill, cancel)
- `tests/integration/test_execution_e2e.py` — Full pipeline: intent → preflight → paper fill → karma intent

**8/8 tests passing.** Reconciled with Sprint 2A APIs.