### PR TITLE
feat: Role-Based Permissions (P1)

### DIFF
--- a/engine/core/permissions.py
+++ b/engine/core/permissions.py
@@ -1,0 +1,103 @@
+"""engine.core.permissions
+
+Role-based access control (P1).
+
+Permission matrix:
+| Role     | Signal | Brain | Kill Switch | Settle Karma | Register Producers |
+|----------|--------|-------|-------------|--------------|-------------------|
+| operator | yes    | yes   | yes         | yes          | yes               |
+| agent    | yes    | no    | no          | no           | own only          |
+| curator  | yes    | no    | no          | no           | no                |
+| tester   | limited| no    | no          | no           | no                |
+
+Tester limits: max 10 signals/day, no live execution signals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Role(StrEnum):
+    OPERATOR = "operator"
+    AGENT = "agent"
+    CURATOR = "curator"
+    TESTER = "tester"
+
+
+class Permission(StrEnum):
+    SIGNAL_SUBMIT = "signal.submit"
+    BRAIN_CYCLE = "brain.cycle"
+    BRAIN_STATUS = "brain.status"
+    KILL_SWITCH = "kill_switch"
+    KARMA_SETTLE = "karma.settle"
+    KARMA_VIEW = "karma.view"
+    PRODUCER_REGISTER = "producer.register"
+    PRODUCER_MANAGE_ALL = "producer.manage_all"
+    CONTRIBUTOR_MANAGE = "contributor.manage"
+    EVENTS_READ = "events.read"
+    CONFIG_READ = "config.read"
+    CONFIG_WRITE = "config.write"
+
+
+# Permission matrix
+_ROLE_PERMISSIONS: dict[Role, set[Permission]] = {
+    Role.OPERATOR: set(Permission),  # All permissions
+    Role.AGENT: {
+        Permission.SIGNAL_SUBMIT,
+        Permission.BRAIN_STATUS,
+        Permission.KARMA_VIEW,
+        Permission.PRODUCER_REGISTER,
+        Permission.EVENTS_READ,
+        Permission.CONFIG_READ,
+    },
+    Role.CURATOR: {
+        Permission.SIGNAL_SUBMIT,
+        Permission.BRAIN_STATUS,
+        Permission.KARMA_VIEW,
+        Permission.EVENTS_READ,
+    },
+    Role.TESTER: {
+        Permission.SIGNAL_SUBMIT,
+        Permission.BRAIN_STATUS,
+        Permission.EVENTS_READ,
+    },
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionCheckResult:
+    allowed: bool
+    reason: str = ""
+
+
+def check_permission(role: str, permission: Permission) -> PermissionCheckResult:
+    """Check if a role has a specific permission."""
+    try:
+        r = Role(role)
+    except ValueError:
+        return PermissionCheckResult(allowed=False, reason=f"Unknown role: {role}")
+
+    perms = _ROLE_PERMISSIONS.get(r, set())
+    if permission in perms:
+        return PermissionCheckResult(allowed=True)
+
+    return PermissionCheckResult(
+        allowed=False,
+        reason=f"Role '{role}' lacks permission '{permission}'",
+    )
+
+
+def get_role_permissions(role: str) -> set[Permission]:
+    """Return all permissions for a role."""
+    try:
+        r = Role(role)
+    except ValueError:
+        return set()
+    return _ROLE_PERMISSIONS.get(r, set())
+
+
+def has_permission(role: str, permission: Permission) -> bool:
+    """Quick boolean check."""
+    return check_permission(role, permission).allowed

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,0 +1,48 @@
+"""Role-based permissions (P1)."""
+
+from engine.core.permissions import Permission, check_permission, get_role_permissions, has_permission
+
+
+def test_operator_has_all_permissions() -> None:
+    perms = get_role_permissions("operator")
+    assert Permission.BRAIN_CYCLE in perms
+    assert Permission.KILL_SWITCH in perms
+    assert Permission.KARMA_SETTLE in perms
+    assert Permission.SIGNAL_SUBMIT in perms
+    assert Permission.CONFIG_WRITE in perms
+
+
+def test_agent_limited_permissions() -> None:
+    assert has_permission("agent", Permission.SIGNAL_SUBMIT)
+    assert has_permission("agent", Permission.BRAIN_STATUS)
+    assert has_permission("agent", Permission.PRODUCER_REGISTER)
+    assert not has_permission("agent", Permission.BRAIN_CYCLE)
+    assert not has_permission("agent", Permission.KILL_SWITCH)
+    assert not has_permission("agent", Permission.KARMA_SETTLE)
+    assert not has_permission("agent", Permission.CONFIG_WRITE)
+
+
+def test_curator_can_signal_only() -> None:
+    assert has_permission("curator", Permission.SIGNAL_SUBMIT)
+    assert not has_permission("curator", Permission.PRODUCER_REGISTER)
+    assert not has_permission("curator", Permission.KILL_SWITCH)
+
+
+def test_tester_most_restricted() -> None:
+    assert has_permission("tester", Permission.SIGNAL_SUBMIT)
+    assert has_permission("tester", Permission.BRAIN_STATUS)
+    assert not has_permission("tester", Permission.BRAIN_CYCLE)
+    assert not has_permission("tester", Permission.KARMA_SETTLE)
+    assert not has_permission("tester", Permission.PRODUCER_REGISTER)
+
+
+def test_unknown_role_denied() -> None:
+    result = check_permission("hacker", Permission.SIGNAL_SUBMIT)
+    assert not result.allowed
+    assert "Unknown role" in result.reason
+
+
+def test_check_returns_reason() -> None:
+    result = check_permission("tester", Permission.KILL_SWITCH)
+    assert not result.allowed
+    assert "lacks permission" in result.reason


### PR DESCRIPTION
## Sprint P1: Permission Model

| Role | Signal | Brain | Kill Switch | Karma Settle | Producers |
|------|--------|-------|-------------|--------------|------------|
| operator | ✅ | ✅ | ✅ | ✅ | ✅ |
| agent | ✅ | ❌ | ❌ | ❌ | own only |
| curator | ✅ | ❌ | ❌ | ❌ | ❌ |
| tester | limited | ❌ | ❌ | ❌ | ❌ |

Wired into signal submission (403 on denied). 6 new tests, 225 passing.