### PR TITLE
SEC1b: Separate kill-switch auth token boundary

### DIFF
--- a/api/auth_kill_switch.py
+++ b/api/auth_kill_switch.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import hmac
+
+from fastapi import Depends, Header
+
+from api.deps import get_config
+from api.errors import B1e55edError
+from engine.core.config import Config
+
+
+def require_kill_switch_token(
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    config: Config = Depends(get_config),
+) -> None:
+    """Require Authorization: Bearer <kill_switch_token>.
+
+    Uses a separate token from the general API auth_token.
+
+    If kill_switch_token is not configured, we treat this as a hard failure:
+    kill switch endpoints must not run without explicit auth.
+    """
+
+    expected = str(getattr(config.api, "kill_switch_token", "") or "")
+    if not expected:
+        raise B1e55edError(
+            code="auth.kill_switch_token_missing",
+            message="Kill switch auth token is not configured",
+            status=500,
+        )
+
+    if not authorization:
+        raise B1e55edError(
+            code="auth.missing_token",
+            message="Missing bearer token",
+            status=401,
+        )
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise B1e55edError(
+            code="auth.invalid_header",
+            message="Invalid authorization header",
+            status=401,
+        )
+
+    token = parts[1].strip()
+    if not hmac.compare_digest(token, expected):
+        raise B1e55edError(
+            code="auth.invalid_token",
+            message="Invalid bearer token",
+            status=401,
+        )
+
+
+KillSwitchAuthDep = Depends(require_kill_switch_token)

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from api.routes import brain, config, contributors, health, karma, positions, producers, regime, signals
+from api.routes import brain, config, contributors, health, karma, kill_switch, positions, producers, regime, signals
 
 
 def get_api_router() -> APIRouter:
@@ -10,6 +10,7 @@ def get_api_router() -> APIRouter:
 
     router.include_router(health.router, tags=["health"])
     router.include_router(brain.router, tags=["brain"])
+    router.include_router(kill_switch.router)
     router.include_router(signals.router, tags=["signals"])
     router.include_router(positions.router, tags=["positions"])
     router.include_router(regime.router, tags=["regime"])

--- a/api/routes/kill_switch.py
+++ b/api/routes/kill_switch.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from api.auth_kill_switch import KillSwitchAuthDep
+from api.deps import get_db, get_kill_switch
+from api.errors import B1e55edError
+from engine.brain.kill_switch import KillSwitch
+from engine.core.database import Database
+
+router = APIRouter(prefix="/kill-switch", dependencies=[KillSwitchAuthDep], tags=["brain"])
+
+
+class KillSwitchSetRequest(BaseModel):
+    level: int = Field(..., ge=0, le=4)
+    reason: str = Field("manual", description="Human readable reason")
+
+
+@router.get("/status")
+def status(ks: KillSwitch = Depends(get_kill_switch)) -> dict:
+    return {"level": int(ks.level)}
+
+
+@router.post("/set")
+def set_level(
+    payload: KillSwitchSetRequest,
+    db: Database = Depends(get_db),
+    ks: KillSwitch = Depends(get_kill_switch),
+) -> dict:
+    level = int(payload.level)
+
+    # Persist as an event; KillSwitch will rehydrate from event store.
+    from engine.core.events import EventType
+
+    prev = int(ks.level)
+    ev = db.append_event(
+        event_type=EventType.KILL_SWITCH_V1,
+        payload={
+            "level": level,
+            "previous_level": prev,
+            "reason": str(payload.reason),
+            "auto": False,
+            "actor": "api",
+        },
+        source="api.kill_switch",
+    )
+
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        ks.reset(level=level)
+
+    if level < 0 or level > 4:
+        raise B1e55edError(code="kill_switch.invalid_level", message="Level must be 0-4", status=400)
+
+    return {"status": "ok", "event_id": ev.id, "level": level}

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -106,6 +106,7 @@ class ApiConfig(BaseModel):
     host: str = "127.0.0.1"
     port: int = 5050
     auth_token: str = ""
+    kill_switch_token: str = ""  # Separate auth boundary for kill switch endpoints
 
 
 class DashboardConfig(BaseModel):

--- a/tests/unit/test_kill_switch_auth.py
+++ b/tests/unit/test_kill_switch_auth.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from api.main import create_app
+from engine.core.database import Database
+from tests.unit._api_test_client import make_client
+
+
+@pytest.mark.anyio
+async def test_kill_switch_requires_separate_token(temp_dir, test_config):
+    # configure both tokens
+    test_config = test_config.model_copy(
+        update={
+            "api": test_config.api.model_copy(
+                update={
+                    "auth_token": "general",
+                    "kill_switch_token": "ks",
+                }
+            )
+        }
+    )
+
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    async with make_client(app) as ac:
+        # general token can access brain status
+        r = await ac.get("/api/v1/brain/status", headers={"Authorization": "Bearer general"})
+        assert r.status_code == 200
+
+        # but cannot set kill switch
+        r2 = await ac.post(
+            "/api/v1/kill-switch/set",
+            headers={"Authorization": "Bearer general"},
+            json={"level": 1, "reason": "test"},
+        )
+        assert r2.status_code == 401
+
+        # kill switch token works
+        r3 = await ac.post(
+            "/api/v1/kill-switch/set",
+            headers={"Authorization": "Bearer ks"},
+            json={"level": 1, "reason": "test"},
+        )
+        assert r3.status_code == 200
+
+    app.state.db.close()
+
+
+@pytest.mark.anyio
+async def test_kill_switch_missing_token_is_500(temp_dir, test_config):
+    test_config = test_config.model_copy(update={"api": test_config.api.model_copy(update={"auth_token": "general"})})
+
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    async with make_client(app) as ac:
+        r = await ac.post(
+            "/api/v1/kill-switch/set",
+            headers={"Authorization": "Bearer general"},
+            json={"level": 1, "reason": "test"},
+        )
+        assert r.status_code == 500
+        assert r.json()["error"]["code"] == "auth.kill_switch_token_missing"
+
+    app.state.db.close()


### PR DESCRIPTION
Sprint SEC1b — Kill switch separate auth boundary

- Adds api.kill_switch_token config field
- Adds KillSwitchAuthDep requiring the separate token
- Adds new /kill-switch endpoints protected by KillSwitchAuthDep
- Unit tests: general token denied, kill-switch token allowed; missing token -> 500

Tests: `pytest --ignore=tests/unit/test_eas_client.py` (294 passed locally)