### PR TITLE
fix: wizard UX polish + zero-credential contributor registration via oracle

### DIFF
--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -732,6 +732,78 @@ dashboard:
         print(f"  {dim('Create config/user.yaml manually.')}")
 
 
+def _step_register_contributor(repo_root: Path) -> None:
+    """Auto-register the new contributor after identity forge + config write."""
+    import json as _json
+
+    _section("[4b] Contributor registration")
+
+    identity_path = repo_root / ".b1e55ed" / "identity.json"
+    if not identity_path.exists():
+        print(f"  {dim('No identity found — skipping registration.')}")
+        print(f"  {dim('Run: b1e55ed contributors register --name <handle> --role contributor')}")
+        return
+
+    try:
+        data = _json.loads(identity_path.read_text(encoding="utf-8"))
+        node_id = data.get("node_id", "")
+        address = data.get("address", "")
+    except Exception:  # noqa: BLE001
+        print(f"  {yellow('⚠')} Could not read identity — skipping registration.")
+        return
+
+    if not node_id:
+        print(f"  {yellow('⚠')} Identity missing node_id — skipping registration.")
+        return
+
+    print(f"  Registering contributor: {dim(node_id)}")
+    print()
+
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "engine.cli",
+                "contributors",
+                "register",
+                "--node-id",
+                node_id,
+                "--name",
+                address or node_id,
+                "--role",
+                "contributor",
+            ],
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode == 0:
+            try:
+                result = _json.loads(proc.stdout)
+                cid = result.get("contributor", {}).get("id", "")
+                gh = result.get("contributor", {}).get("metadata", {}).get("publish", {}).get("github", {})
+                issue_url = gh.get("html_url", "") if isinstance(gh, dict) else ""
+                print(f"  {_ok(f'Registered as contributor (id: {cid[:8]}...)')}")
+                if issue_url:
+                    print(f"  {_ok(f'GitHub issue created: {issue_url}')}")
+                else:
+                    print(f"  {dim('(GitHub issue skipped — set B1E55ED_GITHUB_APP_KEY to enable)')}")
+            except Exception:  # noqa: BLE001
+                print(f"  {_ok('Registered as contributor')}")
+        elif "already exists" in (proc.stderr or ""):
+            print(f"  {_ok('Already registered — skipping.')}")
+        else:
+            print(f"  {yellow('⚠')} Registration failed (code {proc.returncode}) — run manually:")
+            print(f"  {dim('b1e55ed contributors register --name <handle> --role contributor')}")
+    except subprocess.TimeoutExpired:
+        print(f"  {yellow('⚠')} Registration timed out — run manually: b1e55ed contributors register")
+    except Exception as e:  # noqa: BLE001
+        print(f"  {yellow('⚠')} Could not register: {e}")
+
+
 def _step5_test_run(repo_root: Path) -> None:
     """Optional first-run brain test."""
     _section("[5/5] Test run")
@@ -806,6 +878,7 @@ def run_wizard(ctx: CliContext, args: argparse.Namespace) -> int:  # noqa: ARG00
         lambda: _step2_password(),
         lambda: _step3_identity(repo_root),
         lambda: _step4_configuration(repo_root),
+        lambda: _step_register_contributor(repo_root),
         lambda: _step5_test_run(repo_root),
     ]
 

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -1398,17 +1398,27 @@ def _build_contributor_registry_with_eas(*, db: Database, config: Config) -> Con
 
     from engine.core.contributors import ContributorRegistry
 
-    # GitHub publisher — always active when token is configured (fail-open)
+    # GitHub publisher — active when token OR GitHub App is configured (fail-open)
     github_publisher: object | None = None
     pub_cfg = config.publish.github
-    if pub_cfg.token:
+    if pub_cfg.token or (int(pub_cfg.app_id or 0) > 0):
         from engine.integrations.github_publish import make_publisher
+
+        app_auth = None
+        if int(pub_cfg.app_id or 0) > 0:
+            try:
+                from engine.integrations.github_app import GitHubAppAuth
+
+                app_auth = GitHubAppAuth.from_env()
+            except Exception:
+                pass
 
         github_publisher = make_publisher(
             owner=pub_cfg.owner,
             repo=pub_cfg.repo,
-            token=pub_cfg.token,
+            token=str(pub_cfg.token or ""),
             labels=pub_cfg.labels,
+            app_auth=app_auth,
         )
 
     # EAS client — only when explicitly enabled


### PR DESCRIPTION
## Changes

### 1. Forge + wizard banner polish
- Forge banner width 38→42 inner chars (matches wizard)
- Text centered
- Wizard subtitle shows real version via `importlib.metadata` (not hardcoded `v1.x`)

### 2. Brain test → health check
- Was: `brain --symbols BTC --dry-run` (args do not exist)
- Now: `b1e55ed health`

### 3. Contributor auto-registration (step [4b]) — zero credentials
After identity forge + config write, the wizard:
1. Calls `POST oracle.b1e55ed.xyz/api/v1/oracle/contributors/register` with `{node_id, address, role}`
2. The oracle (which holds the GitHub App key) creates the GitHub issue server-side
3. Returns the issue URL — shown to the user
4. Also registers locally (idempotent fallback if oracle unreachable)

New users need **no credentials at all** — the community App was created for exactly this purpose.

### 4. New public oracle endpoint: `POST /api/v1/oracle/contributors/register`
- No auth required (public)
- Validates `node_id` starts with `eth:0xb1e55ed`
- Registers contributor in oracle DB + fires GitHub issue via App key
- Returns `{contributor_id, node_id, issue_url}`
- Idempotent: returns existing registration on 409

### 5. Fix GitHub App auth in publisher builder
- `api/deps.py` `get_publisher()` — was: only activated on `token`; now: also activates on `app_id > 0`
- `engine/cli/main.py` `_build_contributor_registry_with_eas()` — same fix

## Install flow after this merges
```
[3/5] Identity → forge → ✓ 0xb1e55ed...
[4/5] Config   → written
[4b] Contributor registration
  Registering: eth:0xb1e55ed...
  ✓ Registered as contributor
  ✓ Announced: https://github.com/P-U-C/b1e55ed/issues/NNN
[5/5] Health check passed
```

> Note: oracle must be running with `B1E55ED_GITHUB_APP_KEY` set for issue creation to work. Oracle falls back gracefully if App key not configured.