### PR TITLE
B1a: Minimal backtest engine + simulator + metrics

### DIFF
--- a/engine/backtest/__init__.py
+++ b/engine/backtest/__init__.py
@@ -1,6 +1,7 @@
-"""b1e55ed package boundary.
+"""engine.backtest
 
-0xb1e55ed = "blessed". The name is the first easter egg.
+Backtest engine (B1).
 
-A grimoire is not a textbook. It is a book of names, invocations, and hard-won procedures.
+B1a implements a minimal simulator + metrics. B1b will implement the full
+strategy library + walk-forward validation + FDR correction.
 """

--- a/engine/backtest/engine.py
+++ b/engine/backtest/engine.py
@@ -1,4 +1,51 @@
-"""Module placeholder.
+"""engine.backtest.engine
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Backtest entry point.
+
+B1a implements a minimal, correct loop:
+- strategy generates a position signal
+- simulator converts signal + prices into equity curve
+- validation computes metrics
+
+Data ingestion (OHLCV loaders, feature store integration) is intentionally
+out of scope for B1a.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.simulator import SimConfig, SimResult, simulate
+from engine.backtest.strategies.base import Strategy
+from engine.backtest.validation import Metrics, compute_metrics
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestConfig:
+    fee_bps: float = 10.0
+    periods_per_year: int = 365
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestResult:
+    sim: SimResult
+    metrics: Metrics
+
+
+def run_backtest(
+    *,
+    strategy: Strategy,
+    close: np.ndarray,
+    high: np.ndarray | None = None,
+    low: np.ndarray | None = None,
+    volume: np.ndarray | None = None,
+    cfg: BacktestConfig | None = None,
+) -> BacktestResult:
+    cfg = cfg or BacktestConfig()
+
+    res = strategy.generate(close=close, high=high, low=low, volume=volume)
+    sim = simulate(close=close, signal=res.signal, cfg=SimConfig(fee_bps=cfg.fee_bps))
+    metrics = compute_metrics(equity=sim.equity, returns=sim.returns, periods_per_year=cfg.periods_per_year)
+    return BacktestResult(sim=sim, metrics=metrics)

--- a/engine/backtest/simulator.py
+++ b/engine/backtest/simulator.py
@@ -1,4 +1,69 @@
-"""Module placeholder.
+"""engine.backtest.simulator
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Single-asset backtest simulator.
+
+This is intentionally minimal but correct:
+- position determined by signal (-1..+1)
+- daily/period returns applied with transaction costs when position changes
+
+No leverage, no funding, no slippage model beyond fixed bps.
+Those can be layered later.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class SimConfig:
+    fee_bps: float = 10.0  # 0.10% per position change notional
+
+
+@dataclass(frozen=True, slots=True)
+class SimResult:
+    equity: np.ndarray  # (T,)
+    returns: np.ndarray  # (T,)
+    position: np.ndarray  # (T,)
+    fees: np.ndarray  # (T,)
+
+
+def simulate(*, close: np.ndarray, signal: np.ndarray, cfg: SimConfig | None = None) -> SimResult:
+    cfg = cfg or SimConfig()
+
+    close = close.astype(np.float64)
+    signal = np.clip(signal.astype(np.float64), -1.0, 1.0)
+
+    if close.ndim != 1 or signal.ndim != 1 or close.shape[0] != signal.shape[0]:
+        raise ValueError("close and signal must be 1D arrays of same length")
+
+    t_len = close.shape[0]
+    if t_len == 0:
+        return SimResult(
+            equity=np.zeros(0, dtype=np.float64),
+            returns=np.zeros(0, dtype=np.float64),
+            position=np.zeros(0, dtype=np.float64),
+            fees=np.zeros(0, dtype=np.float64),
+        )
+
+    # Compute bar returns (simple)
+    ret = np.zeros(t_len, dtype=np.float64)
+    ret[1:] = (close[1:] / close[:-1]) - 1.0
+
+    pos = signal.copy()
+
+    # Fees when position changes
+    fees = np.zeros(t_len, dtype=np.float64)
+    turnover = np.abs(np.diff(pos, prepend=pos[0]))
+    # If you go 0 -> 1, turnover=1; 1 -> -1, turnover=2.
+    fees = turnover * (cfg.fee_bps / 10_000.0)
+
+    strat_ret = pos * ret - fees
+
+    equity = np.ones(t_len, dtype=np.float64)
+    for t in range(1, t_len):
+        equity[t] = equity[t - 1] * (1.0 + strat_ret[t])
+
+    return SimResult(equity=equity, returns=strat_ret, position=pos, fees=fees)

--- a/engine/backtest/strategies/base.py
+++ b/engine/backtest/strategies/base.py
@@ -1,4 +1,32 @@
-"""Module placeholder.
+"""engine.backtest.strategies.base
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Backtest strategy contract.
+
+A strategy is a pure function over a price series and optional features.
+It outputs a position signal per bar.
+
+Signal convention:
+- -1.0 = fully short
+-  0.0 = flat
+- +1.0 = fully long
+
+The simulator translates signals into trades.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyResult:
+    signal: np.ndarray  # float64, shape (T,)
+
+
+class Strategy:
+    name: str = "strategy"
+
+    def generate(self, *, close: np.ndarray, high: np.ndarray | None = None, low: np.ndarray | None = None, volume: np.ndarray | None = None) -> StrategyResult:
+        raise NotImplementedError

--- a/engine/backtest/strategies/momentum.py
+++ b/engine/backtest/strategies/momentum.py
@@ -1,4 +1,36 @@
-"""Module placeholder.
+"""engine.backtest.strategies.momentum
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Simple momentum strategy:
+- long if close / close[n] - 1 > threshold
+- flat otherwise
+
+No shorting in v1.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+@dataclass(frozen=True, slots=True)
+class MomentumStrategy(Strategy):
+    name: str = "momentum"
+    lookback: int = 20
+    threshold: float = 0.02
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        close = close.astype(np.float64)
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        n = int(self.lookback)
+        if n >= t_len or n <= 0:
+            return StrategyResult(signal=sig)
+
+        mom = (close / np.roll(close, n)) - 1.0
+        mom[:n] = 0.0
+        sig[mom > float(self.threshold)] = 1.0
+        return StrategyResult(signal=sig)

--- a/engine/backtest/sweep.py
+++ b/engine/backtest/sweep.py
@@ -1,4 +1,16 @@
-"""Module placeholder.
+"""engine.backtest.sweep
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Parameter sweep harness.
+
+B1a includes only the contract. B1b will implement real strategy grids.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SweepResult:
+    items: list[dict[str, Any]]

--- a/engine/backtest/validation.py
+++ b/engine/backtest/validation.py
@@ -1,4 +1,49 @@
-"""Module placeholder.
+"""engine.backtest.validation
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Performance metrics + walk-forward helpers.
+
+This is v1: enough to prevent self-deception.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class Metrics:
+    total_return: float
+    sharpe: float
+    max_drawdown: float
+
+
+def _max_drawdown(equity: np.ndarray) -> float:
+    if equity.size == 0:
+        return 0.0
+    peak = np.maximum.accumulate(equity)
+    dd = (equity / peak) - 1.0
+    return float(dd.min())
+
+
+def sharpe(returns: np.ndarray, *, periods_per_year: int = 365) -> float:
+    r = returns.astype(np.float64)
+    if r.size < 2:
+        return 0.0
+    mu = float(np.mean(r))
+    sd = float(np.std(r, ddof=1))
+    if sd == 0.0:
+        return 0.0
+    return (mu / sd) * np.sqrt(periods_per_year)
+
+
+def compute_metrics(*, equity: np.ndarray, returns: np.ndarray, periods_per_year: int = 365) -> Metrics:
+    if equity.size == 0:
+        return Metrics(total_return=0.0, sharpe=0.0, max_drawdown=0.0)
+    total_return = float(equity[-1] - 1.0)
+    return Metrics(
+        total_return=total_return,
+        sharpe=sharpe(returns, periods_per_year=periods_per_year),
+        max_drawdown=_max_drawdown(equity),
+    )

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+
+from engine.backtest.engine import run_backtest
+from engine.backtest.strategies.momentum import MomentumStrategy
+
+
+def test_backtest_runs_and_metrics():
+    close = np.array([100, 101, 102, 103, 104, 103, 105], dtype=np.float64)
+    strat = MomentumStrategy(lookback=2, threshold=0.005)
+    res = run_backtest(strategy=strat, close=close)
+
+    assert res.sim.equity.shape[0] == close.shape[0]
+    assert isinstance(res.metrics.total_return, float)
+    assert isinstance(res.metrics.sharpe, float)
+    assert isinstance(res.metrics.max_drawdown, float)
+
+
+def test_backtest_empty_series():
+    close = np.array([], dtype=np.float64)
+    strat = MomentumStrategy(lookback=2, threshold=0.01)
+    res = run_backtest(strategy=strat, close=close)
+    assert res.sim.equity.size == 0
+    assert res.metrics.total_return == 0.0

--- a/tests/unit/test_backtest_simulator.py
+++ b/tests/unit/test_backtest_simulator.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+
+from engine.backtest.simulator import SimConfig, simulate
+
+
+def test_simulator_flat_signal_equity_constant():
+    close = np.array([100, 101, 99, 100], dtype=np.float64)
+    sig = np.zeros_like(close)
+    res = simulate(close=close, signal=sig)
+    assert float(res.equity[-1]) == 1.0
+
+
+def test_simulator_fee_on_position_change():
+    close = np.array([100, 100, 100, 100], dtype=np.float64)
+    sig = np.array([0, 1, 1, 0], dtype=np.float64)
+    res = simulate(close=close, signal=sig, cfg=SimConfig(fee_bps=10.0))
+    # no price movement, only fees -> equity < 1
+    assert float(res.equity[-1]) < 1.0

--- a/tests/unit/test_backtest_validation.py
+++ b/tests/unit/test_backtest_validation.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import numpy as np
+
+from engine.backtest.validation import compute_metrics
+
+
+def test_validation_max_drawdown():
+    equity = np.array([1.0, 1.2, 1.1, 1.3, 1.0], dtype=np.float64)
+    returns = np.array([0.0, 0.2, -0.0833, 0.1818, -0.2307], dtype=np.float64)
+    m = compute_metrics(equity=equity, returns=returns)
+    assert m.max_drawdown < 0


### PR DESCRIPTION
Sprint B1a — implement the backtest engine skeleton (replace placeholders).

- Adds Strategy contract (signal in [-1, +1])
- Adds single-asset simulator with transaction fees + equity curve
- Adds validation metrics: total_return, Sharpe, max drawdown
- Adds run_backtest entry point
- Adds MomentumStrategy as reference implementation
- Adds unit tests for simulator/metrics/engine

Tests: `pytest --ignore=tests/unit/test_eas_client.py` (297 passed locally)