### PR TITLE
B1c: Walk-forward validation + bootstrap p-values + BH-FDR

### DIFF
--- a/engine/backtest/__init__.py
+++ b/engine/backtest/__init__.py
@@ -2,6 +2,7 @@
 
 Backtest engine (B1).
 
-B1a implements a minimal simulator + metrics. B1b will implement the full
-strategy library + walk-forward validation + FDR correction.
+B1a implements a minimal simulator + metrics.
+B1b implements baseline strategies.
+B1c implements walk-forward validation + FDR correction.
 """

--- a/engine/backtest/stats.py
+++ b/engine/backtest/stats.py
@@ -1,0 +1,65 @@
+"""engine.backtest.stats
+
+Statistical testing helpers for backtests (B1c).
+
+This is not academic finance. It's a guardrail:
+- p-value via simple bootstrap against a null of zero-mean returns
+- FDR correction (Benjamini–Hochberg)
+
+If the test says 'noise', treat it as noise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class TestResult:
+    statistic: float
+    p_value: float
+
+
+def bootstrap_p_value_mean_gt_zero(
+    returns: np.ndarray,
+    *,
+    n_boot: int = 2000,
+    seed: int = 0,
+) -> TestResult:
+    """Bootstrap p-value for mean(returns) > 0.
+
+    Null: mean == 0. Uses sign-flip bootstrap.
+    """
+
+    r = returns.astype(np.float64)
+    if r.size < 5:
+        return TestResult(statistic=float(np.mean(r) if r.size else 0.0), p_value=1.0)
+
+    rng = np.random.default_rng(int(seed))
+    obs = float(np.mean(r))
+
+    # sign-flip: symmetric around 0
+    flips = rng.choice([-1.0, 1.0], size=(n_boot, r.size))
+    sims = np.mean(flips * r[None, :], axis=1)
+    p = float((np.sum(sims >= obs) + 1.0) / (n_boot + 1.0))
+    return TestResult(statistic=obs, p_value=p)
+
+
+def benjamini_hochberg(p_values: list[float], *, q: float = 0.05) -> list[bool]:
+    """Return boolean mask of discoveries under BH-FDR."""
+
+    if not p_values:
+        return []
+    m = len(p_values)
+    pv = np.array(p_values, dtype=np.float64)
+    order = np.argsort(pv)
+    thresh = q * (np.arange(1, m + 1) / m)
+    passed = pv[order] <= thresh
+    if not np.any(passed):
+        return [False] * m
+
+    k = int(np.max(np.where(passed)[0]))
+    cutoff = float(pv[order][k])
+    return [float(p) <= cutoff for p in p_values]

