### PR TITLE
fix: forge workflow_dispatch accepts tag_name input

### DIFF
--- a/.github/workflows/forge-release.yml
+++ b/.github/workflows/forge-release.yml
@@ -3,7 +3,12 @@ name: Build Forge Binaries
 on:
   release:
     types: [published]
-  workflow_dispatch:  # allow manual trigger
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to upload binaries to (e.g. v1.0.0-beta.5)'
+        required: false
+        default: 'v1.0.0-beta.5'
 
 jobs:
   build:
@@ -40,6 +45,7 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: tools/forge/${{ matrix.artifact }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

When `Build Forge Binaries` is triggered via `workflow_dispatch` on `main`, `github.ref_name` is `main` — so `softprops/action-gh-release` can't find the release to upload to.

## Fix

Adds a `tag_name` input (default: `v1.0.0-beta.5`) to the `workflow_dispatch` trigger. The upload step uses `${{ github.event.inputs.tag_name || github.ref_name }}`, so:
- Manual dispatch on `main` → uses the input tag
- Automatic dispatch on a release event → uses `github.ref_name` (the tag)

## After merging

Trigger via: **Actions → Build Forge Binaries → Run workflow → branch: main → tag: v1.0.0-beta.5**