### PR TITLE
fix: EAS verify tamper detection + document uninstall command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,6 +19,21 @@ b1e55ed wizard
 Covers: identity forge → config → producer registration → brain first run → API setup.
 From source: `./b1e55ed wizard` or `uv run b1e55ed wizard`.
 
+### `b1e55ed uninstall`
+
+Removes b1e55ed from the system. Prompts for confirmation unless `--yes` is given.
+
+```text
+b1e55ed uninstall [--yes] [--keep-data]
+```
+
+| Flag | Description |
+|---|---|
+| `--yes` | Skip confirmation prompts |
+| `--keep-data` | Preserve the data directory (brain DB, logs, config) |
+
+Alternatively, run the standalone script: `./uninstall.sh`.
+
 ### `b1e55ed setup`
 
 Low-level setup. Writes `config/user.yaml`, initializes `data/brain.db`. The wizard calls this internally.

--- a/engine/integrations/eas.py
+++ b/engine/integrations/eas.py
@@ -245,6 +245,21 @@ class EASClient:
 
             if not attester:
                 return False
+
+            # Consistency check: data_bytes must match data dict if both present
+            data_field = attestation.get("data")
+            if data_field is not None and isinstance(data_field, dict):
+                import json
+
+                # Re-encode data_bytes to compare
+                try:
+                    decoded = json.loads(payload_bytes.decode("utf-8"))
+                    # Sort keys for deterministic comparison
+                    if json.dumps(decoded, sort_keys=True, separators=(",", ":")) != json.dumps(data_field, sort_keys=True, separators=(",", ":")):
+                        return False
+                except Exception:
+                    return False
+
             return recovered == attester
         except Exception:
             return False


### PR DESCRIPTION
## Summary

Fixes two CI failures introduced by recent direct-to-main commits.

### Fix 1 — EAS offchain attestation tamper detection

`verify_offchain_attestation` was verifying the signature against `data_bytes` but not checking consistency between `data_bytes` and the decoded `data` dict. An attacker could tamper with the `data` field while leaving `data_bytes` untouched and verification would pass.

Added a consistency check: if both `data` and `data_bytes` are present, verify they decode to the same content. Returns `False` if inconsistent.

Fixes: `tests/unit/test_eas_client.py::test_offchain_attestation_sign_and_verify`

### Fix 2 — Document `uninstall` command in CLI reference

`scripts/check_cli_docs.py` enforces that every CLI command has a docs entry. The `uninstall` command was added but `docs/cli-reference.md` was not updated.

Added `uninstall` section to the CLI reference.

Fixes: `docs.yml / cli-docs` job

## Tests

- `test_eas_client.py` — now passes including tamper detection
- `check_cli_docs.py` — passes with uninstall documented