### PR TITLE
PH1a: Producer response caps + JSON schema guard

### DIFF
--- a/engine/producers/aci.py
+++ b/engine/producers/aci.py
@@ -91,9 +91,16 @@ class ACIProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(
+            self.ctx.client.request_json(
+                "POST",
+                url,
+                expected=(list, dict),
+                json={"symbols": symbols},
+                max_bytes=1024 * 1024,
+                max_items=2000,
+            )
+        )
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
 

--- a/engine/producers/curator.py
+++ b/engine/producers/curator.py
@@ -57,8 +57,7 @@ class CuratorIntelProducer(BaseProducer):
 
         if url:
             # Endpoint can be mocked in tests via ctx.client
-            resp = asyncio.run(self.ctx.client.request("GET", url))
-            data = resp.json()
+            data = asyncio.run(self.ctx.client.request_json("GET", url, expected=(list, dict), max_bytes=512 * 1024, max_items=2000))
         elif fp:
             p = Path(fp)
             if not p.exists():

--- a/engine/producers/etf.py
+++ b/engine/producers/etf.py
@@ -51,9 +51,7 @@ class ETFFlowsProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/events.py
+++ b/engine/producers/events.py
@@ -50,9 +50,7 @@ class MarketEventsProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/onchain.py
+++ b/engine/producers/onchain.py
@@ -49,9 +49,7 @@ class OnchainFlowsProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/orderbook.py
+++ b/engine/producers/orderbook.py
@@ -47,9 +47,7 @@ class OrderbookDepthProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/price_ws.py
+++ b/engine/producers/price_ws.py
@@ -50,9 +50,7 @@ class PriceAlertsProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/sentiment.py
+++ b/engine/producers/sentiment.py
@@ -52,9 +52,7 @@ class MarketSentimentProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/stablecoin.py
+++ b/engine/producers/stablecoin.py
@@ -42,9 +42,7 @@ class StablecoinSupplyProducer(BaseProducer):
             self.ctx.logger.warning("stablecoin_supply_endpoint_missing")
             return []
 
-        resp = asyncio.run(self.ctx.client.request("GET", url))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("GET", url, expected=(list, dict)))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/ta.py
+++ b/engine/producers/ta.py
@@ -49,9 +49,7 @@ class TechnicalAnalysisProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -52,9 +52,7 @@ class TradFiBasisProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/engine/producers/whale.py
+++ b/engine/producers/whale.py
@@ -44,9 +44,7 @@ class WhaleTrackingProducer(BaseProducer):
             return []
 
         symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        resp = asyncio.run(self.ctx.client.request("POST", url, json={"symbols": symbols}))
-
-        data: Any = resp.json()
+        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
         if not isinstance(data, list):

--- a/tests/unit/test_client_request_json_limits.py
+++ b/tests/unit/test_client_request_json_limits.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from engine.core.client import DataClient
+
+
+@pytest.mark.anyio
+async def test_request_json_blocks_too_large(monkeypatch):
+    client = DataClient()
+
+    async def _fake_request(method: str, url: str, **kwargs):
+        return httpx.Response(200, content=b"x" * (600 * 1024))
+
+    monkeypatch.setattr(client, "request", _fake_request)
+
+    with pytest.raises(httpx.TransportError):
+        await client.request_json("GET", "https://example.com", max_bytes=512 * 1024)
+
+
+@pytest.mark.anyio
+async def test_request_json_schema_mismatch(monkeypatch):
+    client = DataClient()
+
+    async def _fake_request(method: str, url: str, **kwargs):
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(client, "request", _fake_request)
+
+    with pytest.raises(httpx.TransportError):
+        await client.request_json("GET", "https://example.com", expected=list)
+
+
+@pytest.mark.anyio
+async def test_request_json_max_items(monkeypatch):
+    client = DataClient()
+
+    async def _fake_request(method: str, url: str, **kwargs):
+        return httpx.Response(200, json=[{"i": i} for i in range(10)])
+
+    monkeypatch.setattr(client, "request", _fake_request)
+
+    with pytest.raises(httpx.TransportError):
+        await client.request_json("GET", "https://example.com", expected=list, max_items=5)

--- a/tests/unit/test_producer_aci.py
+++ b/tests/unit/test_producer_aci.py
@@ -26,6 +26,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 @pytest.mark.parametrize(
     ("text", "expected"),

--- a/tests/unit/test_producer_curator.py
+++ b/tests/unit/test_producer_curator.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_curator_intel_producer_publishes_events_from_url(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_CURATOR_URL", "https://example.test/curator")

--- a/tests/unit/test_producer_etf.py
+++ b/tests/unit/test_producer_etf.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_etf_flows_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_ETF_FLOWS_URL", "https://example.test/etf")

--- a/tests/unit/test_producer_events.py
+++ b/tests/unit/test_producer_events.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_events_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_EVENTS_URL", "https://example.test/events")

--- a/tests/unit/test_producer_onchain.py
+++ b/tests/unit/test_producer_onchain.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_onchain_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_ONCHAIN_FLOWS_URL", "https://example.test/onchain/flows")

--- a/tests/unit/test_producer_orderbook.py
+++ b/tests/unit/test_producer_orderbook.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_orderbook_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_ORDERBOOK_URL", "https://example.test/orderbook")

--- a/tests/unit/test_producer_price_ws.py
+++ b/tests/unit/test_producer_price_ws.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_price_ws_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_PRICE_WS_URL", "https://example.test/prices")

--- a/tests/unit/test_producer_sentiment.py
+++ b/tests/unit/test_producer_sentiment.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_market_sentiment_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_SENTIMENT_URL", "https://example.test/sentiment")

--- a/tests/unit/test_producer_stablecoin.py
+++ b/tests/unit/test_producer_stablecoin.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_stablecoin_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_STABLECOIN_SUPPLY_URL", "https://example.test/stablecoin/supply")

--- a/tests/unit/test_producer_ta.py
+++ b/tests/unit/test_producer_ta.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_ta_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_TA_URL", "https://example.test/ta")

--- a/tests/unit/test_producer_tradfi.py
+++ b/tests/unit/test_producer_tradfi.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_tradfi_basis_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_TRADFI_BASIS_URL", "https://example.test/basis")

--- a/tests/unit/test_producer_whale.py
+++ b/tests/unit/test_producer_whale.py
@@ -25,6 +25,10 @@ class DummyClient:
         assert self._response is not None
         return self._response
 
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
 
 def test_whale_producer_publishes_events(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("B1E55ED_WHALE_TRACKING_URL", "https://example.test/whale")


### PR DESCRIPTION
Sprint PH1 (continued): producer hardening via response caps + schema enforcement.

- Adds DataClient.request_json() with max_bytes + max_items caps
- Adds expected-type validation (list/dict) to fail fast on malformed producer responses
- Updates all HTTP-based producers to use request_json() (removes raw resp.json())
- Updates producer unit-test DummyClients to provide request_json()
- Adds unit tests for request_json caps

Tests: `pytest --ignore=tests/unit/test_eas_client.py`