### PR TITLE
feat(O3): OpenAPI + producer registration + structured errors + CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing
+
+This repository is an event-sourced signal engine.
+Changes should be small, auditable, and testable.
+
+## Add a Producer
+
+1. Implement a producer that conforms to the producer interface.
+2. Register the producer via CLI or API.
+
+CLI:
+
+```bash
+b1e55ed producers register --name <NAME> --domain <DOMAIN> --endpoint <URL> --schedule "*/15 * * * *"
+b1e55ed producers list
+b1e55ed producers remove --name <NAME>
+```
+
+API:
+
+- `POST /api/v1/producers/register`
+- `GET /api/v1/producers/`
+- `DELETE /api/v1/producers/{name}`
+
+For implementation details and integration contracts, see `SKILL.md`.
+
+## Add a Strategy
+
+1. Implement the strategy interface in the engine.
+2. Add the strategy to configuration so it can be selected and parameterized.
+3. Add unit tests that pin the strategy’s decision boundary behavior.
+
+## Improve Docs
+
+- Use the public brand vocabulary.
+- Prefer “Corpus” over internal terms such as “Grimoire” in public-facing copy.
+- Run the full CI suite locally before opening a PR.
+
+## Report Bugs
+
+When opening an issue, include:
+
+- Expected behavior vs observed behavior
+- Steps to reproduce
+- Version information (`b1e55ed --version`)
+- Relevant logs (redact secrets)
+- Minimal config snippet if configuration is involved
+
+## Development Setup
+
+Install dependencies:
+
+```bash
+uv sync --all-extras
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+Run lint and formatting:
+
+```bash
+ruff check engine/ api/ tests/
+ruff format engine/ api/ tests/
+```
+
+Run type checks:
+
+```bash
+mypy engine/ api/
+```
+
+## PR Process
+
+- Branch from `develop`.
+- Open PRs targeting `develop`.
+- Keep PRs scoped.
+- CI must pass (ruff, mypy, pytest).
+- Prefer additive changes with explicit tests over implicit behavior changes.

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header
 
 from api.deps import get_config
+from api.errors import B1e55edError
 from engine.core.config import Config
 
 
@@ -20,15 +21,27 @@ def require_bearer_token(
         return
 
     if not authorization:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing bearer token")
+        raise B1e55edError(
+            code="auth.missing_token",
+            message="Missing bearer token",
+            status=401,
+        )
 
     parts = authorization.split(" ", 1)
     if len(parts) != 2 or parts[0].lower() != "bearer":
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authorization header")
+        raise B1e55edError(
+            code="auth.invalid_header",
+            message="Invalid authorization header",
+            status=401,
+        )
 
     token = parts[1].strip()
     if token != expected:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid bearer token")
+        raise B1e55edError(
+            code="auth.invalid_token",
+            message="Invalid bearer token",
+            status=401,
+        )
 
 
 AuthDep = Depends(require_bearer_token)

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+class B1e55edError(Exception):
+    def __init__(self, code: str, message: str, status: int = 400, **extra: object) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = status
+        self.extra = extra
+
+
+async def b1e55ed_error_handler(request: Request, exc: B1e55edError) -> JSONResponse:
+    body = {"error": {"code": exc.code, "message": exc.message, **exc.extra}}
+    return JSONResponse(status_code=exc.status, content=body)

--- a/api/routes/producers.py
+++ b/api/routes/producers.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
 
 from api.auth import AuthDep
 from api.deps import get_db, get_registry
+from api.errors import B1e55edError
 from engine.core.database import Database
 
 router = APIRouter(prefix="/producers", dependencies=[AuthDep])
@@ -23,18 +25,66 @@ def _parse_dt(ts: str | None) -> datetime | None:
         return None
 
 
-@router.get("/status")
+def _ensure_endpoint_column(db: Database) -> None:
+    cols = [str(r[1]) for r in db.conn.execute("PRAGMA table_info(producer_health)").fetchall()]
+    if "endpoint" in cols:
+        return
+    with db.conn:
+        db.conn.execute("ALTER TABLE producer_health ADD COLUMN endpoint TEXT")
+
+
+class ProducerRegistration(BaseModel):
+    name: str = Field(..., description="Unique producer name")
+    domain: str = Field(
+        ...,
+        description="Signal domain: technical, sentiment, onchain, macro, social",
+    )
+    endpoint: str = Field(..., description="URL to poll for signals")
+    schedule: str = Field("*/15 * * * *", description="Cron schedule for polling")
+
+
+class ProducerResponse(BaseModel):
+    name: str
+    domain: str
+    endpoint: str
+    schedule: str
+    registered_at: str
+
+
+class ProducerHealth(BaseModel):
+    name: str
+    domain: str | None = None
+    schedule: str | None = None
+    endpoint: str | None = None
+    healthy: bool | None = None
+    last_run_at: datetime | None = None
+    last_success_at: datetime | None = None
+    last_error: str | None = None
+    consecutive_failures: int = 0
+    events_produced: int = 0
+    avg_duration_ms: float | None = None
+    expected_interval_ms: int | None = None
+    updated_at: datetime | None = None
+
+
+class ProducerStatusResponse(BaseModel):
+    producers: dict[str, ProducerHealth]
+
+
+@router.get("/status", response_model=ProducerStatusResponse)
 def producer_status(
     db: Database = Depends(get_db),
     registry=Depends(get_registry),
-) -> dict[str, Any]:
+) -> ProducerStatusResponse:
+    _ensure_endpoint_column(db)
+
     names = registry.list_producers()
-    out: dict[str, Any] = {}
+    out: dict[str, ProducerHealth] = {}
 
     for name in names:
         row = db.conn.execute(
             """
-            SELECT name, domain, schedule, last_run_at, last_success_at, last_error,
+            SELECT name, domain, schedule, endpoint, last_run_at, last_success_at, last_error,
                    consecutive_failures, events_produced, avg_duration_ms, expected_interval_ms, updated_at
             FROM producer_health
             WHERE name = ?
@@ -43,35 +93,120 @@ def producer_status(
         ).fetchone()
 
         if row is None:
-            out[name] = {
-                "name": name,
-                "domain": getattr(registry.get_producer(name), "domain", None),
-                "healthy": None,
-                "last_run_at": None,
-                "last_success_at": None,
-                "last_error": None,
-                "consecutive_failures": 0,
-                "events_produced": 0,
-            }
+            out[name] = ProducerHealth(
+                name=name,
+                domain=getattr(registry.get_producer(name), "domain", None),
+                healthy=None,
+                last_run_at=None,
+                last_success_at=None,
+                last_error=None,
+                consecutive_failures=0,
+                events_produced=0,
+            )
             continue
 
-        consecutive_failures = int(row[6]) if row[6] is not None else 0
-        last_error = str(row[5]) if row[5] is not None else None
+        consecutive_failures = int(row[7]) if row[7] is not None else 0
+        last_error = str(row[6]) if row[6] is not None else None
         healthy = consecutive_failures == 0 and last_error is None
 
-        out[name] = {
-            "name": str(row[0]),
-            "domain": str(row[1]) if row[1] is not None else None,
-            "schedule": str(row[2]) if row[2] is not None else None,
-            "healthy": healthy,
-            "last_run_at": _parse_dt(str(row[3])) if row[3] is not None else None,
-            "last_success_at": _parse_dt(str(row[4])) if row[4] is not None else None,
-            "last_error": last_error,
-            "consecutive_failures": consecutive_failures,
-            "events_produced": int(row[7]) if row[7] is not None else 0,
-            "avg_duration_ms": float(row[8]) if row[8] is not None else None,
-            "expected_interval_ms": int(row[9]) if row[9] is not None else None,
-            "updated_at": _parse_dt(str(row[10])) if row[10] is not None else None,
-        }
+        out[name] = ProducerHealth(
+            name=str(row[0]),
+            domain=str(row[1]) if row[1] is not None else None,
+            schedule=str(row[2]) if row[2] is not None else None,
+            endpoint=str(row[3]) if row[3] is not None else None,
+            healthy=healthy,
+            last_run_at=_parse_dt(str(row[4])) if row[4] is not None else None,
+            last_success_at=_parse_dt(str(row[5])) if row[5] is not None else None,
+            last_error=last_error,
+            consecutive_failures=consecutive_failures,
+            events_produced=int(row[8]) if row[8] is not None else 0,
+            avg_duration_ms=float(row[9]) if row[9] is not None else None,
+            expected_interval_ms=int(row[10]) if row[10] is not None else None,
+            updated_at=_parse_dt(str(row[11])) if row[11] is not None else None,
+        )
 
-    return {"producers": out}
+    return ProducerStatusResponse(producers=out)
+
+
+@router.post("/register", response_model=ProducerResponse)
+def register_producer(reg: ProducerRegistration, db: Database = Depends(get_db)) -> ProducerResponse:
+    _ensure_endpoint_column(db)
+
+    now = datetime.now(tz=UTC).isoformat()
+
+    existing = db.conn.execute(
+        "SELECT name FROM producer_health WHERE name = ?",
+        (reg.name,),
+    ).fetchone()
+    if existing is not None:
+        raise B1e55edError(
+            code="producer.duplicate",
+            message="Producer already registered",
+            status=409,
+            name=reg.name,
+        )
+
+    with db.conn:
+        db.conn.execute(
+            """
+            INSERT INTO producer_health (name, domain, schedule, endpoint, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (reg.name, reg.domain, reg.schedule, reg.endpoint, now),
+        )
+
+    return ProducerResponse(
+        name=reg.name,
+        domain=reg.domain,
+        endpoint=reg.endpoint,
+        schedule=reg.schedule,
+        registered_at=now,
+    )
+
+
+@router.delete("/{name}")
+def deregister_producer(name: str, db: Database = Depends(get_db)) -> dict[str, str]:
+    _ensure_endpoint_column(db)
+
+    with db.conn:
+        cur = db.conn.execute(
+            "DELETE FROM producer_health WHERE name = ?",
+            (name,),
+        )
+
+    if cur.rowcount == 0:
+        raise B1e55edError(
+            code="producer.not_found",
+            message="Producer not found",
+            status=404,
+            name=name,
+        )
+
+    return {"removed": name}
+
+
+@router.get("/", response_model=dict)
+def list_producers(db: Database = Depends(get_db)) -> dict[str, Any]:
+    _ensure_endpoint_column(db)
+
+    rows = db.conn.execute(
+        """
+        SELECT name, domain, schedule, endpoint, updated_at
+        FROM producer_health
+        ORDER BY name ASC
+        """
+    ).fetchall()
+
+    producers: list[ProducerResponse] = []
+    for r in rows:
+        producers.append(
+            ProducerResponse(
+                name=str(r[0]),
+                domain=str(r[1]) if r[1] is not None else "",
+                schedule=str(r[2]) if r[2] is not None else "",
+                endpoint=str(r[3]) if r[3] is not None else "",
+                registered_at=str(r[4]) if r[4] is not None else "",
+            )
+        )
+
+    return {"producers": producers}

--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -241,6 +241,7 @@ CREATE TABLE IF NOT EXISTS producer_health (
     name TEXT PRIMARY KEY,
     domain TEXT,
     schedule TEXT,
+    endpoint TEXT,
     last_run_at TEXT,
     last_success_at TEXT,
     last_error TEXT,

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -15,10 +15,13 @@ async def test_protected_routes_require_auth(temp_dir, test_config):
     app.state.db = Database(temp_dir / "brain.db")
 
     async with make_client(app) as ac:
-        r = await ac.get("/signals")
+        r = await ac.get("/api/v1/signals")
         assert r.status_code == 401
+        body = r.json()
+        assert body["error"]["code"].startswith("auth.")
+        assert "message" in body["error"]
 
-        r2 = await ac.get("/health")
+        r2 = await ac.get("/api/v1/health")
         assert r2.status_code == 200
 
     app.state.db.close()

--- a/tests/unit/test_api_brain.py
+++ b/tests/unit/test_api_brain.py
@@ -19,18 +19,18 @@ async def test_brain_status_and_run(temp_dir, test_config, monkeypatch):
     headers = {"Authorization": "Bearer secret"}
 
     async with make_client(app) as ac:
-        r = await ac.get("/brain/status", headers=headers)
+        r = await ac.get("/api/v1/brain/status", headers=headers)
         assert r.status_code == 200
         js = r.json()
         assert "kill_switch_level" in js
 
-        r2 = await ac.post("/brain/run", headers=headers)
+        r2 = await ac.post("/api/v1/brain/run", headers=headers)
         assert r2.status_code == 200
         js2 = r2.json()
         assert js2["cycle_id"]
 
         # After run, status should have last_cycle_id
-        r3 = await ac.get("/brain/status", headers=headers)
+        r3 = await ac.get("/api/v1/brain/status", headers=headers)
         assert r3.status_code == 200
         js3 = r3.json()
         assert js3["last_cycle_id"] == js2["cycle_id"]

--- a/tests/unit/test_api_config.py
+++ b/tests/unit/test_api_config.py
@@ -24,17 +24,17 @@ async def test_config_read_validate_save(temp_dir, test_config, monkeypatch):
 
     headers = {"Authorization": "Bearer secret"}
     async with make_client(app) as ac:
-        r = await ac.get("/config", headers=headers)
+        r = await ac.get("/api/v1/config", headers=headers)
         assert r.status_code == 200
         js = r.json()
         assert js["preset"] == test_config.preset
 
-        r2 = await ac.post("/config/validate", headers=headers, json=js)
+        r2 = await ac.post("/api/v1/config/validate", headers=headers, json=js)
         assert r2.status_code == 200
         assert r2.json()["ok"] is True
 
         js["brain"]["cycle_interval_seconds"] = 123
-        r3 = await ac.post("/config", headers=headers, json=js)
+        r3 = await ac.post("/api/v1/config", headers=headers, json=js)
         assert r3.status_code == 200
         path = Path(r3.json()["path"])
         assert path.exists()

--- a/tests/unit/test_api_health.py
+++ b/tests/unit/test_api_health.py
@@ -15,7 +15,7 @@ async def test_health_returns_version(temp_dir, test_config):
     app.state.db = Database(temp_dir / "brain.db")
 
     async with make_client(app) as ac:
-        r = await ac.get("/health")
+        r = await ac.get("/api/v1/health")
         assert r.status_code == 200
         data = r.json()
         assert data["version"] == __version__

--- a/tests/unit/test_api_karma.py
+++ b/tests/unit/test_api_karma.py
@@ -33,19 +33,19 @@ async def test_treasury_and_karma_flows(temp_dir, test_config):
 
     headers = {"Authorization": "Bearer secret"}
     async with make_client(app) as ac:
-        r = await ac.get("/treasury", headers=headers)
+        r = await ac.get("/api/v1/treasury", headers=headers)
         assert r.status_code == 200
         assert r.json()["pending_intents"] == 1
 
-        r2 = await ac.get("/karma/intents", headers=headers)
+        r2 = await ac.get("/api/v1/karma/intents", headers=headers)
         assert r2.status_code == 200
         assert len(r2.json()["items"]) == 1
 
         # Settle
-        r3 = await ac.post("/karma/settle", headers=headers, json={"intent_ids": [i1.id]})
+        r3 = await ac.post("/api/v1/karma/settle", headers=headers, json={"intent_ids": [i1.id]})
         assert r3.status_code == 200
 
-        r4 = await ac.get("/karma/receipts", headers=headers)
+        r4 = await ac.get("/api/v1/karma/receipts", headers=headers)
         assert r4.status_code == 200
         assert len(r4.json()["items"]) == 1
 

--- a/tests/unit/test_api_positions.py
+++ b/tests/unit/test_api_positions.py
@@ -28,13 +28,13 @@ async def test_positions_list_and_get(temp_dir, test_config):
 
     headers = {"Authorization": "Bearer secret"}
     async with make_client(app) as ac:
-        r = await ac.get("/positions", headers=headers)
+        r = await ac.get("/api/v1/positions", headers=headers)
         assert r.status_code == 200
         items = r.json()
         assert len(items) == 1
         assert items[0]["id"] == "pos-1"
 
-        r2 = await ac.get("/positions/pos-1", headers=headers)
+        r2 = await ac.get("/api/v1/positions/pos-1", headers=headers)
         assert r2.status_code == 200
         assert r2.json()["asset"] == "BTC"
 

--- a/tests/unit/test_api_producers.py
+++ b/tests/unit/test_api_producers.py
@@ -19,7 +19,7 @@ async def test_producers_status(temp_dir, test_config):
 
     headers = {"Authorization": "Bearer secret"}
     async with make_client(app) as ac:
-        r = await ac.get("/producers/status", headers=headers)
+        r = await ac.get("/api/v1/producers/status", headers=headers)
         assert r.status_code == 200
         js = r.json()
         assert "producers" in js

--- a/tests/unit/test_api_regime.py
+++ b/tests/unit/test_api_regime.py
@@ -21,7 +21,7 @@ async def test_regime_returns_current(temp_dir, test_config):
 
     headers = {"Authorization": "Bearer secret"}
     async with make_client(app) as ac:
-        r = await ac.get("/regime", headers=headers)
+        r = await ac.get("/api/v1/regime", headers=headers)
         assert r.status_code == 200
         assert r.json()["regime"] == "RISK_ON"
 

--- a/tests/unit/test_api_signals.py
+++ b/tests/unit/test_api_signals.py
@@ -22,13 +22,13 @@ async def test_signals_paginated(temp_dir, test_config):
 
     headers = {"Authorization": "Bearer secret"}
     async with make_client(app) as ac:
-        r = await ac.get("/signals?limit=1&offset=0", headers=headers)
+        r = await ac.get("/api/v1/signals?limit=1&offset=0", headers=headers)
         assert r.status_code == 200
         js = r.json()
         assert js["total"] >= 2
         assert len(js["items"]) == 1
 
-        r2 = await ac.get("/signals?domain=ta", headers=headers)
+        r2 = await ac.get("/api/v1/signals?domain=ta", headers=headers)
         assert r2.status_code == 200
         js2 = r2.json()
         assert all(item["type"].startswith("signal.ta") for item in js2["items"])

--- a/tests/unit/test_producer_registration.py
+++ b/tests/unit/test_producer_registration.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from api.main import create_app
+from engine.core.database import Database
+from tests.unit._api_test_client import make_client
+
+
+@pytest.mark.anyio
+async def test_producer_register_list_remove_lifecycle(temp_dir, test_config):
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    async with make_client(app) as ac:
+        reg = {
+            "name": "unit-test-producer",
+            "domain": "technical",
+            "endpoint": "https://example.com/signals",
+            "schedule": "*/5 * * * *",
+        }
+
+        r1 = await ac.post("/api/v1/producers/register", json=reg)
+        assert r1.status_code == 200
+        js1 = r1.json()
+        assert js1["name"] == reg["name"]
+        assert js1["endpoint"] == reg["endpoint"]
+        assert "registered_at" in js1
+
+        r2 = await ac.get("/api/v1/producers/")
+        assert r2.status_code == 200
+        js2 = r2.json()
+        assert "producers" in js2
+        assert any(p["name"] == reg["name"] for p in js2["producers"])
+
+        r3 = await ac.delete(f"/api/v1/producers/{reg['name']}")
+        assert r3.status_code == 200
+        assert r3.json()["removed"] == reg["name"]
+
+        r4 = await ac.get("/api/v1/producers/")
+        assert r4.status_code == 200
+        assert all(p["name"] != reg["name"] for p in r4.json()["producers"])
+
+    app.state.db.close()
+
+
+@pytest.mark.anyio
+async def test_duplicate_registration_returns_structured_error(temp_dir, test_config):
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    async with make_client(app) as ac:
+        reg = {
+            "name": "dup-producer",
+            "domain": "sentiment",
+            "endpoint": "https://example.com/x",
+            "schedule": "*/15 * * * *",
+        }
+
+        r1 = await ac.post("/api/v1/producers/register", json=reg)
+        assert r1.status_code == 200
+
+        r2 = await ac.post("/api/v1/producers/register", json=reg)
+        assert r2.status_code == 409
+        js = r2.json()
+        assert js["error"]["code"] == "producer.duplicate"
+        assert js["error"]["name"] == "dup-producer"
+
+    app.state.db.close()

--- a/tests/unit/test_structured_errors.py
+++ b/tests/unit/test_structured_errors.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from api.errors import B1e55edError
+from api.main import create_app
+from engine.core.database import Database
+from tests.unit._api_test_client import make_client
+
+
+@pytest.mark.anyio
+async def test_b1e55ed_error_handler_json_shape(temp_dir, test_config):
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    @app.get("/api/v1/_test/error")
+    def _raise() -> None:
+        raise B1e55edError(code="test.error", message="boom", status=418, detail="extra")
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/_test/error")
+        assert r.status_code == 418
+        js = r.json()
+        assert js == {"error": {"code": "test.error", "message": "boom", "detail": "extra"}}
+
+    app.state.db.close()
+
+
+@pytest.mark.anyio
+async def test_b1e55ed_error_handler_status_codes(temp_dir, test_config):
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    @app.get("/api/v1/_test/notfound")
+    def _notfound() -> None:
+        raise B1e55edError(code="x.not_found", message="missing", status=404)
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/_test/notfound")
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "x.not_found"
+
+    app.state.db.close()


### PR DESCRIPTION
## Sprint O3 — Agent Interface

### OpenAPI Polish
- All routes under `/api/v1/`
- Swagger UI at `/docs`, raw spec at `/openapi.json`
- Tag descriptions + response models on key endpoints

### Producer Registration API
- `POST /api/v1/producers/register` + `DELETE /api/v1/producers/{name}`
- CLI: `b1e55ed producers register|list|remove`
- `endpoint` column added to `producer_health` schema

### Structured Errors
- `B1e55edError` + handler → consistent `{"error": {"code", "message"}}` format
- Applied to auth, kill switch (423), producer not found/duplicate

### CONTRIBUTING.md
- Producer/strategy contribution guide, dev setup, PR process
- PUC brand voice

### Tests
- All existing tests updated for `/api/v1/` prefix
- New: `test_producer_registration.py`, `test_structured_errors.py`
- **181 tests passing**, mypy clean, ruff clean