### PR TITLE
fix(ci): green tests (setup + producer registry)

### DIFF
--- a/engine/security/keystore.py
+++ b/engine/security/keystore.py
@@ -227,7 +227,15 @@ class Keystore:
     Lookup order is Tier 0 → Tier 1 → Tier 2 by default (env overrides are convenient).
 
     Note: Tier 0 is read-only by design.
+
+    Compatibility: CLI uses `Keystore.default()`, `set()`, and `describe()`.
     """
+
+    @classmethod
+    def default(cls) -> "Keystore":
+        """Default keystore constructor used by the CLI."""
+
+        return cls(enable_keyring=True)
 
     def __init__(
         self,
@@ -268,6 +276,25 @@ class Keystore:
                 os.chmod(self._metadata_path, 0o600)
             except OSError:
                 pass
+
+    def set(self, name: str, value: str, tier: KeystoreTier = KeystoreTier.ENCRYPTED_FILE) -> None:
+        """Compatibility wrapper: store a key."""
+
+        self.store_key(name, value, tier)
+
+    def get(self, name: str) -> str:
+        """Compatibility wrapper: fetch a key."""
+
+        return self.get_key(name)
+
+    def describe(self) -> str:
+        """Human-readable keystore status for CLI output."""
+
+        h = self.key_health()
+        parts = [f"overall={h.get('overall')}"]
+        parts.append(f"tier1={'on' if h.get('tier1_configured') else 'off'}")
+        parts.append(f"tier2={'on' if h.get('tier2_available') else 'off'}")
+        return "Keystore(" + ", ".join(parts) + ")"
 
     def store_key(self, name: str, value: str, tier: KeystoreTier) -> None:
         if tier == KeystoreTier.ENV:


### PR DESCRIPTION
Fix CI failures:

- Restore ensure_identity + identity_status; default identity path uses legacy ~/.b1e55ed/identity.key
- Allow non-interactive setup without master password (plaintext identity fallback for tests; warning included)
- Add Keystore.default()/set()/get()/describe() wrappers used by CLI
- Prevent producer registry auto-discovery from polluting unit tests when registry already has entries

Result: `uv run pytest -q` passes (150/150).