### PR TITLE
fix: resolve release tag via API — /releases/latest skips pre-releases

### DIFF
--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -417,7 +417,23 @@ def _auto_download_forge() -> str | None:
         print(f"  {yellow('⚠')} No pre-built binary for {system}/{machine}.")
         return None
 
-    url = f"https://github.com/P-U-C/b1e55ed/releases/latest/download/{artifact}"
+    # /releases/latest skips pre-releases — resolve tag via API instead
+    try:
+        with urllib.request.urlopen(  # noqa: S310
+            "https://api.github.com/repos/P-U-C/b1e55ed/releases?per_page=1"
+        ) as resp:
+            import json as _json
+
+            releases = _json.loads(resp.read())
+            tag = releases[0]["tag_name"] if releases else None
+    except Exception:  # noqa: BLE001
+        tag = None
+
+    if not tag:
+        print(f"  {red('✗')} Could not resolve latest release tag.")
+        return None
+
+    url = f"https://github.com/P-U-C/b1e55ed/releases/download/{tag}/{artifact}"
     dest_dir = Path.home() / ".local" / "share" / "b1e55ed" / "bin"
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / "b1e55ed-forge"

--- a/install.sh
+++ b/install.sh
@@ -227,15 +227,21 @@ info "Downloading Rust forge binary..."
 FORGE_DIR="$HOME/.local/share/b1e55ed/bin"
 mkdir -p "$FORGE_DIR"
 
+# Resolve latest release tag (including pre-releases — /releases/latest skips them)
+RELEASE_TAG=$(curl -fsSL "https://api.github.com/repos/P-U-C/b1e55ed/releases?per_page=1" 2>/dev/null \
+    | python3 -c "import sys,json; r=json.load(sys.stdin); print(r[0]['tag_name'])" 2>/dev/null || echo "")
+
 # Detect platform
 FORGE_URL=""
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # Universal binary — works on both Apple Silicon and Intel
-    FORGE_URL="https://github.com/P-U-C/b1e55ed/releases/latest/download/b1e55ed-forge-macos"
-elif [[ "$OSTYPE" == "linux"* ]]; then
-    ARCH=$(uname -m)
-    if [[ "$ARCH" == "x86_64" ]]; then
-        FORGE_URL="https://github.com/P-U-C/b1e55ed/releases/latest/download/b1e55ed-forge-linux-x86_64"
+if [ -n "$RELEASE_TAG" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # Universal binary — works on both Apple Silicon and Intel
+        FORGE_URL="https://github.com/P-U-C/b1e55ed/releases/download/${RELEASE_TAG}/b1e55ed-forge-macos"
+    elif [[ "$OSTYPE" == "linux"* ]]; then
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "x86_64" ]]; then
+            FORGE_URL="https://github.com/P-U-C/b1e55ed/releases/download/${RELEASE_TAG}/b1e55ed-forge-linux-x86_64"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Root Cause

`https://github.com/.../releases/latest/download/...` returns **404 for pre-releases**. GitHub's `/releases/latest` endpoint only resolves to non-pre-release versions. Since `v1.0.0-beta.5` is a pre-release, the binary URL 404ed even though the asset exists on the release.

## Fix

Both `install.sh` and `wizard.py` now hit the GitHub API (`/releases?per_page=1`) to resolve the actual latest tag (including pre-releases), then build the explicit download URL:
```
https://github.com/P-U-C/b1e55ed/releases/download/{tag}/b1e55ed-forge-macos
```

## Files changed
- `install.sh` — resolves tag via `curl | python3` before building URL
- `engine/cli/commands/wizard.py` — `_auto_download_forge()` resolves tag via `urllib.request` before downloading