### PR TITLE
feat: zero-credential contributor registration via oracle relay

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -82,21 +82,35 @@ def get_karma(request: Request) -> KarmaEngine:
 
 
 def get_publisher(request: Request) -> object | None:
-    """Return a bound GitHub publisher callable, or None if no token configured.
+    """Return a bound GitHub publisher callable, or None if not configured.
 
-    The publisher is fail-open — returns None on failure rather than raising.
-    Consumers should inject this and pass to ContributorRegistry; the registry
-    handles the None case gracefully.
+    Supports both static PAT (publish.github.token) and GitHub App auth
+    (publish.github.app_id + B1E55ED_GITHUB_APP_KEY env var).
+    Fail-open — returns None on failure rather than raising.
     """
     from engine.integrations.github_publish import make_publisher
 
     cfg = get_config(request)
     pub_cfg = cfg.publish.github
-    if not pub_cfg.token:
+    has_token = bool(pub_cfg.token)
+    has_app = int(pub_cfg.app_id or 0) > 0
+
+    if not has_token and not has_app:
         return None
+
+    app_auth = None
+    if has_app:
+        try:
+            from engine.integrations.github_app import GitHubAppAuth
+
+            app_auth = GitHubAppAuth.from_env()
+        except Exception:
+            pass
+
     return make_publisher(
         owner=pub_cfg.owner,
         repo=pub_cfg.repo,
-        token=pub_cfg.token,
+        token=str(pub_cfg.token or ""),
         labels=pub_cfg.labels,
+        app_auth=app_auth,
     )

--- a/api/routes/oracle.py
+++ b/api/routes/oracle.py
@@ -132,3 +132,86 @@ async def get_producer_provenance(
         },
         note=result.note,
     )
+
+
+# ---------------------------------------------------------------------------
+# Public contributor registration — no auth required.
+# The oracle holds the GitHub App key; new installs call this to get
+# their registration issue created without needing credentials.
+# ---------------------------------------------------------------------------
+
+
+class ContributorRegisterOracleRequest(BaseModel):
+    node_id: str
+    name: str = ""
+    role: str = "contributor"
+
+
+class ContributorRegisterOracleResponse(BaseModel):
+    contributor_id: str
+    node_id: str
+    name: str
+    role: str
+    registered_at: str
+    issue_url: str | None = None
+
+
+@router.post("/contributors/register", response_model=ContributorRegisterOracleResponse)
+def oracle_register_contributor(
+    req: ContributorRegisterOracleRequest,
+    request: Request,
+    db: Database = Depends(get_db),
+) -> ContributorRegisterOracleResponse:
+    """Public endpoint — registers a new contributor and creates a GitHub issue.
+
+    Called by ``b1e55ed wizard`` on new installs.  No authentication required.
+    The oracle supplies GitHub App credentials server-side so installers don't
+    need a token.
+    """
+    from api.deps import get_publisher
+    from engine.core.contributors import ContributorRegistry
+
+    if not req.node_id.startswith("eth:0xb1e55ed"):
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail="node_id must start with eth:0xb1e55ed")
+
+    name = req.name or req.node_id
+    publisher = get_publisher(request)
+    reg = ContributorRegistry(db, github_publisher=publisher)
+
+    try:
+        c = reg.register(node_id=req.node_id, name=name, role=req.role)
+    except ValueError:
+        # Already registered — look up and return existing
+        existing = next((x for x in reg.list_all() if x.node_id == req.node_id), None)
+        if existing:
+            issue_url = None
+            pub = (existing.metadata.get("publish") or {}).get("github") if isinstance(existing.metadata, dict) else None
+            if isinstance(pub, dict):
+                issue_url = pub.get("html_url")
+            return ContributorRegisterOracleResponse(
+                contributor_id=existing.id,
+                node_id=existing.node_id,
+                name=existing.name,
+                role=existing.role,
+                registered_at=existing.registered_at,
+                issue_url=issue_url,
+            )
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=409, detail="contributor already registered") from None
+
+    issue_url: str | None = None
+    pub = (c.metadata.get("publish") or {}).get("github") if isinstance(c.metadata, dict) else None
+    if isinstance(pub, dict):
+        issue_url = pub.get("html_url")
+
+    return ContributorRegisterOracleResponse(
+        contributor_id=c.id,
+        node_id=c.node_id,
+        name=c.name,
+        role=c.role,
+        registered_at=c.registered_at,
+        issue_url=issue_url,
+    )

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -732,16 +732,20 @@ dashboard:
         print(f"  {dim('Create config/user.yaml manually.')}")
 
 
+_ORACLE_URL = "https://oracle.b1e55ed.xyz"
+
+
 def _step_register_contributor(repo_root: Path) -> None:
-    """Auto-register the new contributor after identity forge + config write."""
+    """Auto-register new contributor via the oracle (no credentials needed on user machine)."""
     import json as _json
+    import urllib.error
+    import urllib.request
 
     _section("[4b] Contributor registration")
 
     identity_path = repo_root / ".b1e55ed" / "identity.json"
     if not identity_path.exists():
-        print(f"  {dim('No identity found — skipping registration.')}")
-        print(f"  {dim('Run: b1e55ed contributors register --name <handle> --role contributor')}")
+        print(f"  {dim('No identity — skipping registration.')}")
         return
 
     try:
@@ -749,16 +753,37 @@ def _step_register_contributor(repo_root: Path) -> None:
         node_id = data.get("node_id", "")
         address = data.get("address", "")
     except Exception:  # noqa: BLE001
-        print(f"  {yellow('⚠')} Could not read identity — skipping registration.")
+        print(f"  {yellow('⚠')} Could not read identity — skipping.")
         return
 
     if not node_id:
-        print(f"  {yellow('⚠')} Identity missing node_id — skipping registration.")
         return
 
-    print(f"  Registering contributor: {dim(node_id)}")
+    print(f"  Registering: {dim(node_id)}")
     print()
 
+    # Try oracle first — it holds the GitHub App key, creates the issue server-side
+    issue_url: str | None = None
+    registered = False
+    try:
+        payload = _json.dumps({"node_id": node_id, "name": address or node_id, "role": "contributor"}).encode()
+        req = urllib.request.Request(
+            f"{_ORACLE_URL}/api/v1/oracle/contributors/register",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            result = _json.loads(resp.read())
+            issue_url = result.get("issue_url")
+            registered = True
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            registered = True  # already registered — fine
+    except Exception:  # noqa: BLE001
+        pass  # oracle unreachable — fall through to local
+
+    # Always register locally too (idempotent)
     try:
         proc = subprocess.run(
             [
@@ -780,28 +805,17 @@ def _step_register_contributor(repo_root: Path) -> None:
             text=True,
             timeout=30,
         )
-        if proc.returncode == 0:
-            try:
-                result = _json.loads(proc.stdout)
-                cid = result.get("contributor", {}).get("id", "")
-                gh = result.get("contributor", {}).get("metadata", {}).get("publish", {}).get("github", {})
-                issue_url = gh.get("html_url", "") if isinstance(gh, dict) else ""
-                print(f"  {_ok(f'Registered as contributor (id: {cid[:8]}...)')}")
-                if issue_url:
-                    print(f"  {_ok(f'GitHub issue created: {issue_url}')}")
-                else:
-                    print(f"  {dim('(GitHub issue skipped — set B1E55ED_GITHUB_APP_KEY to enable)')}")
-            except Exception:  # noqa: BLE001
-                print(f"  {_ok('Registered as contributor')}")
-        elif "already exists" in (proc.stderr or ""):
-            print(f"  {_ok('Already registered — skipping.')}")
-        else:
-            print(f"  {yellow('⚠')} Registration failed (code {proc.returncode}) — run manually:")
-            print(f"  {dim('b1e55ed contributors register --name <handle> --role contributor')}")
-    except subprocess.TimeoutExpired:
-        print(f"  {yellow('⚠')} Registration timed out — run manually: b1e55ed contributors register")
-    except Exception as e:  # noqa: BLE001
-        print(f"  {yellow('⚠')} Could not register: {e}")
+        if proc.returncode == 0 or "already exists" in (proc.stderr or ""):
+            registered = True
+    except Exception:  # noqa: BLE001
+        pass
+
+    if registered:
+        print(f"  {_ok('Registered as contributor')}")
+        if issue_url:
+            print(f"  {_ok(f'Announced: {issue_url}')}")
+    else:
+        print(f"  {yellow('⚠')} Registration failed — run manually: b1e55ed contributors register")
 
 
 def _step5_test_run(repo_root: Path) -> None:


### PR DESCRIPTION
## What

Wizard now auto-registers new contributors **without any credentials** on the user's machine. The community GitHub App (already created) handles issue creation server-side via the oracle.

## Changes

### `engine/cli/commands/wizard.py`
- New step `[4b] Contributor registration` runs after config is written
- Calls `POST oracle.b1e55ed.xyz/api/v1/oracle/contributors/register`
- Oracle uses GitHub App key to create announcement issue
- Falls back to local-only registration if oracle unreachable

### `api/routes/oracle.py`
- New public endpoint `POST /oracle/contributors/register` (no auth)
- Validates `node_id` starts with `eth:0xb1e55ed`
- Registers in oracle DB + fires GitHub issue via App key
- Returns `{contributor_id, node_id, issue_url}`
- Idempotent (returns existing on duplicate)

### `api/deps.py`
- `get_publisher()` now activates on `app_id > 0` (not just `token`)
- Previously GitHub App auth was silently skipped — issues never fired

### `engine/cli/main.py`
- `_build_contributor_registry_with_eas()` same fix — App auth now wired

## Oracle requirement
`B1E55ED_GITHUB_APP_KEY` must be set on the oracle server. New user machines need nothing.