### PR TITLE
chore: pre-commit hook for auto ruff format + lint

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Auto-format and lint before commit. Fail if unfixable issues remain.
+set -e
+
+# Find the venv
+if [ -f ".venv/bin/ruff" ]; then
+    RUFF=".venv/bin/ruff"
+elif command -v ruff &>/dev/null; then
+    RUFF="ruff"
+else
+    echo "⚠️  ruff not found — skipping pre-commit lint"
+    exit 0
+fi
+
+# Auto-fix what we can
+$RUFF format . --quiet
+$RUFF check . --fix --quiet 2>/dev/null || true
+
+# Stage any auto-fixed files
+git diff --name-only | xargs -r git add
+
+# Final check — fail if unfixable issues remain
+$RUFF check . --quiet
+$RUFF format --check . --quiet


### PR DESCRIPTION
Adds `.githooks/pre-commit` that auto-runs `ruff format` and `ruff check --fix` before every commit.

Fails only if unfixable issues remain. No more lint CI failures from formatting.

Setup: `git config core.hooksPath .githooks`