### PR TITLE
O2: Webhooks (subscriptions + dispatcher + CLI)

### DIFF
--- a/engine/core/webhooks.py
+++ b/engine/core/webhooks.py
@@ -1,0 +1,137 @@
+"""engine.core.webhooks
+
+Persistent outbound webhook subscriptions + dispatcher.
+
+Design goals:
+- stdlib-only HTTP (urllib.request)
+- best-effort delivery (never block/abort event persistence)
+- simple glob matching on event type strings (fnmatch)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from typing import Any
+
+from engine.core.models import Event
+
+
+@dataclass(frozen=True)
+class WebhookSubscription:
+    id: int
+    url: str
+    event_globs: str
+    enabled: bool
+    created_at: str
+
+
+def _split_event_globs(event_globs: str) -> list[str]:
+    # Stored as a comma-separated list.
+    parts = [p.strip() for p in event_globs.split(",")]
+    return [p for p in parts if p]
+
+
+def subscription_matches(sub: WebhookSubscription, *, event_type: str) -> bool:
+    return any(fnmatchcase(event_type, g) for g in _split_event_globs(sub.event_globs))
+
+
+def list_webhook_subscriptions(db: Any) -> list[WebhookSubscription]:
+    rows = db.conn.execute("SELECT id, url, event_globs, enabled, created_at FROM webhook_subscriptions ORDER BY id ASC").fetchall()
+    out: list[WebhookSubscription] = []
+    for r in rows:
+        out.append(
+            WebhookSubscription(
+                id=int(r[0]),
+                url=str(r[1]),
+                event_globs=str(r[2]),
+                enabled=bool(int(r[3])),
+                created_at=str(r[4]),
+            )
+        )
+    return out
+
+
+def add_webhook_subscription(db: Any, *, url: str, event_globs: str, enabled: bool = True) -> int:
+    with db.conn:
+        cur = db.conn.execute(
+            "INSERT INTO webhook_subscriptions (url, event_globs, enabled) VALUES (?, ?, ?)",
+            (url, event_globs, 1 if enabled else 0),
+        )
+    return int(cur.lastrowid)
+
+
+def remove_webhook_subscription(db: Any, *, sub_id: int) -> bool:
+    with db.conn:
+        cur = db.conn.execute("DELETE FROM webhook_subscriptions WHERE id = ?", (int(sub_id),))
+    return int(cur.rowcount) > 0
+
+
+def _post_json(url: str, payload: dict[str, Any], *, timeout_s: float) -> None:
+    body = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json", "User-Agent": "b1e55ed-webhooks/1"},
+    )
+    # urlopen timeout covers connect + read.
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310
+        _ = resp.read()  # drain
+
+
+def dispatch_event_webhooks(db: Any, event: Event) -> None:
+    """Dispatch webhooks for a committed event.
+
+    Best-effort semantics:
+    - does nothing if no enabled subscriptions match
+    - for each subscription, tries up to 3 times with exponential backoff
+    """
+
+    event_type = str(event.type)
+
+    rows = db.conn.execute("SELECT id, url, event_globs, enabled, created_at FROM webhook_subscriptions WHERE enabled = 1").fetchall()
+
+    if not rows:
+        return
+
+    payload = {
+        "event": {
+            "id": event.id,
+            "type": event_type,
+            "ts": event.ts.isoformat(),
+            "observed_at": event.observed_at.isoformat() if event.observed_at else None,
+            "source": event.source,
+            "trace_id": event.trace_id,
+            "schema_version": event.schema_version,
+            "dedupe_key": event.dedupe_key,
+            "payload": event.payload,
+            "prev_hash": event.prev_hash,
+            "hash": event.hash,
+        }
+    }
+
+    for r in rows:
+        sub = WebhookSubscription(
+            id=int(r[0]),
+            url=str(r[1]),
+            event_globs=str(r[2]),
+            enabled=bool(int(r[3])),
+            created_at=str(r[4]),
+        )
+        if not subscription_matches(sub, event_type=event_type):
+            continue
+
+        backoff_s = 0.5
+        for attempt in range(1, 4):
+            try:
+                _post_json(sub.url, payload, timeout_s=3.0)
+                break
+            except (urllib.error.URLError, TimeoutError, ValueError):
+                if attempt < 3:
+                    time.sleep(backoff_s)
+                    backoff_s *= 2

--- a/tests/integration/test_webhooks_dispatch.py
+++ b/tests/integration/test_webhooks_dispatch.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.webhooks import add_webhook_subscription
+
+
+def test_append_event_triggers_webhook_dispatch(temp_dir, monkeypatch) -> None:
+    db = Database(temp_dir / "brain.db")
+
+    add_webhook_subscription(db, url="http://example/hook", event_globs="signal.price_alert.*")
+
+    sent: list[dict[str, object]] = []
+
+    def fake_post_json(url: str, payload: dict[str, object], *, timeout_s: float) -> None:
+        sent.append({"url": url, "payload": payload, "timeout_s": timeout_s})
+
+    monkeypatch.setattr("engine.core.webhooks._post_json", fake_post_json)
+
+    db.append_event(
+        event_type=EventType.SIGNAL_PRICE_ALERT_V1,
+        payload={"symbol": "BTC", "price": 123.45, "rule": "test"},
+        ts=datetime.now(tz=UTC),
+    )
+
+    assert len(sent) == 1
+    assert sent[0]["url"] == "http://example/hook"
+    assert sent[0]["payload"]["event"]["type"] == str(EventType.SIGNAL_PRICE_ALERT_V1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -35,6 +35,7 @@ def test_cli_help_includes_subcommands(capsys: pytest.CaptureFixture[str]) -> No
     assert "signal" in out
     assert "alerts" in out
     assert "positions" in out
+    assert "webhooks" in out
     assert "kill-switch" in out
     assert "health" in out
     assert "api" in out
@@ -68,6 +69,7 @@ def test_cli_unknown_command_errors(capsys: pytest.CaptureFixture[str]) -> None:
         "signal",
         "alerts",
         "positions",
+        "webhooks",
         "kill-switch",
         "health",
         "api",
@@ -145,3 +147,24 @@ def test_cli_health_returns_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert "ok" in payload
     assert "config" in payload
     assert "db" in payload
+
+
+def test_cli_webhooks_crud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    repo_root = _scaffold_repo(tmp_path)
+    monkeypatch.chdir(repo_root)
+
+    rc = main(["webhooks", "add", "http://example/hook", "--events", "signal.*"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "ok"
+    sub_id = int(out["id"])
+
+    rc = main(["webhooks", "list", "--json"])
+    assert rc == 0
+    subs = json.loads(capsys.readouterr().out)
+    assert any(int(s["id"]) == sub_id for s in subs)
+
+    rc = main(["webhooks", "remove", str(sub_id)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "ok"

--- a/tests/unit/test_webhooks.py
+++ b/tests/unit/test_webhooks.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import urllib.error
+from datetime import UTC, datetime
+
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.models import Event, compute_event_hash
+from engine.core.webhooks import (
+    WebhookSubscription,
+    add_webhook_subscription,
+    dispatch_event_webhooks,
+    subscription_matches,
+)
+
+
+def _mk_event(event_type: EventType) -> Event:
+    now = datetime.now(tz=UTC)
+    payload = {"x": 1}
+    h = compute_event_hash(
+        prev_hash=None,
+        event_type=event_type,
+        payload=payload,
+        ts=now,
+        source="test",
+        trace_id=None,
+        schema_version="v1",
+        dedupe_key=None,
+        event_id="e1",
+    )
+    return Event(id="e1", type=event_type, ts=now, payload=payload, source="test", hash=h)
+
+
+def test_subscription_matches_globs() -> None:
+    sub = WebhookSubscription(
+        id=1,
+        url="http://example",
+        event_globs="signal.* , system.*",
+        enabled=True,
+        created_at="",
+    )
+    assert subscription_matches(sub, event_type="signal.ta.v1")
+    assert subscription_matches(sub, event_type="system.kill_switch.v1")
+    assert not subscription_matches(sub, event_type="brain.cycle.v1")
+
+
+def test_dispatch_retries_with_backoff(monkeypatch, tmp_path) -> None:
+    db = Database(tmp_path / "brain.db")
+    add_webhook_subscription(db, url="http://example/hook", event_globs="signal.*")
+
+    calls: list[float] = []
+    sleeps: list[float] = []
+
+    def fake_sleep(s: float) -> None:
+        sleeps.append(float(s))
+
+    def fake_urlopen(req, timeout: float = 0.0):  # noqa: ANN001
+        calls.append(float(timeout))
+        if len(calls) < 3:
+            raise urllib.error.URLError("boom")
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self) -> bytes:
+                return b"ok"
+
+        return _Resp()
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    dispatch_event_webhooks(db, _mk_event(EventType.SIGNAL_TA_V1))
+
+    assert len(calls) == 3
+    assert sleeps == [0.5, 1.0]
+
+
+def test_dispatch_skips_nonmatching(monkeypatch, tmp_path) -> None:
+    db = Database(tmp_path / "brain.db")
+    add_webhook_subscription(db, url="http://example/hook", event_globs="system.*")
+
+    def fake_urlopen(req, timeout: float = 0.0):  # noqa: ANN001
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    dispatch_event_webhooks(db, _mk_event(EventType.SIGNAL_TA_V1))


### PR DESCRIPTION
Adds persistent webhook subscriptions in brain.db and a best-effort dispatcher fired after event commit. Includes CLI CRUD: b1e55ed webhooks add|list|remove.

- Table: webhook_subscriptions (id,url,event_globs,enabled,created_at)
- Dispatch uses fnmatch globs, stdlib urllib.request
- Retries w/ exponential backoff (3 attempts)
- Unit + integration tests