### PR TITLE
fix: forge-release job needs contents:write permission to upload assets

### DIFF
--- a/.github/workflows/forge-release.yml
+++ b/.github/workflows/forge-release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Problem

The `Build Forge Binaries` workflow was successfully compiling the Rust binary (17.94s build on macOS arm64) but failing to upload with:

```
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v1.0.0-beta.5
HttpError: Resource not accessible by integration
```

The `build` job was missing `permissions: contents: write`, so `GITHUB_TOKEN` had read-only access and could not upload release assets.

## Fix

Adds `permissions: contents: write` to the `build` job.

## After merging

Re-trigger via: Actions → Build Forge Binaries → Run workflow → ref: `refs/tags/v1.0.0-beta.5`