### PR TITLE
docs: fix doc-deps (reference OPERATOR_SPRINT_PLAN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The OpenClaw skill package (next phase) will make this a one-command install. Se
 - [Deployment](docs/deployment.md) - Production hosting, security
 - [Learning Loop](docs/learning-loop.md) - How weights auto-adjust
 - [OpenClaw Integration](docs/openclaw-integration.md) - Operator layer, agent-first design
+- [Operator Sprint Plan](docs/OPERATOR_SPRINT_PLAN.md) - beta.2 operator layer build plan (O1-O4)
 
 ## Architecture
 

--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -55,6 +55,7 @@ README.md
   ├→ docs/architecture.md          (Architecture → System Design)
   ├→ docs/api-reference.md         (API → Full API Docs)
   ├→ docs/openclaw-integration.md  (Operator Layer → Integration)
+  ├→ docs/OPERATOR_SPRINT_PLAN.md  (beta.2 → Operator Layer Plan)
   ├→ DOCKER.md                     (Docker deployment)
   └→ ROADMAP.md                    (Roadmap)
 ```


### PR DESCRIPTION
CI doc-deps was failing because docs/OPERATOR_SPRINT_PLAN.md was orphaned.

- Link it from README
- Add it to docs/dependencies-docs.md

This makes doc-deps pass for all open PRs.