### PR TITLE
B1b: Baseline strategy library (MA/RSI/breakout/reversion/etc)

### DIFF
--- a/engine/backtest/strategies/__init__.py
+++ b/engine/backtest/strategies/__init__.py
@@ -1,6 +1,32 @@
-"""b1e55ed package boundary.
+"""engine.backtest.strategies
 
-0xb1e55ed = "blessed". The name is the first easter egg.
+Strategy library (B1).
 
-A grimoire is not a textbook. It is a book of names, invocations, and hard-won procedures.
+These are intentionally simple baselines. The goal is correctness and
+comparability, not sophistication.
 """
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+from engine.backtest.strategies.breakout import BreakoutStrategy
+from engine.backtest.strategies.combined import CombinedStrategy
+from engine.backtest.strategies.funding_arb import FundingArbStrategy
+from engine.backtest.strategies.ma_crossover import MACrossoverStrategy
+from engine.backtest.strategies.mean_reversion import MeanReversionStrategy
+from engine.backtest.strategies.momentum import MomentumStrategy
+from engine.backtest.strategies.rsi_reversion import RSIReversionStrategy
+from engine.backtest.strategies.trend_following import TrendFollowingStrategy
+from engine.backtest.strategies.volatility import VolatilityFilterStrategy
+
+__all__ = [
+    "Strategy",
+    "StrategyResult",
+    "BreakoutStrategy",
+    "CombinedStrategy",
+    "FundingArbStrategy",
+    "MACrossoverStrategy",
+    "MeanReversionStrategy",
+    "MomentumStrategy",
+    "RSIReversionStrategy",
+    "TrendFollowingStrategy",
+    "VolatilityFilterStrategy",
+]

--- a/engine/backtest/strategies/breakout.py
+++ b/engine/backtest/strategies/breakout.py
@@ -1,4 +1,40 @@
-"""Module placeholder.
+"""engine.backtest.strategies.breakout
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Simple breakout (long-only):
+- long when close > max(high, lookback)
+- flat otherwise
+
+Requires high series; if missing falls back to close.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+@dataclass(frozen=True, slots=True)
+class BreakoutStrategy(Strategy):
+    name: str = "breakout"
+    lookback: int = 20
+
+    def generate(self, *, close: np.ndarray, high: np.ndarray | None = None, low=None, volume=None) -> StrategyResult:
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        n = int(self.lookback)
+        if t_len == 0 or n <= 1:
+            return StrategyResult(signal=sig)
+
+        h = high if high is not None else close
+        h = h.astype(np.float64)
+        # rolling max of previous n bars
+        roll = np.full_like(h, np.nan, dtype=np.float64)
+        for i in range(n, t_len):
+            roll[i] = float(np.max(h[i - n : i]))
+
+        mask = np.isfinite(roll)
+        sig[mask & (close > roll)] = 1.0
+        return StrategyResult(signal=sig)

--- a/engine/backtest/strategies/combined.py
+++ b/engine/backtest/strategies/combined.py
@@ -1,4 +1,34 @@
-"""Module placeholder.
+"""engine.backtest.strategies.combined
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Combined strategy: momentum OR MA crossover.
+
+This is not the final ensemble logic; it just replaces placeholders
+and provides a multi-signal example.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+from engine.backtest.strategies.ma_crossover import MACrossoverStrategy
+from engine.backtest.strategies.momentum import MomentumStrategy
+
+
+@dataclass(frozen=True, slots=True)
+class CombinedStrategy(Strategy):
+    name: str = "combined"
+
+    mom_lookback: int = 20
+    mom_threshold: float = 0.02
+
+    fast: int = 10
+    slow: int = 50
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        mom = MomentumStrategy(lookback=self.mom_lookback, threshold=self.mom_threshold).generate(close=close).signal
+        ma = MACrossoverStrategy(fast=self.fast, slow=self.slow).generate(close=close).signal
+        sig = np.clip(mom + ma, 0.0, 1.0)
+        return StrategyResult(signal=sig)

--- a/engine/backtest/strategies/funding_arb.py
+++ b/engine/backtest/strategies/funding_arb.py
@@ -1,4 +1,23 @@
-"""Module placeholder.
+"""engine.backtest.strategies.funding_arb
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Placeholder replacement.
+
+True funding arb requires funding/basis series and execution constraints.
+For B1b we implement a trivial strategy that stays flat.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+@dataclass(frozen=True, slots=True)
+class FundingArbStrategy(Strategy):
+    name: str = "funding_arb"
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        return StrategyResult(signal=np.zeros(close.shape[0], dtype=np.float64))

--- a/engine/backtest/strategies/ma_crossover.py
+++ b/engine/backtest/strategies/ma_crossover.py
@@ -1,4 +1,53 @@
-"""Module placeholder.
+"""engine.backtest.strategies.ma_crossover
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Moving average crossover:
+- long when fast_ma > slow_ma
+- flat otherwise
+
+No shorting in v1.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+def _sma(x: np.ndarray, n: int) -> np.ndarray:
+    x = x.astype(np.float64)
+    if n <= 1:
+        return x
+    out = np.full_like(x, np.nan, dtype=np.float64)
+    if x.size < n:
+        return out
+
+    csum = np.cumsum(x, dtype=np.float64)
+    # rolling sum for windows ending at i (inclusive): sum[x[i-n+1:i+1]]
+    roll_sum = csum[n - 1 :].copy()
+    roll_sum[1:] = roll_sum[1:] - csum[:-n]
+    out[n - 1 :] = roll_sum / float(n)
+    return out
+
+
+@dataclass(frozen=True, slots=True)
+class MACrossoverStrategy(Strategy):
+    name: str = "ma_crossover"
+    fast: int = 10
+    slow: int = 50
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        fast = int(self.fast)
+        slow = int(self.slow)
+        if t_len == 0 or fast <= 0 or slow <= 0 or fast >= slow:
+            return StrategyResult(signal=sig)
+
+        f = _sma(close, fast)
+        s = _sma(close, slow)
+        mask = np.isfinite(f) & np.isfinite(s)
+        sig[mask & (f > s)] = 1.0
+        return StrategyResult(signal=sig)

--- a/engine/backtest/strategies/mean_reversion.py
+++ b/engine/backtest/strategies/mean_reversion.py
@@ -1,4 +1,60 @@
-"""Module placeholder.
+"""engine.backtest.strategies.mean_reversion
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Z-score mean reversion (long-only):
+- compute rolling mean/std of close
+- long when z < -entry_z
+- exit when z > -exit_z
+
+Toy baseline.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+def _rolling_mean_std(x: np.ndarray, n: int) -> tuple[np.ndarray, np.ndarray]:
+    x = x.astype(np.float64)
+    mu = np.full_like(x, np.nan, dtype=np.float64)
+    sd = np.full_like(x, np.nan, dtype=np.float64)
+    if n <= 1 or x.size == 0:
+        return mu, sd
+
+    for i in range(n, x.size):
+        w = x[i - n : i]
+        mu[i] = float(np.mean(w))
+        sd[i] = float(np.std(w, ddof=1)) if n > 1 else 0.0
+    return mu, sd
+
+
+@dataclass(frozen=True, slots=True)
+class MeanReversionStrategy(Strategy):
+    name: str = "mean_reversion"
+    lookback: int = 20
+    entry_z: float = 1.0
+    exit_z: float = 0.2
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        n = int(self.lookback)
+        if t_len == 0 or n <= 2:
+            return StrategyResult(signal=sig)
+
+        mu, sd = _rolling_mean_std(close, n)
+        in_pos = False
+        for i in range(t_len):
+            if not np.isfinite(mu[i]) or not np.isfinite(sd[i]) or sd[i] == 0:
+                continue
+            z = float((close[i] - mu[i]) / sd[i])
+            if not in_pos and z < -float(self.entry_z):
+                in_pos = True
+            elif in_pos and z > -float(self.exit_z):
+                in_pos = False
+            sig[i] = 1.0 if in_pos else 0.0
+
+        return StrategyResult(signal=sig)

--- a/engine/backtest/strategies/rsi_reversion.py
+++ b/engine/backtest/strategies/rsi_reversion.py
@@ -1,4 +1,67 @@
-"""Module placeholder.
+"""engine.backtest.strategies.rsi_reversion
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+RSI reversion (long-only):
+- long when RSI < oversold
+- flat when RSI > exit
+
+This is a toy baseline.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+def _rsi(close: np.ndarray, n: int) -> np.ndarray:
+    close = close.astype(np.float64)
+    if n <= 1 or close.size == 0:
+        return np.full_like(close, np.nan, dtype=np.float64)
+
+    diff = np.diff(close, prepend=close[0])
+    up = np.maximum(diff, 0.0)
+    down = np.maximum(-diff, 0.0)
+
+    # Wilder smoothing (EMA-like)
+    rsi = np.full_like(close, np.nan, dtype=np.float64)
+    avg_up = np.mean(up[1 : n + 1])
+    avg_down = np.mean(down[1 : n + 1])
+
+    for i in range(n + 1, close.size):
+        avg_up = (avg_up * (n - 1) + up[i]) / n
+        avg_down = (avg_down * (n - 1) + down[i]) / n
+        rs = avg_up / avg_down if avg_down > 0 else np.inf
+        rsi[i] = 100.0 - (100.0 / (1.0 + rs))
+
+    return rsi
+
+
+@dataclass(frozen=True, slots=True)
+class RSIReversionStrategy(Strategy):
+    name: str = "rsi_reversion"
+    period: int = 14
+    oversold: float = 30.0
+    exit: float = 50.0
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        period = int(self.period)
+        if t_len == 0 or period <= 1:
+            return StrategyResult(signal=sig)
+
+        r = _rsi(close, period)
+        in_pos = False
+        for i in range(t_len):
+            if not np.isfinite(r[i]):
+                continue
+            if not in_pos and r[i] < float(self.oversold):
+                in_pos = True
+            elif in_pos and r[i] > float(self.exit):
+                in_pos = False
+            sig[i] = 1.0 if in_pos else 0.0
+
+        return StrategyResult(signal=sig)

--- a/engine/backtest/strategies/trend_following.py
+++ b/engine/backtest/strategies/trend_following.py
@@ -1,4 +1,33 @@
-"""Module placeholder.
+"""engine.backtest.strategies.trend_following
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Trend following baseline (long-only):
+- long when close > SMA(lookback)
+- flat otherwise
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+from engine.backtest.strategies.ma_crossover import _sma
+
+
+@dataclass(frozen=True, slots=True)
+class TrendFollowingStrategy(Strategy):
+    name: str = "trend_following"
+    lookback: int = 50
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        n = int(self.lookback)
+        if t_len == 0 or n <= 1:
+            return StrategyResult(signal=sig)
+
+        ma = _sma(close, n)
+        mask = np.isfinite(ma)
+        sig[mask & (close > ma)] = 1.0
+        return StrategyResult(signal=sig)

--- a/engine/backtest/strategies/volatility.py
+++ b/engine/backtest/strategies/volatility.py
@@ -1,4 +1,41 @@
-"""Module placeholder.
+"""engine.backtest.strategies.volatility
 
-Hashcash lineage precedes Bitcoin (1997). The code remembers.
+Volatility filter baseline (long-only):
+- compute rolling std of returns
+- long when vol < max_vol (avoid chaotic regimes)
+
+This is a toy strategy that demonstrates feature gating.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.strategies.base import Strategy, StrategyResult
+
+
+@dataclass(frozen=True, slots=True)
+class VolatilityFilterStrategy(Strategy):
+    name: str = "volatility"
+    lookback: int = 20
+    max_vol: float = 0.05
+
+    def generate(self, *, close: np.ndarray, high=None, low=None, volume=None) -> StrategyResult:
+        t_len = close.shape[0]
+        sig = np.zeros(t_len, dtype=np.float64)
+        n = int(self.lookback)
+        if t_len == 0 or n <= 2:
+            return StrategyResult(signal=sig)
+
+        ret = np.zeros(t_len, dtype=np.float64)
+        ret[1:] = (close[1:] / close[:-1]) - 1.0
+
+        vol = np.full(t_len, np.nan, dtype=np.float64)
+        for i in range(n, t_len):
+            vol[i] = float(np.std(ret[i - n : i], ddof=1))
+
+        mask = np.isfinite(vol)
+        sig[mask & (vol < float(self.max_vol))] = 1.0
+        return StrategyResult(signal=sig)

--- a/tests/unit/test_backtest_strategies_smoke.py
+++ b/tests/unit/test_backtest_strategies_smoke.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+
+from engine.backtest.engine import run_backtest
+from engine.backtest.strategies import (
+    BreakoutStrategy,
+    CombinedStrategy,
+    FundingArbStrategy,
+    MACrossoverStrategy,
+    MeanReversionStrategy,
+    MomentumStrategy,
+    RSIReversionStrategy,
+    TrendFollowingStrategy,
+    VolatilityFilterStrategy,
+)
+
+
+def test_strategies_smoke_run():
+    close = np.linspace(100.0, 110.0, 200).astype(np.float64)
+    high = close * 1.01
+
+    strategies = [
+        MomentumStrategy(lookback=20, threshold=0.01),
+        MACrossoverStrategy(fast=10, slow=50),
+        RSIReversionStrategy(period=14, oversold=30, exit=50),
+        BreakoutStrategy(lookback=20),
+        MeanReversionStrategy(lookback=20, entry_z=1.0, exit_z=0.2),
+        TrendFollowingStrategy(lookback=50),
+        VolatilityFilterStrategy(lookback=20, max_vol=0.05),
+        CombinedStrategy(mom_lookback=20, mom_threshold=0.01, fast=10, slow=50),
+        FundingArbStrategy(),
+    ]
+
+    for s in strategies:
+        res = run_backtest(strategy=s, close=close, high=high)
+        assert res.sim.equity.shape[0] == close.shape[0]


### PR DESCRIPTION
Sprint B1b — replace placeholder strategy modules with baseline implementations.

- Implemented: MA crossover, RSI reversion, breakout, mean reversion, trend following, volatility filter
- Implemented: Combined strategy (momentum OR MA crossover)
- Funding arb remains a flat baseline (real arb needs funding/basis series, slated for B1c)
- Added strategies/__init__ exports
- Added smoke test to ensure all strategies run end-to-end

Tests: `pytest --ignore=tests/unit/test_eas_client.py` (300 passed locally)