--- a/engine/backtest/walkforward.py
+++ b/engine/backtest/walkforward.py
@@ -1,0 +1,120 @@
+"""engine.backtest.walkforward
+
+Walk-forward validation harness (B1c).
+
+Goal: prevent self-deception.
+- Rolling train/test windows
+- Optional embargo between train and test
+- Strategy evaluated out-of-sample per window
+
+This is single-asset v1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from engine.backtest.engine import BacktestConfig, BacktestResult, run_backtest
+from engine.backtest.strategies.base import Strategy
+
+
+@dataclass(frozen=True, slots=True)
+class Window:
+    train_start: int
+    train_end: int
+    test_start: int
+    test_end: int
+
+
+def build_windows(
+    *,
+    t_len: int,
+    train_size: int,
+    test_size: int,
+    step_size: int,
+    embargo: int = 0,
+) -> list[Window]:
+    if t_len <= 0:
+        return []
+    if train_size <= 0 or test_size <= 0 or step_size <= 0:
+        raise ValueError("train_size/test_size/step_size must be > 0")
+
+    out: list[Window] = []
+    start = 0
+    while True:
+        train_start = start
+        train_end = train_start + train_size
+        test_start = train_end + embargo
+        test_end = test_start + test_size
+        if test_end > t_len:
+            break
+        out.append(Window(train_start=train_start, train_end=train_end, test_start=test_start, test_end=test_end))
+        start += step_size
+    return out
+
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardResult:
+    windows: list[Window]
+    window_metrics: list[dict[str, float]]
+    combined_oos_equity: np.ndarray
+    combined_oos_returns: np.ndarray
+
+
+def run_walkforward(
+    *,
+    strategy: Strategy,
+    close: np.ndarray,
+    high: np.ndarray | None = None,
+    low: np.ndarray | None = None,
+    volume: np.ndarray | None = None,
+    train_size: int,
+    test_size: int,
+    step_size: int,
+    embargo: int = 0,
+    cfg: BacktestConfig | None = None,
+) -> WalkForwardResult:
+    t_len = int(close.shape[0])
+    windows = build_windows(t_len=t_len, train_size=train_size, test_size=test_size, step_size=step_size, embargo=embargo)
+
+    # For now strategies have no fit() step; train window is informational.
+    # We evaluate OOS by slicing test windows.
+    all_returns: list[np.ndarray] = []
+    all_equity: list[np.ndarray] = []
+    metrics: list[dict[str, float]] = []
+
+    for w in windows:
+        test_close = close[w.test_start : w.test_end]
+        test_high = high[w.test_start : w.test_end] if high is not None else None
+        test_low = low[w.test_start : w.test_end] if low is not None else None
+        test_vol = volume[w.test_start : w.test_end] if volume is not None else None
+
+        bt: BacktestResult = run_backtest(strategy=strategy, close=test_close, high=test_high, low=test_low, volume=test_vol, cfg=cfg)
+        all_returns.append(bt.sim.returns)
+        all_equity.append(bt.sim.equity)
+        metrics.append(
+            {
+                "total_return": float(bt.metrics.total_return),
+                "sharpe": float(bt.metrics.sharpe),
+                "max_drawdown": float(bt.metrics.max_drawdown),
+            }
+        )
+
+    if not all_returns:
+        return WalkForwardResult(windows=windows, window_metrics=metrics, combined_oos_equity=np.zeros(0), combined_oos_returns=np.zeros(0))
+
+    combined_returns = np.concatenate(all_returns).astype(np.float64)
+
+    # Combine equity by compounding across windows
+    eq = np.ones(combined_returns.shape[0], dtype=np.float64)
+    for i in range(1, eq.shape[0]):
+        eq[i] = eq[i - 1] * (1.0 + combined_returns[i])
+
+    return WalkForwardResult(
+        windows=windows,
+        window_metrics=metrics,
+        combined_oos_equity=eq,
+        combined_oos_returns=combined_returns,
+    )

--- a/tests/unit/test_backtest_walkforward.py
+++ b/tests/unit/test_backtest_walkforward.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+
+from engine.backtest.stats import benjamini_hochberg, bootstrap_p_value_mean_gt_zero
+from engine.backtest.strategies.momentum import MomentumStrategy
+from engine.backtest.walkforward import build_windows, run_walkforward
+
+
+def test_build_windows_basic():
+    w = build_windows(t_len=100, train_size=50, test_size=20, step_size=10, embargo=2)
+    assert len(w) > 0
+    assert w[0].train_start == 0
+    assert w[0].train_end == 50
+    assert w[0].test_start == 52
+
+
+def test_walkforward_runs():
+    close = np.linspace(100.0, 110.0, 200).astype(np.float64)
+    strat = MomentumStrategy(lookback=10, threshold=0.001)
+    res = run_walkforward(strategy=strat, close=close, train_size=80, test_size=40, step_size=40, embargo=2)
+    assert res.combined_oos_returns.size > 0
+    assert res.combined_oos_equity.size == res.combined_oos_returns.size
+
+
+def test_bootstrap_p_value():
+    r = np.array([0.01] * 50, dtype=np.float64)
+    tr = bootstrap_p_value_mean_gt_zero(r, n_boot=200, seed=1)
+    assert 0.0 <= tr.p_value <= 1.0
+
+
+def test_bh_fdr_mask():
+    p = [0.001, 0.02, 0.2, 0.9]
+    mask = benjamini_hochberg(p, q=0.05)
+    assert mask[0] is True
+    assert mask[-1] is False


### PR DESCRIPTION
Sprint B1c — stop lying to ourselves: walk-forward validation + multiple-testing discipline.

- Adds walk-forward window builder + OOS evaluation harness
- Adds bootstrap p-value test for mean returns > 0 (sign-flip)
- Adds Benjamini–Hochberg FDR correction helper
- Adds unit tests (windows, walk-forward run, bootstrap, BH)

Tests: `pytest --ignore=tests/unit/test_eas_client.py` (304 passed locally)