### PR TITLE
chore: bump version to 1.0.0-beta.5

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -22,7 +22,7 @@ try:
 
     __version__ = _pkg_version("b1e55ed")
 except Exception:
-    __version__ = "1.0.0-beta.4"  # fallback when running from source without install
+    __version__ = "1.0.0-beta.5"  # fallback when running from source without install
 
 # 0xb1e55ed = "blessed"
 BLESSED_HEX = 0xB1E55ED

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "b1e55ed"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 description = "Sovereign AI trading intelligence with compound learning"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bumps `pyproject.toml` and the `engine/__init__.py` fallback from `1.0.0-beta.4` → `1.0.0-beta.5`.

**After merging**: tag `v1.0.0-beta.5` to trigger `forge-release.yml`, which builds and uploads the Rust `b1e55ed-forge` binaries for macOS arm64, macOS x86_64, and Linux x86_64 as release assets.

## What beta.5 includes (since beta.4)
- macOS install: uv Python bootstrap, stderr suppression
- `eth-account` moved to default deps (forge works out of the box)
- Wizard: symbol pack presets, enforced vanity identity, GitHub token prominence
- `b1e55ed uninstall` command + `uninstall.sh`
- GitHub App auth integration (App ID 2953603)
- Version reads from `importlib.metadata` (single source of truth)
- EAS offchain tamper detection fix
- Workflows no longer push directly to main