### PR TITLE
feat: parameter grid sweep + FDR across grid (B1e)

### DIFF
--- a/engine/backtest/sweep.py
+++ b/engine/backtest/sweep.py
@@ -26,6 +26,7 @@ Correcting once across the whole grid keeps FDR ≤ q.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import itertools
 from dataclasses import dataclass
 from typing import Any
@@ -149,6 +150,17 @@ def make_strategy(name: str, params: dict[str, Any]) -> Strategy:
 # ---------------------------------------------------------------------------
 
 
+def _combo_seed(base_seed: int, strategy: str, combo: dict[str, Any]) -> int:
+    """Derive a deterministic seed from the strategy name and param values.
+
+    This ensures the bootstrap RNG stream is tied to the *identity* of the
+    combo, not its iteration order — so reordering ``--param`` flags or
+    grid declarations produces identical results.
+    """
+    key = f"{base_seed}:{strategy}:" + ";".join(f"{k}={v}" for k, v in sorted(combo.items()))
+    return int(hashlib.sha256(key.encode()).hexdigest()[:8], 16)
+
+
 def _expand_grid(params: dict[str, list[Any]]) -> list[dict[str, Any]]:
     """Expand a dict of param->values into all combinations."""
     if not params:
@@ -233,7 +245,7 @@ def run_grid_sweep(
     partial_results: list[dict[str, Any]] = []
     p_values: list[float] = []
 
-    for i, combo in enumerate(combos):
+    for combo in combos:
         strat = make_strategy(config.strategy, combo)
         wf = run_walkforward(
             strategy=strat,
@@ -262,7 +274,8 @@ def run_grid_sweep(
             oos_sharpe = 0.0
             oos_max_drawdown = 0.0
 
-        test_result = bootstrap_p_value_mean_gt_zero(oos_returns, n_boot=n_boot, seed=seed + i)
+        combo_rng_seed = _combo_seed(seed, config.strategy, combo)
+        test_result = bootstrap_p_value_mean_gt_zero(oos_returns, n_boot=n_boot, seed=combo_rng_seed)
         p_values.append(test_result.p_value)
 
         partial_results.append(

--- a/engine/cli.py
+++ b/engine/cli.py
@@ -2035,6 +2035,9 @@ def _handle_backtest_gridsweep(args: argparse.Namespace) -> int:
         except ValueError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
+        if name in param_grid:
+            print(f"error: duplicate --param {name!r}. Specify all values in one flag: --param {name}=v1,v2,...", file=sys.stderr)
+            return 2
         param_grid[name] = values
 
     # --- validate param names exist on the strategy ---

--- a/tests/unit/test_backtest_gridsweep.py
+++ b/tests/unit/test_backtest_gridsweep.py
@@ -342,3 +342,62 @@ def test_expand_grid_single() -> None:
 
 def test_expand_grid_empty() -> None:
     assert _expand_grid({}) == [{}]
+
+
+# ---------------------------------------------------------------------------
+# 10. Deterministic combo seeds (PR #69 review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_combo_seed_order_independent() -> None:
+    """Reordering params in the grid should not change p-values."""
+    from engine.backtest.sweep import _combo_seed
+
+    # Same combo, different dict ordering
+    seed_a = _combo_seed(42, "momentum", {"lookback": 10, "threshold": 0.01})
+    seed_b = _combo_seed(42, "momentum", {"threshold": 0.01, "lookback": 10})
+    assert seed_a == seed_b
+
+
+def test_combo_seed_differs_across_combos() -> None:
+    from engine.backtest.sweep import _combo_seed
+
+    seed_a = _combo_seed(42, "momentum", {"lookback": 10})
+    seed_b = _combo_seed(42, "momentum", {"lookback": 20})
+    assert seed_a != seed_b
+
+
+# ---------------------------------------------------------------------------
+# 11. Reject duplicate --param names (PR #69 review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_duplicate_param_rejected(tmp_path: Path) -> None:
+    from engine.cli import main
+
+    csv_path = tmp_path / "prices.csv"
+    _write_prices_csv(csv_path, n=300)
+    rc = main(
+        [
+            "backtest",
+            "gridsweep",
+            "--strategy",
+            "momentum",
+            "--prices",
+            str(csv_path),
+            "--param",
+            "lookback=10,20",
+            "--param",
+            "lookback=30,40",
+            "--train",
+            "60",
+            "--test",
+            "30",
+            "--step",
+            "30",
+            "--bootstrap",
+            "100",
+            "--json",
+        ]
+    )
+    assert rc == 2


### PR DESCRIPTION
## B1e: Parameter Grid Runner + FDR Across Grid

### What it adds
- **`b1e55ed backtest gridsweep`** CLI command
- Grid sweep engine (`engine/backtest/sweep.py`) — itertools.product over param grids, walk-forward per combo, BH-FDR correction across ALL combos
- `make_strategy()` helper — instantiate any strategy by name + params with validation
- `--param` repeatable flag — auto-detects int vs float
- Human-readable table + JSON output

### Why this matters
Single walk-forward (B1d) is a toy. Sweeping a parameter grid with BH-FDR correction across the whole grid separates signal from noise.

### Tests
- 13 new tests
- Full suite: **317 passed**, mypy clean

### Next
B1f+ — multi-strategy sweep