### PR TITLE
chore: sync main → develop (wizard, forge, oracle relay)

### DIFF
--- a/.github/workflows/b1e55ing-merge.yml
+++ b/.github/workflows/b1e55ing-merge.yml
@@ -66,9 +66,14 @@ jobs:
             --github-token "$GITHUB_TOKEN" \
             --mode gemini
 
-      - name: Commit
+      - name: Post blessing as PR comment
         if: steps.blessed.outputs.already_blessed == 'false'
-        run: |
-          git config user.name "a b1e55ing"
-          git config user.email "bot@permanentupperclass.com"
-          git diff --quiet || (git add -A && git commit -m "chore: a b1e55ing [skip ci]" && git push)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '🙏 a b1e55ing',
+            });

--- a/.github/workflows/dep-graphs.yml
+++ b/.github/workflows/dep-graphs.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -38,12 +39,17 @@ jobs:
       - name: Validate doc deps
         run: bash scripts/validate_doc_deps.sh
 
-      - name: Commit if changed
-        run: |
-          git config user.name "b1e55ed[bot]"
-          git config user.email "bot@permanentupperclass.com"
-          git diff --quiet && echo "No changes." || (
-            git add docs/dependencies-code.md docs/dependencies-docs.md
-            git commit -m "chore: auto-update dependency graphs [skip ci]"
-            git push
-          )
+      - name: Open PR if changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: auto-update dependency graphs [skip ci]"
+          author: "b1e55ed[bot] <bot@permanentupperclass.com>"
+          branch: chore/auto-dep-graphs
+          delete-branch: true
+          title: "chore: auto-update dependency graphs"
+          body: "Automated dependency graph update triggered by changes to source files.\n\n_This PR was opened automatically by the dep-graphs workflow._"
+          labels: "automated,documentation"
+          add-paths: |
+            docs/dependencies-code.md
+            docs/dependencies-docs.md

--- a/.github/workflows/forge-release.yml
+++ b/.github/workflows/forge-release.yml
@@ -1,0 +1,63 @@
+name: Build Forge Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to upload binaries to (e.g. v1.0.0-beta.5)'
+        required: false
+        default: 'v1.0.0-beta.5'
+
+jobs:
+  build-macos-universal:
+    name: Build macos-universal
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - name: Build arm64 + x86_64 and combine into universal binary
+        run: |
+          cd tools/forge
+          cargo build --release --target aarch64-apple-darwin
+          cargo build --release --target x86_64-apple-darwin
+          lipo -create \
+            target/aarch64-apple-darwin/release/b1e55ed-forge \
+            target/x86_64-apple-darwin/release/b1e55ed-forge \
+            -output b1e55ed-forge-macos
+          file b1e55ed-forge-macos
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          files: tools/forge/b1e55ed-forge-macos
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux:
+    name: Build linux-x86_64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - name: Build
+        run: |
+          cd tools/forge
+          cargo build --release --target x86_64-unknown-linux-gnu
+          cp target/x86_64-unknown-linux-gnu/release/b1e55ed-forge b1e55ed-forge-linux-x86_64
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          files: tools/forge/b1e55ed-forge-linux-x86_64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ cd b1e55ed && uv sync
 
 | Guide | |
 |-------|-|
+| [How it works](docs/how-it-works.md) | Plain-English overview — objectives, flywheel, benefits |
 | [Getting started](docs/getting-started.md) | Install and first run |
 | [Architecture](docs/architecture.md) | System design and data flow |
 | [Configuration](docs/configuration.md) | All config keys |

--- a/api/deps.py
+++ b/api/deps.py
@@ -82,21 +82,35 @@ def get_karma(request: Request) -> KarmaEngine:
 
 
 def get_publisher(request: Request) -> object | None:
-    """Return a bound GitHub publisher callable, or None if no token configured.
+    """Return a bound GitHub publisher callable, or None if not configured.
 
-    The publisher is fail-open — returns None on failure rather than raising.
-    Consumers should inject this and pass to ContributorRegistry; the registry
-    handles the None case gracefully.
+    Supports both static PAT (publish.github.token) and GitHub App auth
+    (publish.github.app_id + B1E55ED_GITHUB_APP_KEY env var).
+    Fail-open — returns None on failure rather than raising.
     """
     from engine.integrations.github_publish import make_publisher
 
     cfg = get_config(request)
     pub_cfg = cfg.publish.github
-    if not pub_cfg.token:
+    has_token = bool(pub_cfg.token)
+    has_app = int(pub_cfg.app_id or 0) > 0
+
+    if not has_token and not has_app:
         return None
+
+    app_auth = None
+    if has_app:
+        try:
+            from engine.integrations.github_app import GitHubAppAuth
+
+            app_auth = GitHubAppAuth.from_env()
+        except Exception:
+            pass
+
     return make_publisher(
         owner=pub_cfg.owner,
         repo=pub_cfg.repo,
-        token=pub_cfg.token,
+        token=str(pub_cfg.token or ""),
         labels=pub_cfg.labels,
+        app_auth=app_auth,
     )

--- a/api/routes/oracle.py
+++ b/api/routes/oracle.py
@@ -132,3 +132,86 @@ async def get_producer_provenance(
         },
         note=result.note,
     )
+
+
+# ---------------------------------------------------------------------------
+# Public contributor registration — no auth required.
+# The oracle holds the GitHub App key; new installs call this to get
+# their registration issue created without needing credentials.
+# ---------------------------------------------------------------------------
+
+
+class ContributorRegisterOracleRequest(BaseModel):
+    node_id: str
+    name: str = ""
+    role: str = "contributor"
+
+
+class ContributorRegisterOracleResponse(BaseModel):
+    contributor_id: str
+    node_id: str
+    name: str
+    role: str
+    registered_at: str
+    issue_url: str | None = None
+
+
+@router.post("/contributors/register", response_model=ContributorRegisterOracleResponse)
+def oracle_register_contributor(
+    req: ContributorRegisterOracleRequest,
+    request: Request,
+    db: Database = Depends(get_db),
+) -> ContributorRegisterOracleResponse:
+    """Public endpoint — registers a new contributor and creates a GitHub issue.
+
+    Called by ``b1e55ed wizard`` on new installs.  No authentication required.
+    The oracle supplies GitHub App credentials server-side so installers don't
+    need a token.
+    """
+    from api.deps import get_publisher
+    from engine.core.contributors import ContributorRegistry
+
+    if not req.node_id.startswith("eth:0xb1e55ed"):
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail="node_id must start with eth:0xb1e55ed")
+
+    name = req.name or req.node_id
+    publisher = get_publisher(request)
+    reg = ContributorRegistry(db, github_publisher=publisher)
+
+    try:
+        c = reg.register(node_id=req.node_id, name=name, role=req.role)
+    except ValueError:
+        # Already registered — look up and return existing
+        existing = next((x for x in reg.list_all() if x.node_id == req.node_id), None)
+        if existing:
+            issue_url = None
+            pub = (existing.metadata.get("publish") or {}).get("github") if isinstance(existing.metadata, dict) else None
+            if isinstance(pub, dict):
+                issue_url = pub.get("html_url")
+            return ContributorRegisterOracleResponse(
+                contributor_id=existing.id,
+                node_id=existing.node_id,
+                name=existing.name,
+                role=existing.role,
+                registered_at=existing.registered_at,
+                issue_url=issue_url,
+            )
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=409, detail="contributor already registered") from None
+
+    issue_url: str | None = None
+    pub = (c.metadata.get("publish") or {}).get("github") if isinstance(c.metadata, dict) else None
+    if isinstance(pub, dict):
+        issue_url = pub.get("html_url")
+
+    return ContributorRegisterOracleResponse(
+        contributor_id=c.id,
+        node_id=c.node_id,
+        name=c.name,
+        role=c.role,
+        registered_at=c.registered_at,
+        issue_url=issue_url,
+    )

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,6 +19,21 @@ b1e55ed wizard
 Covers: identity forge → config → producer registration → brain first run → API setup.
 From source: `./b1e55ed wizard` or `uv run b1e55ed wizard`.
 
+### `b1e55ed uninstall`
+
+Removes b1e55ed from the system. Prompts for confirmation unless `--yes` is given.
+
+```text
+b1e55ed uninstall [--yes] [--keep-data]
+```
+
+| Flag | Description |
+|---|---|
+| `--yes` | Skip confirmation prompts |
+| `--keep-data` | Preserve the data directory (brain DB, logs, config) |
+
+Alternatively, run the standalone script: `./uninstall.sh`.
+
 ### `b1e55ed setup`
 
 Low-level setup. Writes `config/user.yaml`, initializes `data/brain.db`. The wizard calls this internally.

--- a/docs/dependencies-code.md
+++ b/docs/dependencies-code.md
@@ -288,12 +288,42 @@ See `docs/security.md` for enforcement details.
 
 ---
 
+---
+
+---
+
+---
+
+---
+
+---
+
 ## Undocumented (auto-detected)
 
 > Modules detected by CI but not yet assigned to a layer. Move each entry to the correct layer section and add a description.
 
 ```
 api/routes/metrics.py
+api/schemas/brain.py
+api/schemas/common.py
+api/schemas/positions.py
+api/schemas/signals.py
+dashboard/app.py
+dashboard/contributors.py
+dashboard/identity.py
+dashboard/producers.py
+dashboard/routes/home.py
+dashboard/routes/positions.py
+dashboard/routes/regime.py
+dashboard/routes/settings.py
+dashboard/routes/signals.py
+dashboard/routes/treasury.py
+dashboard/services/api_client.py
+dashboard/webhooks.py
+engine/cli/commands/uninstall.py
 engine/cli/commands/wizard.py
+engine/config/github_app_defaults.py
+engine/core/identity_gate.py
 engine/execution/recovery.py
+engine/integrations/github_app.py
 ```

--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -13,6 +13,7 @@ A ⇒ B     A heavily references B
 
 ```text
 README.md
+  → docs/how-it-works.md
   → docs/getting-started.md
   → docs/configuration.md
   → docs/cli-reference.md
@@ -33,6 +34,16 @@ README.md
 ```
 
 ## Core docs
+
+### `docs/how-it-works.md`
+
+```text
+how-it-works.md
+  → getting-started.md
+  → architecture.md
+  → learning-loop.md
+  → oracle.md
+```
 
 ### `docs/getting-started.md`
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,88 @@
+# How b1e55ed Works
+
+b1e55ed is a sovereign trading intelligence system. You run it. You own the keys. You own the data. It learns from every trade you make and every signal it processes — then uses that knowledge to get sharper over time.
+
+The design philosophy is simple: most trading systems execute instructions. b1e55ed builds a model of what works, refines it continuously, and attributes every outcome back to the source that called it.
+
+---
+
+## The Problem It Solves
+
+Signals are everywhere. On-chain flows, market structure, social sentiment, macro indicators — the information exists. The bottleneck is synthesis and memory.
+
+Most operators process signals in isolation. They don't track which sources were right, which were noise, or how the combination changes over time. Each cycle starts from scratch.
+
+b1e55ed doesn't forget.
+
+---
+
+## How It Operates
+
+The system has three layers that feed each other.
+
+**Producers** are signal sources. They watch markets, wallets, on-chain data, and social dynamics. Each producer emits structured signals — a view on an asset, a conviction level, a proposed direction.
+
+**The Brain** synthesizes those signals into a single conviction score. It weights each producer by their historical accuracy. A producer who has been right gets more weight. One who has been consistently wrong gets less. The Brain also reads the regime — bull, bear, chop — and adjusts how it interprets signals accordingly.
+
+**Execution** turns conviction into action. Dynamic Kelly sizing determines position size based on edge. A kill switch gates everything — if conditions deteriorate past thresholds, the system stops trading until conditions recover.
+
+Every step — every signal received, every conviction scored, every trade opened or closed — writes to an append-only log with a cryptographic hash chain. Nothing is editable after the fact. The audit trail is the database.
+
+---
+
+## The Flywheel
+
+The system compounds. This is not a metaphor.
+
+```
+Signal → Synthesis → Trade → Outcome → Attribution → Weight Update
+   ↑                                                        ↓
+   └─────────────────── Better predictions ←───────────────┘
+```
+
+When a trade closes, the outcome is traced back to the signals that caused it. Each contributing producer's karma score updates — profits flow in, losses flow out. The Brain recalibrates weights based on who was right.
+
+The next cycle runs with better weights. The cycle after that, better still.
+
+Six months in, the system's understanding of which sources are actually predictive — not in theory, but in your market, in your regime — is something no static model can replicate.
+
+---
+
+## Objectives
+
+**Build an accurate picture of edge.** Not generic backtests — a live, continuously updated model of what signals have actually produced returns in real conditions.
+
+**Eliminate noise at the source.** Producers who don't perform lose influence automatically. No manual tuning required after setup.
+
+**Make attribution permanent.** Every signal is tied to a producer. Every outcome is tied to the signals that drove it. The hash chain means these links can't be rewritten. If a producer generated alpha, that record exists forever.
+
+**Operate without dependency.** No cloud services required. No vendor lock-in. The system runs on your hardware, your keys generate your identity, and the data lives in your database.
+
+---
+
+## Benefits
+
+**Compound accuracy.** The system you're running in month six has six months of outcome data feeding back into its weights. Static systems don't have this. Discretionary traders don't either, unless they keep meticulous records — and most don't.
+
+**Trustless provenance.** The oracle exposes each producer's track record publicly, without auth, backed by the hash chain. Any external agent can verify whether a signal source has historically been worth following. The query doesn't change the score — that's the anti-Goodhart guarantee.
+
+**Regime awareness.** Markets behave differently depending on the macro structure. A signal that works in a trending bull market is often noise in choppy consolidation. The Brain conditions its synthesis on the current regime, so the same producer can carry different weight depending on context.
+
+**Sovereignty.** Your identity is a keypair you generated. Your data is a local SQLite database you can inspect, export, or migrate. The system can run airgapped. Nothing requires a cloud account, a subscription, or trust in a third party.
+
+**Survivability.** The kill switch is unconditional. If drawdown exceeds configured thresholds, trading stops — regardless of what signals are saying. Capital preservation is hard-coded, not a guideline.
+
+---
+
+## What It's Not
+
+b1e55ed is not a black box that generates returns while you ignore it. It requires setup, configuration of signal sources, and ongoing operator judgment about what the system is telling you.
+
+It is a system for operators who want to build a rigorous, compounding understanding of their own edge — and have it encoded in something that runs, records, and gets better over time.
+
+---
+
+→ [Get started](getting-started.md) — install and first run  
+→ [Architecture](architecture.md) — technical design  
+→ [Learning loop](learning-loop.md) — how compound scoring works in detail  
+→ [Oracle](oracle.md) — public provenance verification

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -17,7 +17,12 @@ __all__ = [
     "ALIGNMENT_CHECK",
 ]
 
-__version__ = "2.0.0"
+try:
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("b1e55ed")
+except Exception:
+    __version__ = "1.0.0-beta.5"  # fallback when running from source without install
 
 # 0xb1e55ed = "blessed"
 BLESSED_HEX = 0xB1E55ED

--- a/engine/cli/commands/uninstall.py
+++ b/engine/cli/commands/uninstall.py
@@ -1,0 +1,439 @@
+"""engine.cli.commands.uninstall
+
+Interactive uninstaller for b1e55ed.
+
+Design constraints:
+- stdlib only (no external deps)
+- ANSI color codes with TTY detection fallback
+- Never silently deletes anything — always asks first
+- --yes flag skips confirmations
+- --keep-data preserves data + config dirs
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engine.cli.main import CliContext
+
+# ── ANSI helpers ──────────────────────────────────────────────────────────────
+
+IS_TTY = sys.stdout.isatty()
+
+
+def _c(code: str, text: str) -> str:
+    if not IS_TTY:
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def bold(t: str) -> str:
+    return _c("1", t)
+
+
+def green(t: str) -> str:
+    return _c("0;32", t)
+
+
+def yellow(t: str) -> str:
+    return _c("1;33", t)
+
+
+def red(t: str) -> str:
+    return _c("0;31", t)
+
+
+def dim(t: str) -> str:
+    return _c("2", t)
+
+
+def _ok(msg: str = "") -> str:
+    return green("✓") + (f" {msg}" if msg else "")
+
+
+def _skip(msg: str = "") -> str:
+    return dim("–") + (f" {msg}" if msg else "")
+
+
+def _warn(msg: str = "") -> str:
+    return yellow("⚠") + (f" {msg}" if msg else "")
+
+
+# ── Confirmation helper ───────────────────────────────────────────────────────
+
+
+def _confirm(prompt: str, *, default: bool, yes_all: bool) -> bool:
+    """Ask the user for confirmation. Returns True if confirmed."""
+    if yes_all:
+        print(f"  {prompt} {dim('[auto-yes]')}")
+        return True
+    hint = "[Y/n]" if default else "[y/N]"
+    try:
+        raw = input(f"  {prompt} {hint}: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    if not raw:
+        return default
+    return raw in ("y", "yes", "1")
+
+
+# ── RC file helpers ───────────────────────────────────────────────────────────
+
+_RC_FILES = [
+    Path.home() / ".bashrc",
+    Path.home() / ".zshrc",
+    Path.home() / ".bash_profile",
+]
+
+_PATH_MARKER = "# Added by b1e55ed installer"
+_LOCAL_BIN_PATTERN = ".local/bin"
+_MASTER_PASSWORD_PATTERN = "B1E55ED_MASTER_PASSWORD"
+
+
+def _remove_lines_from_rc(rc: Path, *, match_patterns: list[str], description: str) -> bool:
+    """Remove lines containing any of match_patterns from rc file.
+
+    Also removes the comment line immediately before a matching line if it
+    matches _PATH_MARKER. Returns True if any lines were removed.
+    """
+    if not rc.exists():
+        return False
+
+    original = rc.read_text(encoding="utf-8")
+    lines = original.splitlines(keepends=True)
+    new_lines: list[str] = []
+    changed = False
+    skip_next = False
+
+    for i, line in enumerate(lines):
+        if skip_next:
+            skip_next = False
+            continue
+
+        stripped = line.rstrip("\n").rstrip()
+
+        # Check if this is the installer comment marker — if the NEXT line matches
+        # one of our patterns, skip both.
+        if stripped == _PATH_MARKER and i + 1 < len(lines):
+            next_line = lines[i + 1].rstrip("\n").rstrip()
+            if any(pat in next_line for pat in match_patterns):
+                # Skip this comment and the next line
+                skip_next = True
+                changed = True
+                continue
+
+        if any(pat in stripped for pat in match_patterns):
+            changed = True
+            continue
+
+        new_lines.append(line)
+
+    if changed:
+        rc.write_text("".join(new_lines), encoding="utf-8")
+        print(f"  {_ok(f'Removed {description} from {rc}')}")
+
+    return changed
+
+
+# ── Step implementations ──────────────────────────────────────────────────────
+
+
+def _step_uv_uninstall(*, yes_all: bool) -> tuple[bool, str]:
+    """Uninstall via `uv tool uninstall b1e55ed`. Returns (done, note)."""
+    uv = shutil.which("uv")
+    if not uv:
+        return False, "uv not found in PATH — skipping uv tool uninstall"
+
+    if not _confirm("Remove b1e55ed uv tool installation? (runs: uv tool uninstall b1e55ed)", default=True, yes_all=yes_all):
+        return False, "skipped by user"
+
+    try:
+        result = subprocess.run(
+            [uv, "tool", "uninstall", "b1e55ed"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode == 0:
+            return True, "uv tool uninstall succeeded"
+        else:
+            # Not installed as a tool is not a fatal error
+            msg = (result.stderr or result.stdout or "").strip()
+            return False, f"uv tool uninstall exited {result.returncode}: {msg}"
+    except subprocess.TimeoutExpired:
+        return False, "uv tool uninstall timed out"
+    except Exception as e:  # noqa: BLE001
+        return False, f"uv tool uninstall error: {e}"
+
+
+def _step_remove_binary(*, yes_all: bool) -> tuple[bool, str]:
+    """Remove ~/.local/bin/b1e55ed if it still exists."""
+    binary = Path.home() / ".local" / "bin" / "b1e55ed"
+    if not binary.exists():
+        return False, "~/.local/bin/b1e55ed not found (already removed or not installed there)"
+
+    if not _confirm(f"Remove binary {binary}?", default=True, yes_all=yes_all):
+        return False, "skipped by user"
+
+    try:
+        binary.unlink()
+        return True, f"Removed {binary}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"Could not remove {binary}: {e}"
+
+
+def _step_remove_dir(path: Path, label: str, *, yes_all: bool, default_confirm: bool) -> tuple[bool, str]:
+    """Remove a directory after confirmation."""
+    if not path.exists():
+        return False, f"{label} ({path}) not found — nothing to remove"
+
+    if not _confirm(f"Remove {label} at {path}?", default=default_confirm, yes_all=yes_all):
+        return False, f"skipped by user (kept {path})"
+
+    try:
+        shutil.rmtree(path)
+        return True, f"Removed {path}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"Could not remove {path}: {e}"
+
+
+def _step_remove_path_rc_lines(*, yes_all: bool) -> list[tuple[str, bool]]:
+    """Remove PATH export lines from shell rc files."""
+    results = []
+    for rc in _RC_FILES:
+        if not rc.exists():
+            continue
+
+        content = rc.read_text(encoding="utf-8")
+        if _LOCAL_BIN_PATTERN not in content:
+            results.append((str(rc), False))
+            continue
+
+        if not _confirm(
+            f"Remove ~/.local/bin PATH line from {rc}?",
+            default=True,
+            yes_all=yes_all,
+        ):
+            results.append((str(rc), False))
+            continue
+
+        changed = _remove_lines_from_rc(
+            rc,
+            match_patterns=[_LOCAL_BIN_PATTERN],
+            description="PATH export line",
+        )
+        results.append((str(rc), changed))
+    return results
+
+
+def _step_remove_password_rc_lines(*, yes_all: bool) -> list[tuple[str, bool]]:
+    """Remove B1E55ED_MASTER_PASSWORD lines from shell rc files."""
+    results = []
+    for rc in _RC_FILES:
+        if not rc.exists():
+            continue
+
+        content = rc.read_text(encoding="utf-8")
+        if _MASTER_PASSWORD_PATTERN not in content:
+            results.append((str(rc), False))
+            continue
+
+        if not _confirm(
+            f"Remove B1E55ED_MASTER_PASSWORD export from {rc}?",
+            default=True,
+            yes_all=yes_all,
+        ):
+            results.append((str(rc), False))
+            continue
+
+        changed = _remove_lines_from_rc(
+            rc,
+            match_patterns=[_MASTER_PASSWORD_PATTERN],
+            description="B1E55ED_MASTER_PASSWORD export",
+        )
+        results.append((str(rc), changed))
+    return results
+
+
+# ── Public entrypoint ─────────────────────────────────────────────────────────
+
+
+def run_uninstall(ctx: CliContext, args: argparse.Namespace) -> int:
+    """Run the interactive b1e55ed uninstaller."""
+    yes_all: bool = bool(getattr(args, "yes", False))
+    keep_data: bool = bool(getattr(args, "keep_data", False))
+    repo_root: Path = ctx.repo_root
+
+    print()
+    print("  ╔══════════════════════════════════════════╗")
+    print("  ║" + bold("         b1e55ed uninstaller            ") + "║")
+    print("  ╚══════════════════════════════════════════╝")
+    print()
+    print("  This will remove b1e55ed from your system.")
+    if yes_all:
+        print(f"  {yellow('--yes mode: all confirmations will be auto-accepted.')}")
+    if keep_data:
+        print(f"  {yellow('--keep-data mode: data and config directories will be preserved.')}")
+    print()
+
+    removed: list[str] = []
+    skipped: list[str] = []
+
+    # ── 1. uv tool uninstall ──────────────────────────────────────────────────
+    print(bold("  [1/5] uv tool uninstall"))
+    done, note = _step_uv_uninstall(yes_all=yes_all)
+    if done:
+        print(f"  {_ok(note)}")
+        removed.append("uv tool (b1e55ed)")
+    else:
+        print(f"  {_skip(note)}")
+        skipped.append(f"uv uninstall: {note}")
+
+    # ── 2. Remove binary ──────────────────────────────────────────────────────
+    print()
+    print(bold("  [2/5] Remove binary"))
+    done, note = _step_remove_binary(yes_all=yes_all)
+    if done:
+        print(f"  {_ok(note)}")
+        removed.append("~/.local/bin/b1e55ed")
+    else:
+        print(f"  {_skip(note)}")
+        skipped.append(f"binary: {note}")
+
+    # ── 3. Remove data / config dirs ─────────────────────────────────────────
+    print()
+    print(bold("  [3/5] Data and config directories"))
+
+    if keep_data:
+        print(f"  {_skip('--keep-data: preserving data and config directories.')}")
+        skipped.append("data dir (--keep-data)")
+        skipped.append("config dir (--keep-data)")
+    else:
+        # data/ relative to repo_root (brain.db, etc.)
+        data_dir = repo_root / "data"
+        done, note = _step_remove_dir(
+            data_dir,
+            label="local data dir (data/)",
+            yes_all=yes_all,
+            default_confirm=False,  # default NO for data
+        )
+        if done:
+            print(f"  {_ok(note)}")
+            removed.append(str(data_dir))
+        else:
+            print(f"  {_skip(note)}")
+            skipped.append(f"data dir: {note}")
+
+        # .b1e55ed/ (identity + settings)
+        config_dir = repo_root / ".b1e55ed"
+        done, note = _step_remove_dir(
+            config_dir,
+            label="config / identity dir (.b1e55ed/)",
+            yes_all=yes_all,
+            default_confirm=False,  # default NO for identity
+        )
+        if done:
+            print(f"  {_ok(note)}")
+            removed.append(str(config_dir))
+        else:
+            print(f"  {_skip(note)}")
+            skipped.append(f"config dir: {note}")
+
+        # ~/.local/share/b1e55ed/ if it exists
+        xdg_data = Path.home() / ".local" / "share" / "b1e55ed"
+        if xdg_data.exists():
+            done, note = _step_remove_dir(
+                xdg_data,
+                label="XDG data dir (~/.local/share/b1e55ed/)",
+                yes_all=yes_all,
+                default_confirm=False,
+            )
+            if done:
+                print(f"  {_ok(note)}")
+                removed.append(str(xdg_data))
+            else:
+                print(f"  {_skip(note)}")
+                skipped.append(f"XDG data dir: {note}")
+
+        # ~/.config/b1e55ed/ if it exists
+        xdg_config = Path.home() / ".config" / "b1e55ed"
+        if xdg_config.exists():
+            done, note = _step_remove_dir(
+                xdg_config,
+                label="XDG config dir (~/.config/b1e55ed/)",
+                yes_all=yes_all,
+                default_confirm=False,
+            )
+            if done:
+                print(f"  {_ok(note)}")
+                removed.append(str(xdg_config))
+            else:
+                print(f"  {_skip(note)}")
+                skipped.append(f"XDG config dir: {note}")
+
+    # ── 4. Remove PATH lines from shell rc ────────────────────────────────────
+    print()
+    print(bold("  [4/5] Shell PATH additions"))
+    rc_path_results = _step_remove_path_rc_lines(yes_all=yes_all)
+    any_rc_changed = False
+    for rc_file, changed in rc_path_results:
+        if changed:
+            any_rc_changed = True
+            removed.append(f"PATH line in {rc_file}")
+        elif not Path(rc_file).exists():
+            pass  # silently skip missing files
+    if not any_rc_changed:
+        if not rc_path_results:
+            print(f"  {_skip('No shell rc files found.')}")
+        else:
+            print(f"  {_skip('No PATH lines to remove (already clean or skipped).')}")
+
+    # ── 5. Remove B1E55ED_MASTER_PASSWORD from shell rc ──────────────────────
+    print()
+    print(bold("  [5/5] Shell password exports"))
+    rc_pw_results = _step_remove_password_rc_lines(yes_all=yes_all)
+    any_pw_changed = False
+    for rc_file, changed in rc_pw_results:
+        if changed:
+            any_pw_changed = True
+            removed.append(f"B1E55ED_MASTER_PASSWORD in {rc_file}")
+    if not any_pw_changed:
+        if not rc_pw_results:
+            print(f"  {_skip('No shell rc files found.')}")
+        else:
+            print(f"  {_skip('No B1E55ED_MASTER_PASSWORD lines found (already clean or skipped).')}")
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    print()
+    print(bold(green("  ══════════════════════════════════════")))
+    print()
+    if removed:
+        print(f"  {bold('Removed:')}")
+        for item in removed:
+            print(f"    {green('✓')} {item}")
+    else:
+        print(f"  {dim('Nothing was removed.')}")
+
+    if skipped:
+        print()
+        print(f"  {bold('Skipped / not found:')}")
+        for item in skipped:
+            print(f"    {dim('–')} {item}")
+
+    print()
+    if removed:
+        print(f"  {bold(green('Uninstall complete.'))} b1e55ed has been removed.")
+    else:
+        print(f"  {yellow('Uninstall finished with no changes.')}")
+
+    print()
+    print(bold(green("  ══════════════════════════════════════")))
+    print()
+    return 0

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -101,15 +101,169 @@ def _section(title: str) -> None:
     print()
 
 
+# ── Symbol packs ─────────────────────────────────────────────────────────────
+
+_SYMBOL_PACKS: dict[str, dict] = {
+    "1": {
+        "name": "Top 10 — Large caps (BTC, ETH, SOL, BNB, XRP, ADA, AVAX, DOT, LINK, UNI)",
+        "symbols": ["BTC", "ETH", "SOL", "BNB", "XRP", "ADA", "AVAX", "DOT", "LINK", "UNI"],
+    },
+    "2": {
+        "name": "Top 30 — Broad coverage",
+        "symbols": [
+            "BTC",
+            "ETH",
+            "SOL",
+            "BNB",
+            "XRP",
+            "ADA",
+            "AVAX",
+            "DOT",
+            "LINK",
+            "UNI",
+            "LTC",
+            "ATOM",
+            "NEAR",
+            "ARB",
+            "OP",
+            "MATIC",
+            "FIL",
+            "AAVE",
+            "CRV",
+            "SNX",
+            "SUI",
+            "APT",
+            "INJ",
+            "TIA",
+            "SEI",
+            "JTO",
+            "WIF",
+            "BONK",
+            "JUP",
+            "PYTH",
+        ],
+    },
+    "3": {
+        "name": "Top 50 — Comprehensive",
+        "symbols": [
+            "BTC",
+            "ETH",
+            "SOL",
+            "BNB",
+            "XRP",
+            "ADA",
+            "AVAX",
+            "DOT",
+            "LINK",
+            "UNI",
+            "LTC",
+            "ATOM",
+            "NEAR",
+            "ARB",
+            "OP",
+            "MATIC",
+            "FIL",
+            "AAVE",
+            "CRV",
+            "SNX",
+            "SUI",
+            "APT",
+            "INJ",
+            "TIA",
+            "SEI",
+            "JTO",
+            "WIF",
+            "BONK",
+            "JUP",
+            "PYTH",
+            "PEPE",
+            "FLOKI",
+            "MEME",
+            "RENDER",
+            "FET",
+            "OCEAN",
+            "AGIX",
+            "TAO",
+            "IO",
+            "HYPE",
+            "VIRTUAL",
+            "AI16Z",
+            "AIXBT",
+            "GOAT",
+            "DEGEN",
+            "BRETT",
+            "TOSHI",
+            "MOG",
+            "TURBO",
+            "WEN",
+        ],
+    },
+    "4": {
+        "name": "Highest TVL — DeFi protocols",
+        "symbols": [
+            "ETH",
+            "BTC",
+            "SOL",
+            "BNB",
+            "AVAX",
+            "MATIC",
+            "ARB",
+            "OP",
+            "AAVE",
+            "UNI",
+            "CRV",
+            "MKR",
+            "COMP",
+            "LDO",
+            "RPL",
+            "SUSHI",
+            "BAL",
+            "FXS",
+            "CVX",
+            "FRAX",
+        ],
+    },
+    "5": {
+        "name": "AI + Agent coins",
+        "symbols": [
+            "FET",
+            "OCEAN",
+            "AGIX",
+            "RENDER",
+            "TAO",
+            "IO",
+            "VIRTUAL",
+            "AI16Z",
+            "AIXBT",
+            "GOAT",
+            "GRASS",
+            "PRIME",
+            "ATH",
+            "NOS",
+        ],
+    },
+    "6": {
+        "name": "Custom — enter your own",
+        "symbols": [],
+    },
+}
+
 # ── Step helpers ──────────────────────────────────────────────────────────────
 
 
 def _step0_welcome() -> None:
     """Print the welcome banner."""
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        _ver = _pkg_version("b1e55ed")
+    except Exception:  # noqa: BLE001
+        _ver = "?"
+    subtitle = f"contributor intelligence engine v{_ver}".center(40)
     print()
     print("  ╔══════════════════════════════════════════╗")
     print("  ║" + bold("         b1e55ed setup wizard           ") + "║")
-    print("  ║" + dim("  contributor intelligence engine v1.x  ") + "║")
+    print("  ║" + dim(subtitle) + "║")
     print("  ╚══════════════════════════════════════════╝")
     print()
     print("  This wizard will configure b1e55ed in 5 steps.")
@@ -238,6 +392,70 @@ def _step2_password() -> None:
         print(f"  {dim('Password not saved — set B1E55ED_MASTER_PASSWORD manually when needed.')}")
 
 
+def _check_rust_grinder() -> str | None:
+    """Return path to Rust forge binary if available, else None."""
+    import shutil
+
+    candidates = [
+        Path.home() / ".local" / "share" / "b1e55ed" / "bin" / "b1e55ed-forge",
+        Path.home() / ".local" / "bin" / "b1e55ed-forge",
+    ]
+    for p in candidates:
+        if p.exists() and os.access(str(p), os.X_OK):
+            return str(p)
+    found = shutil.which("b1e55ed-forge")
+    return found
+
+
+def _auto_download_forge() -> str | None:
+    """Download the Rust forge binary for the current platform. Returns install path or None."""
+    import platform
+    import stat
+    import urllib.request
+
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system == "darwin":
+        artifact = "b1e55ed-forge-macos"  # universal binary (arm64 + x86_64)
+    elif system == "linux" and machine == "x86_64":
+        artifact = "b1e55ed-forge-linux-x86_64"
+    else:
+        print(f"  {yellow('⚠')} No pre-built binary for {system}/{machine}.")
+        return None
+
+    # /releases/latest skips pre-releases — resolve tag via API instead
+    try:
+        with urllib.request.urlopen(  # noqa: S310
+            "https://api.github.com/repos/P-U-C/b1e55ed/releases?per_page=1"
+        ) as resp:
+            import json as _json
+
+            releases = _json.loads(resp.read())
+            tag = releases[0]["tag_name"] if releases else None
+    except Exception:  # noqa: BLE001
+        tag = None
+
+    if not tag:
+        print(f"  {red('✗')} Could not resolve latest release tag.")
+        return None
+
+    url = f"https://github.com/P-U-C/b1e55ed/releases/download/{tag}/{artifact}"
+    dest_dir = Path.home() / ".local" / "share" / "b1e55ed" / "bin"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / "b1e55ed-forge"
+
+    print(f"  Downloading {artifact}...")
+    try:
+        urllib.request.urlretrieve(url, dest)  # noqa: S310
+        dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        print(f"  {_ok(f'Forge binary installed: {dest}')}")
+        return str(dest)
+    except Exception as e:  # noqa: BLE001
+        print(f"  {red('✗')} Download failed: {e}")
+        return None
+
+
 def _step3_identity(repo_root: Path) -> None:
     """Identity forge/restore step."""
     _section("[3/5] Identity")
@@ -257,38 +475,70 @@ def _step3_identity(repo_root: Path) -> None:
             print(f"  {yellow('⚠')} Existing identity file could not be read — will offer to forge.")
 
     print("  Your identity is an Ethereum address with a " + bold("0xb1e55ed") + " prefix.")
-    print("  Forging takes 10–60 seconds (proof-of-work vanity mining).")
     print()
 
-    try:
-        forge = _ask_yn("  Forge new identity?", default=True)
-    except (EOFError, KeyboardInterrupt):
-        print()
-        print(f"  {dim('Skipping identity forge.')}")
-        return
+    rust_binary = _check_rust_grinder()
 
-    if forge:
+    if rust_binary:
+        # Fast path: Rust binary available
+        print(f"  {_ok(f'Rust grinder found: {rust_binary}')}")
+        print("  Forging a vanity address takes ~2 seconds with the Rust binary.")
         print()
-        print(f"  {dim('Running: b1e55ed identity forge')}")
-        print()
+
         try:
-            proc = subprocess.run(
-                [sys.executable, "-m", "engine.cli", "identity", "forge"],
-                cwd=str(repo_root),
-                check=False,
-            )
-            if proc.returncode == 0:
-                print(f"\n  {_ok('Identity forged successfully')}")
-            else:
-                print(f"\n  {yellow('⚠')} Identity forge exited with code {proc.returncode}")
-                print(f"  {dim('You can retry later: b1e55ed identity forge')}")
-        except Exception as e:  # noqa: BLE001
-            print(f"\n  {red('⚠')} Could not run forge: {e}")
-            print(f"  {dim('Try manually: b1e55ed identity forge')}")
+            forge = _ask_yn("  Forge vanity identity (0xb1e55ed prefix)?", default=True)
+        except (EOFError, KeyboardInterrupt):
+            print()
+            print(f"  {dim('Skipping identity forge.')}")
+            return
+
+        if forge:
+            print()
+            print(f"  {dim('Running: b1e55ed identity forge')}")
+            print()
+            try:
+                proc = subprocess.run(
+                    [sys.executable, "-m", "engine.cli", "identity", "forge"],
+                    cwd=str(repo_root),
+                    check=False,
+                )
+                if proc.returncode == 0:
+                    print(f"\n  {_ok('Identity forged successfully')}")
+                else:
+                    print(f"\n  {yellow('⚠')} Identity forge exited with code {proc.returncode}")
+                    print(f"  {dim('You can retry later: b1e55ed identity forge')}")
+            except Exception as e:  # noqa: BLE001
+                print(f"\n  {red('⚠')} Could not run forge: {e}")
+                print(f"  {dim('Try manually: b1e55ed identity forge')}")
+        else:
+            print()
+            print(f"  {dim('To restore an existing identity:')}")
+            print("    b1e55ed identity restore --eth-key <your-private-key-hex>")
     else:
+        # No Rust binary found — auto-download it
+        print(f"  {yellow('⚠')} Rust forge binary not found — downloading now...")
         print()
-        print(f"  {dim('To restore an existing identity:')}")
-        print("    b1e55ed identity restore --eth-key <your-private-key-hex>")
+        rust_binary = _auto_download_forge()
+        if rust_binary:
+            print()
+            print(f"  {dim('Running: b1e55ed identity forge')}")
+            print()
+            try:
+                proc = subprocess.run(
+                    [sys.executable, "-m", "engine.cli", "identity", "forge"],
+                    cwd=str(repo_root),
+                    check=False,
+                )
+                if proc.returncode == 0:
+                    print(f"\n  {_ok('Identity forged successfully')}")
+                else:
+                    print(f"\n  {yellow('⚠')} Identity forge exited with code {proc.returncode}")
+                    print(f"  {dim('You can retry: b1e55ed identity forge')}")
+            except Exception as e:  # noqa: BLE001
+                print(f"\n  {red('⚠')} Could not run forge: {e}")
+        else:
+            print()
+            print(f"  {dim('Run `b1e55ed identity forge` after installing the binary manually.')}")
 
 
 def _step4_configuration(repo_root: Path) -> None:
@@ -336,32 +586,111 @@ def _step4_configuration(repo_root: Path) -> None:
         print(f"  {_ok(f'Generated token: {api_token[:16]}...')}")
 
     print()
-    print("  " + bold("Brain cycle symbols") + ":")
-    try:
-        symbols_raw = _ask("  Symbols (comma-separated)", default="BTC,ETH,SOL")
-    except (EOFError, KeyboardInterrupt):
-        print()
-        symbols_raw = "BTC,ETH,SOL"
-
-    symbols = [s.strip().upper() for s in symbols_raw.split(",") if s.strip()]
-    if not symbols:
-        symbols = ["BTC", "ETH", "SOL"]
-
+    print("  " + bold("Brain cycle symbols") + " — choose a pack:")
     print()
-    print("  " + bold("GitHub publish token") + " (optional, for public contributor attestations):")
+    for key, pack in _SYMBOL_PACKS.items():
+        print(f"  {bold(key)}) {pack['name']}")
+    print()
     try:
-        github_token = _ask("  Token", default="skip")
+        pack_choice = _ask("  Pack", default="1")
     except (EOFError, KeyboardInterrupt):
         print()
-        github_token = "skip"
+        pack_choice = "1"
 
-    if github_token == "skip":
-        github_token = ""
+    if pack_choice not in _SYMBOL_PACKS:
+        pack_choice = "1"
+
+    if pack_choice == "6":
+        try:
+            symbols_raw = _ask("  Symbols (comma-separated)", default="BTC,ETH,SOL")
+        except (EOFError, KeyboardInterrupt):
+            symbols_raw = "BTC,ETH,SOL"
+        symbols = [s.strip().upper() for s in symbols_raw.split(",") if s.strip()] or ["BTC", "ETH", "SOL"]
+    else:
+        symbols = _SYMBOL_PACKS[pack_choice]["symbols"]
+        print(f"  {_ok(f'Pack selected: {len(symbols)} symbols')}")
+
+    # Determine if GitHub App auth is pre-configured (baked-in app_id)
+    try:
+        from engine.config.github_app_defaults import (
+            COMMUNITY_APP_ID,
+            COMMUNITY_INSTALLATION_ID,
+        )
+
+        app_auth_baked_in = COMMUNITY_APP_ID != 0 and COMMUNITY_INSTALLATION_ID != 0
+        baked_app_id = COMMUNITY_APP_ID
+        baked_installation_id = COMMUNITY_INSTALLATION_ID
+    except Exception:  # noqa: BLE001
+        app_auth_baked_in = False
+        baked_app_id = 0
+        baked_installation_id = 0
+
+    github_token = ""
+
+    if app_auth_baked_in:
+        # GitHub App handles auth automatically — no PAT needed
+        print()
+        print(f"  {_ok('GitHub App auth is pre-configured (app_id=' + str(baked_app_id) + ')')}")
+        print(f"  {dim('No GitHub token needed — the community app handles auth automatically.')}")
+        print(f"  {dim('Set B1E55ED_GITHUB_APP_KEY env var to your app private key PEM to enable publishing.')}")
+    else:
+        print()
+        print("  " + bold("GitHub publish token") + " — required to track your contributions publicly.")
+        print()
+        print(f"  {dim('Contributions without a token are scored locally only (not publicly visible).')}")
+        print(f"  {dim('Create a fine-grained PAT at: https://github.com/settings/tokens?type=beta')}")
+        print(f"  {dim('Required permissions: Issues → Read & Write on P-U-C/b1e55ed only.')}")
+        print()
+        print(f"  {dim('Alternative: configure GitHub App auth (see publish.github.app_id in config).')}")
+        print()
+
+        # Check environment first
+        env_token = os.environ.get("B1E55ED_GITHUB_TOKEN", "") or os.environ.get("GITHUB_TOKEN", "")
+        if env_token:
+            print(f"  {_ok('Token found in environment (B1E55ED_GITHUB_TOKEN / GITHUB_TOKEN)')}")
+            github_token = env_token
+        else:
+            try:
+                github_token = _ask("  GitHub token (or press Enter to skip — you can add later)", default="")
+            except (EOFError, KeyboardInterrupt):
+                print()
+                github_token = ""
+
+            if not github_token:
+                print()
+                print(f"  {yellow('⚠')} No token set — contributions will be scored locally only.")
+                print(f"  {dim('Add later: set B1E55ED_GITHUB_TOKEN=<token> and re-run wizard.')}")
+            else:
+                print(f"  {_ok('Token configured')}")
 
     # Build config YAML
     symbols_yaml = "[" + ", ".join(f'"{s}"' for s in symbols) + "]"
     github_token_value = github_token if github_token else ""
-    github_token_comment = "" if github_token else "  # set to enable public attestations"
+
+    if app_auth_baked_in:
+        github_publish_block = f"""publish:
+  github:
+    # GitHub App auth (preferred — no token needed when app_id is set)
+    app_id: {baked_app_id}        # community GitHub App (pre-configured)
+    installation_id: {baked_installation_id}
+    # Set B1E55ED_GITHUB_APP_KEY env var to your app's private key PEM
+    token: ""        # fallback PAT (used if app_id is 0)
+    owner: "P-U-C"
+    repo: "b1e55ed"
+    labels: ["b1e55ed-attestation"]
+"""
+    else:
+        github_publish_block = f"""publish:
+  github:
+    # GitHub App auth (preferred — no token needed when app_id is set)
+    app_id: 0        # set to enable GitHub App auth
+    installation_id: 0
+    # Set B1E55ED_GITHUB_APP_KEY env var to your app's private key PEM
+    token: "{github_token_value}"        # fallback PAT (used if app_id is 0)
+    owner: "P-U-C"
+    repo: "b1e55ed"
+    labels: ["b1e55ed-attestation"]
+"""
 
     config_content = f"""# Generated by `b1e55ed wizard`
 preset: balanced
@@ -390,13 +719,7 @@ dashboard:
   port: 5051
   auth_token: ""
 
-publish:
-  github:
-    token: "{github_token_value}"{github_token_comment}
-    owner: "P-U-C"
-    repo: "b1e55ed"
-    labels: ["b1e55ed-attestation"]
-"""
+{github_publish_block}"""
 
     try:
         user_cfg.parent.mkdir(parents=True, exist_ok=True)
@@ -409,11 +732,97 @@ publish:
         print(f"  {dim('Create config/user.yaml manually.')}")
 
 
+_ORACLE_URL = "https://oracle.b1e55ed.xyz"
+
+
+def _step_register_contributor(repo_root: Path) -> None:
+    """Auto-register new contributor via the oracle (no credentials needed on user machine)."""
+    import json as _json
+    import urllib.error
+    import urllib.request
+
+    _section("[4b] Contributor registration")
+
+    identity_path = repo_root / ".b1e55ed" / "identity.json"
+    if not identity_path.exists():
+        print(f"  {dim('No identity — skipping registration.')}")
+        return
+
+    try:
+        data = _json.loads(identity_path.read_text(encoding="utf-8"))
+        node_id = data.get("node_id", "")
+        address = data.get("address", "")
+    except Exception:  # noqa: BLE001
+        print(f"  {yellow('⚠')} Could not read identity — skipping.")
+        return
+
+    if not node_id:
+        return
+
+    print(f"  Registering: {dim(node_id)}")
+    print()
+
+    # Try oracle first — it holds the GitHub App key, creates the issue server-side
+    issue_url: str | None = None
+    registered = False
+    try:
+        payload = _json.dumps({"node_id": node_id, "name": address or node_id, "role": "contributor"}).encode()
+        req = urllib.request.Request(
+            f"{_ORACLE_URL}/api/v1/oracle/contributors/register",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            result = _json.loads(resp.read())
+            issue_url = result.get("issue_url")
+            registered = True
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            registered = True  # already registered — fine
+    except Exception:  # noqa: BLE001
+        pass  # oracle unreachable — fall through to local
+
+    # Always register locally too (idempotent)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "engine.cli",
+                "contributors",
+                "register",
+                "--node-id",
+                node_id,
+                "--name",
+                address or node_id,
+                "--role",
+                "contributor",
+            ],
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode == 0 or "already exists" in (proc.stderr or ""):
+            registered = True
+    except Exception:  # noqa: BLE001
+        pass
+
+    if registered:
+        print(f"  {_ok('Registered as contributor')}")
+        if issue_url:
+            print(f"  {_ok(f'Announced: {issue_url}')}")
+    else:
+        print(f"  {yellow('⚠')} Registration failed — run manually: b1e55ed contributors register")
+
+
 def _step5_test_run(repo_root: Path) -> None:
     """Optional first-run brain test."""
     _section("[5/5] Test run")
-    print("  Run a quick brain cycle to verify your setup?")
-    print(f"  {dim('(Runs: b1e55ed brain --symbols BTC --dry-run)')}")
+    print("  Run a quick health check to verify your setup?")
+    print(f"  {dim('(Runs: b1e55ed health)')}")
     print()
 
     try:
@@ -428,38 +837,25 @@ def _step5_test_run(repo_root: Path) -> None:
         return
 
     print()
-    print(f"  {dim('Running brain cycle...')}")
+    print(f"  {dim('Running health check...')}")
     print()
 
-    # Try --dry-run first; if unsupported, just skip
     try:
         proc = subprocess.run(
-            [sys.executable, "-m", "engine.cli", "brain", "--symbols", "BTC", "--dry-run"],
+            [sys.executable, "-m", "engine.cli", "health"],
             cwd=str(repo_root),
             check=False,
-            timeout=120,
+            timeout=30,
         )
         if proc.returncode == 0:
-            print(f"  {_ok('Test run completed successfully')}")
+            print(f"  {_ok('Health check passed')}")
         else:
-            # --dry-run not supported; try plain brain briefly
-            proc2 = subprocess.run(
-                [sys.executable, "-m", "engine.cli", "health"],
-                cwd=str(repo_root),
-                check=False,
-                timeout=30,
-            )
-            if proc2.returncode == 0:
-                print(f"  {_ok('Health check passed (brain test skipped — run manually)')}")
-            else:
-                print(f"  {yellow('⚠')} Test run exited with code {proc.returncode}")
-                print(f"  {dim('Run manually: b1e55ed brain')}")
+            print(f"  {yellow('⚠')} Health check returned code {proc.returncode}")
+            print(f"  {dim('Run manually: b1e55ed health')}")
     except subprocess.TimeoutExpired:
-        print(f"  {yellow('⚠')} Test run timed out (120s)")
-        print(f"  {dim('Run manually: b1e55ed brain')}")
+        print(f"  {yellow('⚠')} Health check timed out")
     except Exception as e:  # noqa: BLE001
-        print(f"  {yellow('⚠')} Could not run test: {e}")
-        print(f"  {dim('Run manually: b1e55ed brain')}")
+        print(f"  {yellow('⚠')} Could not run health check: {e}")
 
 
 def _completion() -> None:
@@ -496,6 +892,7 @@ def run_wizard(ctx: CliContext, args: argparse.Namespace) -> int:  # noqa: ARG00
         lambda: _step2_password(),
         lambda: _step3_identity(repo_root),
         lambda: _step4_configuration(repo_root),
+        lambda: _step_register_contributor(repo_root),
         lambda: _step5_test_run(repo_root),
     ]
 

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -445,6 +445,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("wizard", help="Interactive setup wizard for new contributors")
 
+    p_uninstall = sub.add_parser("uninstall", help="Uninstall b1e55ed and clean up all related files")
+    p_uninstall.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip all confirmations and remove everything automatically.",
+    )
+    p_uninstall.add_argument(
+        "--keep-data",
+        action="store_true",
+        dest="keep_data",
+        help="Remove binary/tool but preserve data and config directories.",
+    )
+
     # -- anchor --
     from engine.cli.commands.anchor import build_anchor_parser
 
@@ -1385,17 +1398,27 @@ def _build_contributor_registry_with_eas(*, db: Database, config: Config) -> Con
 
     from engine.core.contributors import ContributorRegistry
 
-    # GitHub publisher — always active when token is configured (fail-open)
+    # GitHub publisher — active when token OR GitHub App is configured (fail-open)
     github_publisher: object | None = None
     pub_cfg = config.publish.github
-    if pub_cfg.token:
+    if pub_cfg.token or (int(pub_cfg.app_id or 0) > 0):
         from engine.integrations.github_publish import make_publisher
+
+        app_auth = None
+        if int(pub_cfg.app_id or 0) > 0:
+            try:
+                from engine.integrations.github_app import GitHubAppAuth
+
+                app_auth = GitHubAppAuth.from_env()
+            except Exception:
+                pass
 
         github_publisher = make_publisher(
             owner=pub_cfg.owner,
             repo=pub_cfg.repo,
-            token=pub_cfg.token,
+            token=str(pub_cfg.token or ""),
             labels=pub_cfg.labels,
+            app_auth=app_auth,
         )
 
     # EAS client — only when explicitly enabled
@@ -1886,10 +1909,47 @@ def _identity_show(ctx: CliContext, args: argparse.Namespace) -> int:
     return 0
 
 
+def _find_rust_forge_binary(repo_root: Path) -> str | None:
+    """Return path to the Rust forge binary if available, else None."""
+    import shutil
+
+    candidates = [
+        Path.home() / ".local" / "share" / "b1e55ed" / "bin" / "b1e55ed-forge",
+        Path.home() / ".local" / "bin" / "b1e55ed-forge",
+    ]
+    for p in candidates:
+        if p.exists() and os.access(str(p), os.X_OK):
+            return str(p)
+    found = shutil.which("b1e55ed-forge")
+    if found:
+        return found
+    # Also check in-repo build artifact
+    repo_binary = repo_root / "tools" / "forge" / "target" / "release" / "b1e55ed-forge"
+    if repo_binary.exists() and os.access(str(repo_binary), os.X_OK):
+        return str(repo_binary)
+    return None
+
+
+def _print_forge_binary_instructions() -> None:
+    """Print instructions to download the Rust forge binary."""
+    print()
+    print("  Download the Rust grinder for your platform:")
+    print()
+    print("    macOS (universal): https://github.com/P-U-C/b1e55ed/releases/latest/download/b1e55ed-forge-macos")
+    print("    Linux x86_64: https://github.com/P-U-C/b1e55ed/releases/latest/download/b1e55ed-forge-linux-x86_64")
+    print()
+    print("  Install:")
+    print("    mkdir -p ~/.local/share/b1e55ed/bin")
+    print("    curl -Lo ~/.local/share/b1e55ed/bin/b1e55ed-forge <url-for-your-platform>")
+    print("    chmod +x ~/.local/share/b1e55ed/bin/b1e55ed-forge")
+    print()
+    print("  Then re-run: b1e55ed identity forge")
+    print()
+
+
 def _identity_forge(ctx: CliContext, args: argparse.Namespace) -> int:
     """The Forge — identity derivation ritual."""
 
-    import shutil
     import subprocess
     import time
 
@@ -1900,27 +1960,52 @@ def _identity_forge(ctx: CliContext, args: argparse.Namespace) -> int:
     # Expected candidates for 7 hex chars
     expected = 16 ** len(prefix)
 
+    rust_binary = _find_rust_forge_binary(ctx.repo_root)
+
+    # If Rust binary not found and not JSON mode, warn and offer options
+    if rust_binary is None and not use_json:
+        print()
+        print("  ⚠ Rust grinder not found — vanity forge requires the b1e55ed-forge binary.")
+        print()
+        print("  Options:")
+        print("    1) Download forge binary   — fast (~2-10s), then forge immediately")
+        print("    2) Force Python fallback   — ~90 min, not recommended (no random address)")
+        print()
+
+        try:
+            choice = input("  Choice [1]: ").strip() or "1"
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if choice != "2":
+            # Default: option 1 — download instructions, then exit so user installs and re-runs
+            _print_forge_binary_instructions()
+            return 0
+
+        # choice == "2": force Python grinder below (rust_binary stays None)
+        print()
+        print("  ⚠ Starting Python grinder — this will take ~90 minutes.")
+        print("    The b1e55ed prefix is non-negotiable; no random address will be generated.")
+        print()
+
     if not use_json:
         print()
-        print("  ╔══════════════════════════════════════╗")
-        print("  ║         THE FORGE                    ║")
-        print("  ║         b1e55ed identity protocol    ║")
-        print("  ╚══════════════════════════════════════╝")
+        print("  ╔══════════════════════════════════════════╗")
+        print("  ║               THE FORGE                  ║")
+        print("  ║       b1e55ed identity protocol          ║")
+        print("  ╚══════════════════════════════════════════╝")
         print()
         print(f"  Every address in this network begins with 0x{prefix}.")
         print("  Yours is being derived now.")
         print()
-        print("  This takes a few minutes.")
-        print("  The work is the point.")
+        if rust_binary:
+            print("  This takes ~2 seconds with the Rust grinder.")
+        else:
+            print("  Rust grinder not found — using Python fallback (~90 min).")
         print()
         print("  Searching...")
         print()
-
-    rust_binary = shutil.which("b1e55ed-forge")
-    if rust_binary is None:
-        repo_binary = ctx.repo_root / "tools" / "forge" / "target" / "release" / "b1e55ed-forge"
-        if repo_binary.exists():
-            rust_binary = str(repo_binary)
 
     result: dict[str, object] | None = None
 
@@ -2776,6 +2861,12 @@ def _cmd_wizard(ctx: CliContext, args: argparse.Namespace) -> int:
     return run_wizard(ctx, args)
 
 
+def _cmd_uninstall(ctx: CliContext, args: argparse.Namespace) -> int:
+    from engine.cli.commands.uninstall import run_uninstall
+
+    return run_uninstall(ctx, args)
+
+
 def _cmd_anchor(ctx: CliContext, args: argparse.Namespace) -> int:
     from engine.cli.commands.anchor import run_anchor
 
@@ -2803,7 +2894,7 @@ def main(argv: list[str] | None = None) -> int:
     ctx = CliContext(repo_root=_repo_root_from_cwd())
 
     # Commands that don't require forged identity
-    ungated_commands = {"identity", "setup", "wizard"}
+    ungated_commands = {"identity", "setup", "wizard", "uninstall"}
 
     cmd = getattr(args, "command", None)
     if cmd not in ungated_commands:
@@ -2856,6 +2947,7 @@ def main(argv: list[str] | None = None) -> int:
         "anchor": _cmd_anchor,
         "export": _cmd_export,
         "wizard": _cmd_wizard,
+        "uninstall": _cmd_uninstall,
     }
 
     fn = dispatch.get(str(args.command))

--- a/engine/config/__init__.py
+++ b/engine/config/__init__.py
@@ -1,0 +1,1 @@
+# engine.config — static configuration constants and defaults

--- a/engine/config/github_app_defaults.py
+++ b/engine/config/github_app_defaults.py
@@ -1,0 +1,18 @@
+"""engine.config.github_app_defaults
+
+Baked-in public constants for the community GitHub App.
+
+These are public identifiers — not secrets.
+The private key is ALWAYS loaded from the B1E55ED_GITHUB_APP_KEY environment
+variable at runtime; it is never stored in source code or config files.
+
+Update COMMUNITY_APP_ID and COMMUNITY_INSTALLATION_ID once the GitHub App
+has been created (e.g. by zoz) and the values are known.
+"""
+
+from __future__ import annotations
+
+# Placeholder values — update when the GitHub App is created.
+# These are public info (visible in GitHub UI), not secrets.
+COMMUNITY_APP_ID: int = 2953603
+COMMUNITY_INSTALLATION_ID: int = 112556330

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -128,9 +128,13 @@ class EASConfig(BaseModel):
 
 class PublishGithubConfig(BaseModel):
     owner: str = "P-U-C"
-    repo: str = "offchain-attestations"
-    token: str = ""  # PAT or installation token; never logged
-    labels: list[str] = Field(default_factory=lambda: ["attestation", "offchain"])
+    repo: str = "b1e55ed"
+    token: str = ""  # PAT (legacy); never logged
+    # GitHub App auth (preferred when app_id is non-zero)
+    # Private key is loaded from B1E55ED_GITHUB_APP_KEY env var — never stored in config.
+    app_id: int = 0  # GitHub App ID
+    installation_id: int = 0  # GitHub App Installation ID
+    labels: list[str] = Field(default_factory=lambda: ["b1e55ed-attestation"])
     mode: str = "issues"  # future: contents/ipfs
 
 

--- a/engine/integrations/eas.py
+++ b/engine/integrations/eas.py
@@ -245,6 +245,21 @@ class EASClient:
 
             if not attester:
                 return False
+
+            # Consistency check: data_bytes must match data dict if both present
+            data_field = attestation.get("data")
+            if data_field is not None and isinstance(data_field, dict):
+                import json
+
+                # Re-encode data_bytes to compare
+                try:
+                    decoded = json.loads(payload_bytes.decode("utf-8"))
+                    # Sort keys for deterministic comparison
+                    if json.dumps(decoded, sort_keys=True, separators=(",", ":")) != json.dumps(data_field, sort_keys=True, separators=(",", ":")):
+                        return False
+                except Exception:
+                    return False
+
             return recovered == attester
         except Exception:
             return False

--- a/engine/integrations/github_app.py
+++ b/engine/integrations/github_app.py
@@ -1,0 +1,247 @@
+"""engine.integrations.github_app
+
+GitHub App authentication helper.
+Generates short-lived installation tokens (1hr) from a GitHub App private key.
+
+Required env vars (or pass directly):
+  B1E55ED_GITHUB_APP_ID          — numeric App ID
+  B1E55ED_GITHUB_INSTALLATION_ID — numeric Installation ID
+  B1E55ED_GITHUB_APP_KEY         — PEM private key (raw string or path to .pem file)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API = "https://api.github.com"
+
+# Token lifetime constants
+_TOKEN_LIFETIME_SECONDS = 3600  # GitHub installation tokens last 1hr
+_TOKEN_REFRESH_BUFFER = 300  # Refresh when <5 min remain
+
+
+def _b64url(data: bytes) -> str:
+    """Base64url-encode bytes (no padding)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _load_private_key(pem: str) -> RSAPrivateKey:
+    """Load an RSA private key from a PEM string."""
+    key = serialization.load_pem_private_key(pem.encode(), password=None)
+    if not isinstance(key, RSAPrivateKey):
+        raise ValueError("GitHub App private key must be an RSA key")
+    return key
+
+
+def _resolve_pem(raw: str) -> str:
+    """
+    If ``raw`` looks like a file path that exists, read it.
+    Otherwise treat it as the PEM content directly.
+    """
+    # Strip surrounding whitespace
+    raw = raw.strip()
+    if raw and "\n" not in raw and os.path.isfile(raw):
+        return open(raw, encoding="utf-8").read()
+    return raw
+
+
+def generate_jwt(app_id: int, private_key_pem: str) -> str:
+    """Generate a signed RS256 JWT for GitHub App authentication.
+
+    Standard GitHub App JWT flow:
+      - iat = now - 60  (account for clock skew)
+      - exp = now + 540 (9 min; max is 10 min)
+      - iss = app_id (as string per GitHub docs)
+
+    Args:
+        app_id: Numeric GitHub App ID.
+        private_key_pem: PEM-encoded RSA private key string (or path to .pem file).
+
+    Returns:
+        Signed JWT string in ``header.payload.signature`` format.
+    """
+    pem = _resolve_pem(private_key_pem)
+    private_key = _load_private_key(pem)
+
+    now = int(time.time())
+    header: dict[str, Any] = {"alg": "RS256", "typ": "JWT"}
+    claims: dict[str, Any] = {
+        "iss": str(app_id),
+        "iat": now - 60,
+        "exp": now + 540,
+    }
+
+    header_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url(json.dumps(claims, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+
+    signature = private_key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    sig_b64 = _b64url(signature)
+
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+
+def get_installation_token(
+    app_id: int,
+    installation_id: int,
+    private_key_pem: str,
+) -> str:
+    """Exchange a GitHub App JWT for a short-lived installation access token.
+
+    Calls ``POST /app/installations/{installation_id}/access_tokens`` and
+    returns the token string (valid ~1hr).
+
+    Args:
+        app_id: Numeric GitHub App ID.
+        installation_id: Numeric Installation ID.
+        private_key_pem: PEM-encoded RSA private key string (or path to .pem file).
+
+    Returns:
+        Installation access token string.
+
+    Raises:
+        RuntimeError: If the API call fails.
+    """
+    jwt = generate_jwt(app_id, private_key_pem)
+    url = f"{GITHUB_API}/app/installations/{installation_id}/access_tokens"
+    headers = {
+        "Authorization": f"Bearer {jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        with httpx.Client(timeout=15.0) as client:
+            resp = client.post(url, headers=headers)
+    except Exception as exc:
+        raise RuntimeError(f"github_app: HTTP error fetching installation token: {exc}") from exc
+
+    if resp.status_code != 201:
+        raise RuntimeError(f"github_app: failed to get installation token (status={resp.status_code}, body={resp.text[:200]})")
+
+    data = resp.json()
+    token = data.get("token")
+    if not token:
+        raise RuntimeError(f"github_app: no token in response: {data!r}")
+
+    logger.debug("github_app: installation token obtained (expires_at=%s)", data.get("expires_at"))
+    return str(token)
+
+
+class GitHubAppAuth:
+    """Thread-safe GitHub App authenticator with token caching.
+
+    Caches the installation access token and refreshes it automatically
+    when less than 5 minutes remain before expiry.
+
+    Usage::
+
+        auth = GitHubAppAuth.from_env()
+        token = auth.get_token()   # refreshes if needed
+    """
+
+    def __init__(
+        self,
+        app_id: int,
+        installation_id: int,
+        private_key_pem: str,
+    ) -> None:
+        self._app_id = app_id
+        self._installation_id = installation_id
+        self._private_key_pem = _resolve_pem(private_key_pem)
+        self._lock = threading.Lock()
+        self._token: str | None = None
+        self._expires_at: float = 0.0  # Unix timestamp
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_token(self) -> str:
+        """Return a valid installation access token, refreshing if necessary."""
+        with self._lock:
+            if self._token and time.time() < (self._expires_at - _TOKEN_REFRESH_BUFFER):
+                return self._token
+            return self._refresh()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _refresh(self) -> str:
+        """Fetch a new installation token and cache it. Must be called under self._lock."""
+        logger.debug("github_app: refreshing installation token for app_id=%s", self._app_id)
+        token = get_installation_token(
+            self._app_id,
+            self._installation_id,
+            self._private_key_pem,
+        )
+        self._token = token
+        # GitHub tokens last 1hr; track expiry conservatively
+        self._expires_at = time.time() + _TOKEN_LIFETIME_SECONDS
+        return token
+
+    # ------------------------------------------------------------------
+    # Factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_env(cls) -> GitHubAppAuth:
+        """Construct a GitHubAppAuth from environment variables.
+
+        Required env vars:
+          B1E55ED_GITHUB_APP_ID          — numeric App ID
+          B1E55ED_GITHUB_INSTALLATION_ID — numeric Installation ID
+          B1E55ED_GITHUB_APP_KEY         — PEM private key (raw or path to .pem file)
+
+        Raises:
+            RuntimeError: If any required env var is missing or invalid.
+        """
+        missing: list[str] = []
+
+        app_id_raw = os.environ.get("B1E55ED_GITHUB_APP_ID", "")
+        if not app_id_raw:
+            missing.append("B1E55ED_GITHUB_APP_ID")
+
+        installation_id_raw = os.environ.get("B1E55ED_GITHUB_INSTALLATION_ID", "")
+        if not installation_id_raw:
+            missing.append("B1E55ED_GITHUB_INSTALLATION_ID")
+
+        private_key_pem = os.environ.get("B1E55ED_GITHUB_APP_KEY", "")
+        if not private_key_pem:
+            missing.append("B1E55ED_GITHUB_APP_KEY")
+
+        if missing:
+            raise RuntimeError(
+                f"github_app: missing required environment variable(s): {', '.join(missing)}. "
+                "Set B1E55ED_GITHUB_APP_ID, B1E55ED_GITHUB_INSTALLATION_ID, "
+                "and B1E55ED_GITHUB_APP_KEY to use GitHub App auth."
+            )
+
+        try:
+            app_id = int(app_id_raw)
+        except ValueError:
+            raise RuntimeError(f"github_app: B1E55ED_GITHUB_APP_ID must be a number, got: {app_id_raw!r}") from None
+
+        try:
+            installation_id = int(installation_id_raw)
+        except ValueError:
+            raise RuntimeError(f"github_app: B1E55ED_GITHUB_INSTALLATION_ID must be a number, got: {installation_id_raw!r}") from None
+
+        return cls(app_id=app_id, installation_id=installation_id, private_key_pem=private_key_pem)
+
+    def __repr__(self) -> str:
+        return f"GitHubAppAuth(app_id={self._app_id}, installation_id={self._installation_id}, cached={'yes' if self._token else 'no'})"

--- a/engine/integrations/github_publish.py
+++ b/engine/integrations/github_publish.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+if TYPE_CHECKING:
+    from engine.integrations.github_app import GitHubAppAuth
 
 logger = logging.getLogger(__name__)
 
@@ -78,14 +81,31 @@ def publish_attestation_to_github(
     repo: str,
     token: str,
     labels: list[str] | None = None,
+    app_auth: GitHubAppAuth | None = None,
 ) -> dict[str, Any] | None:
     """Create a GitHub Issue for the given attestation.
+
+    Accepts either a static PAT ``token`` or a ``GitHubAppAuth`` instance.
+    When ``app_auth`` is provided it takes precedence; a fresh installation
+    token is fetched before each request.
 
     Returns ``{issue_url, issue_number, owner, repo}`` on success, or
     ``None`` on any failure (fail-open: never raises).
     """
-    if not token:
-        logger.warning("github_publish: no token provided — skipping")
+
+    # Resolve the effective token (app_auth wins over static PAT)
+    def _get_effective_token() -> str:
+        if app_auth is not None:
+            try:
+                return app_auth.get_token()
+            except Exception as exc:
+                logger.warning("github_publish: app_auth.get_token() failed: %s", exc)
+                return ""
+        return token
+
+    effective = _get_effective_token()
+    if not effective:
+        logger.warning("github_publish: no token available — skipping")
         return None
 
     uid = str(attestation.get("uid") or "unknown")
@@ -104,11 +124,6 @@ def publish_attestation_to_github(
         payload["labels"] = labels
 
     url = f"{GITHUB_API}/repos/{owner}/{repo}/issues"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
 
     attempt = 0
     last_status: int | None = None
@@ -117,6 +132,17 @@ def publish_attestation_to_github(
         with httpx.Client(timeout=15.0) as client:
             while attempt < _MAX_ATTEMPTS:
                 attempt += 1
+                # Re-fetch token each attempt so app_auth can provide a fresh one
+                current_token = _get_effective_token()
+                if not current_token:
+                    logger.warning("github_publish: token unavailable on attempt %d — aborting", attempt)
+                    return None
+
+                headers = {
+                    "Authorization": f"Bearer {current_token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                }
                 try:
                     resp = client.post(url, json=payload, headers=headers)
                     last_status = resp.status_code
@@ -144,7 +170,7 @@ def publish_attestation_to_github(
                         resp.status_code,
                         owner,
                         repo,
-                        _redact_token(token),
+                        _redact_token(current_token),
                     )
                     return None
 
@@ -176,8 +202,18 @@ def publish_attestation_to_github(
     return None
 
 
-def make_publisher(*, owner: str, repo: str, token: str, labels: list[str] | None = None) -> object:
+def make_publisher(
+    *,
+    token: str = "",
+    app_auth: GitHubAppAuth | None = None,
+    owner: str = "P-U-C",
+    repo: str = "b1e55ed",
+    labels: list[str] | None = None,
+) -> object:
     """Return a callable publisher bound to the given config.
+
+    Accepts either a static PAT ``token`` or a ``GitHubAppAuth`` instance.
+    When ``app_auth`` is provided it takes precedence over ``token``.
 
     The returned callable matches the ``github_publisher`` signature expected by
     ``ContributorRegistry``:
@@ -194,4 +230,5 @@ def make_publisher(*, owner: str, repo: str, token: str, labels: list[str] | Non
         repo=repo,
         token=token,
         labels=labels,
+        app_auth=app_auth,
     )

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ info "Checking Python version..."
 PYTHON_BIN=""
 for candidate in python3.13 python3.12 python3.11 python3; do
     if command -v "$candidate" &>/dev/null; then
-        version=$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        version=$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null)
         major=$(echo "$version" | cut -d. -f1)
         minor=$(echo "$version" | cut -d. -f2)
         if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 11 ]; }; then
@@ -43,6 +43,48 @@ for candidate in python3.13 python3.12 python3.11 python3; do
 done
 
 if [ -z "$PYTHON_BIN" ]; then
+    # Try to bootstrap Python via uv (works even without Homebrew)
+    if command -v uv &>/dev/null || [[ "$OSTYPE" == "darwin"* ]]; then
+        # Install uv first if needed on macOS
+        if ! command -v uv &>/dev/null; then
+            info "No Python found — installing uv to bootstrap Python..."
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+        fi
+        if command -v uv &>/dev/null; then
+            info "No Python found — bootstrapping via uv..."
+            uv python install 3.13 || uv python install 3.12 || true
+            # Re-probe standard candidates
+            for candidate in python3.13 python3.12 python3.11; do
+                if command -v "$candidate" &>/dev/null 2>/dev/null; then
+                    version=$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null)
+                    major=$(echo "$version" | cut -d. -f1)
+                    minor=$(echo "$version" | cut -d. -f2)
+                    if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 11 ]; }; then
+                        PYTHON_BIN="$candidate"
+                        success "Python $version found via bootstrap ($PYTHON_BIN)"
+                        break
+                    fi
+                fi
+            done
+            # Also try uv's managed Python path directly
+            if [ -z "$PYTHON_BIN" ]; then
+                UV_PYTHON=$(uv python find 3.13 2>/dev/null || uv python find 3.12 2>/dev/null || uv python find 3.11 2>/dev/null || true)
+                if [ -n "$UV_PYTHON" ]; then
+                    version=$("$UV_PYTHON" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null)
+                    major=$(echo "$version" | cut -d. -f1)
+                    minor=$(echo "$version" | cut -d. -f2)
+                    if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 11 ]; }; then
+                        PYTHON_BIN="$UV_PYTHON"
+                        success "Python $version found via uv managed path ($PYTHON_BIN)"
+                    fi
+                fi
+            fi
+        fi
+    fi
+fi
+
+if [ -z "$PYTHON_BIN" ]; then
     error "Python 3.11+ is required but not found."
     echo ""
     echo "  Install Python 3.11+ for your OS:"
@@ -50,8 +92,10 @@ if [ -z "$PYTHON_BIN" ]; then
 
     # Detect OS for install instructions
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo "  macOS (Homebrew):"
+        echo "  macOS (Homebrew or uv):"
         echo "    brew install python@3.11"
+        echo "    # or:"
+        echo "    uv python install 3.13"
     elif [ -f /etc/debian_version ]; then
         echo "  Ubuntu/Debian:"
         echo "    sudo apt update && sudo apt install python3.11 python3.11-venv"
@@ -175,6 +219,42 @@ else
     warn "b1e55ed binary not found in PATH yet."
     echo "  You may need to restart your shell or run:"
     echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+fi
+
+# ── Step 6: Download Rust forge binary ────────────────────────────────────────
+info "Downloading Rust forge binary..."
+
+FORGE_DIR="$HOME/.local/share/b1e55ed/bin"
+mkdir -p "$FORGE_DIR"
+
+# Resolve latest release tag (including pre-releases — /releases/latest skips them)
+RELEASE_TAG=$(curl -fsSL "https://api.github.com/repos/P-U-C/b1e55ed/releases?per_page=1" 2>/dev/null \
+    | python3 -c "import sys,json; r=json.load(sys.stdin); print(r[0]['tag_name'])" 2>/dev/null || echo "")
+
+# Detect platform
+FORGE_URL=""
+if [ -n "$RELEASE_TAG" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # Universal binary — works on both Apple Silicon and Intel
+        FORGE_URL="https://github.com/P-U-C/b1e55ed/releases/download/${RELEASE_TAG}/b1e55ed-forge-macos"
+    elif [[ "$OSTYPE" == "linux"* ]]; then
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "x86_64" ]]; then
+            FORGE_URL="https://github.com/P-U-C/b1e55ed/releases/download/${RELEASE_TAG}/b1e55ed-forge-linux-x86_64"
+        fi
+    fi
+fi
+
+if [ -n "$FORGE_URL" ]; then
+    if curl -fsSL "$FORGE_URL" -o "$FORGE_DIR/b1e55ed-forge" 2>/dev/null; then
+        chmod +x "$FORGE_DIR/b1e55ed-forge"
+        success "Rust forge binary installed (~50M candidates/sec)"
+    else
+        warn "Could not download forge binary (no release yet) — Python fallback will be used"
+        warn "Run 'b1e55ed identity forge' after a release is published, or use random identity"
+    fi
+else
+    warn "No forge binary available for this platform — use 'b1e55ed identity forge' with Python fallback or random identity"
 fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "b1e55ed"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 description = "Sovereign AI trading intelligence with compound learning"
 readme = "README.md"
 license = {text = "MIT"}
@@ -19,12 +19,12 @@ dependencies = [
     "uvicorn>=0.29",
     "jinja2>=3.1",
     "argon2-cffi>=25.1.0",
+    "eth-account>=0.11",
 ]
 
 [project.optional-dependencies]
 eas = [
     "eth-abi>=5.1",
-    "eth-account>=0.11",
     "eth-typing>=3.5",
 ]
 

--- a/tests/unit/test_b1e55ing.py
+++ b/tests/unit/test_b1e55ing.py
@@ -528,9 +528,6 @@ def test_post_merge_already_blessed_skips() -> None:
     # Trigger is pull_request closed, not push (must not run on direct commits)
     assert "types: [closed]" in src
 
-    # Commit message is canonical
-    assert "chore: a b1e55ing [skip ci]" in src
-
-    # Author identity is consistent with the rest of the system
-    assert 'user.name "a b1e55ing"' in src
-    assert "bot@permanentupperclass.com" in src
+    # Post-merge path delivers blessing as a PR comment (not a direct push)
+    assert "createComment" in src
+    assert "a b1e55ing" in src

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# uninstall.sh — b1e55ed uninstaller
+# Usage: ./uninstall.sh
+#   or:  curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/uninstall.sh | bash
+#
+# Flags:
+#   --yes         Skip all confirmations and remove everything
+#   --keep-data   Remove binary/tool but preserve data and config dirs
+set -euo pipefail
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+info()    { echo -e "${BOLD}[b1e55ed]${RESET} $*"; }
+success() { echo -e "${GREEN}✓${RESET} $*"; }
+skipped() { echo -e "${DIM}–${RESET} $*"; }
+warn()    { echo -e "${YELLOW}⚠${RESET} $*"; }
+error()   { echo -e "${RED}✗ ERROR:${RESET} $*" >&2; }
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+YES_ALL=0
+KEEP_DATA=0
+for arg in "$@"; do
+    case "$arg" in
+        --yes)       YES_ALL=1  ;;
+        --keep-data) KEEP_DATA=1 ;;
+        --help|-h)
+            echo "Usage: ./uninstall.sh [--yes] [--keep-data]"
+            echo "  --yes         Skip all confirmations"
+            echo "  --keep-data   Preserve data + config directories"
+            exit 0
+            ;;
+        *)
+            warn "Unknown flag: $arg (ignored)"
+            ;;
+    esac
+done
+
+REMOVED=()
+SKIPPED=()
+
+# ── Confirmation helper ───────────────────────────────────────────────────────
+# Usage: confirm "prompt" <default_yes|default_no>
+# Returns 0 (yes) or 1 (no)
+confirm() {
+    local prompt="$1"
+    local default="${2:-yes}"   # "yes" or "no"
+
+    if [ "$YES_ALL" -eq 1 ]; then
+        echo -e "  ${prompt} ${DIM}[auto-yes]${RESET}"
+        return 0
+    fi
+
+    local hint
+    if [ "$default" = "yes" ]; then
+        hint="[Y/n]"
+    else
+        hint="[y/N]"
+    fi
+
+    local answer
+    read -rp "  ${prompt} ${hint}: " answer || true
+    answer="${answer:-}"
+
+    if [ -z "$answer" ]; then
+        [ "$default" = "yes" ] && return 0 || return 1
+    fi
+    case "${answer,,}" in
+        y|yes|1) return 0 ;;
+        *)        return 1 ;;
+    esac
+}
+
+# ── RC-file line removal ──────────────────────────────────────────────────────
+# Remove lines matching a pattern (and their preceding installer comment) from a file.
+# Usage: remove_rc_lines <file> <pattern> <description>
+remove_rc_lines() {
+    local file="$1"
+    local pattern="$2"
+    local desc="$3"
+
+    [ -f "$file" ] || return 0
+    grep -qF "$pattern" "$file" 2>/dev/null || return 0
+
+    # Use Python (if available) or sed for portable multi-line removal.
+    # We need to remove both the comment marker line and the matching line.
+    if command -v python3 &>/dev/null; then
+        python3 - "$file" "$pattern" <<'PYEOF'
+import sys, pathlib
+
+path = pathlib.Path(sys.argv[1])
+pattern = sys.argv[2]
+marker = "# Added by b1e55ed installer"
+
+lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+new_lines = []
+skip_next = False
+for i, line in enumerate(lines):
+    if skip_next:
+        skip_next = False
+        continue
+    stripped = line.rstrip()
+    if stripped == marker and i + 1 < len(lines):
+        next_stripped = lines[i + 1].rstrip()
+        if pattern in next_stripped:
+            skip_next = True
+            continue
+    if pattern in stripped:
+        continue
+    new_lines.append(line)
+
+path.write_text("".join(new_lines), encoding="utf-8")
+PYEOF
+    else
+        # Fallback: plain sed (removes matching lines, not the comment)
+        sed -i "/$pattern/d" "$file" 2>/dev/null || true
+    fi
+
+    success "Removed ${desc} from ${file}"
+}
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+echo ""
+echo "  ╔══════════════════════════════════════════╗"
+echo "  ║         b1e55ed uninstaller              ║"
+echo "  ╚══════════════════════════════════════════╝"
+echo ""
+if [ "$YES_ALL" -eq 1 ]; then
+    warn "--yes mode: all confirmations will be auto-accepted."
+fi
+if [ "$KEEP_DATA" -eq 1 ]; then
+    warn "--keep-data mode: data and config directories will be preserved."
+fi
+echo ""
+
+# ── Step 1: Check if b1e55ed binary exists ───────────────────────────────────
+info "[1/5] Checking for b1e55ed binary..."
+echo ""
+
+LOCAL_BIN="$HOME/.local/bin"
+B1E55ED_BIN="${LOCAL_BIN}/b1e55ed"
+
+if command -v b1e55ed &>/dev/null; then
+    B1E55ED_PATH="$(command -v b1e55ed)"
+    success "b1e55ed found at: ${B1E55ED_PATH}"
+elif [ -f "$B1E55ED_BIN" ]; then
+    B1E55ED_PATH="$B1E55ED_BIN"
+    success "b1e55ed found at: ${B1E55ED_BIN}"
+else
+    skipped "b1e55ed binary not found in PATH or ~/.local/bin"
+    B1E55ED_PATH=""
+fi
+echo ""
+
+# ── Step 2: uv tool uninstall ─────────────────────────────────────────────────
+info "[2/5] uv tool uninstall..."
+echo ""
+
+if command -v uv &>/dev/null; then
+    if confirm "Remove b1e55ed uv tool installation? (runs: uv tool uninstall b1e55ed)" "yes"; then
+        if uv tool uninstall b1e55ed 2>&1; then
+            success "uv tool uninstall succeeded"
+            REMOVED+=("uv tool (b1e55ed)")
+        else
+            warn "uv tool uninstall failed (may not be installed as a uv tool — continuing)"
+            SKIPPED+=("uv tool uninstall (not installed or error)")
+        fi
+    else
+        skipped "uv tool uninstall skipped by user"
+        SKIPPED+=("uv tool uninstall (skipped)")
+    fi
+else
+    skipped "uv not found in PATH — skipping uv tool uninstall"
+    SKIPPED+=("uv tool uninstall (uv not found)")
+fi
+echo ""
+
+# ── Step 3: Remove ~/.local/bin/b1e55ed ──────────────────────────────────────
+info "[3/5] Remove binary..."
+echo ""
+
+if [ -f "$B1E55ED_BIN" ]; then
+    if confirm "Remove binary at ${B1E55ED_BIN}?" "yes"; then
+        rm -f "$B1E55ED_BIN"
+        success "Removed ${B1E55ED_BIN}"
+        REMOVED+=("~/.local/bin/b1e55ed")
+    else
+        skipped "Binary not removed (kept at ${B1E55ED_BIN})"
+        SKIPPED+=("binary (~/.local/bin/b1e55ed)")
+    fi
+else
+    skipped "~/.local/bin/b1e55ed not found (already removed)"
+    SKIPPED+=("binary (not found)")
+fi
+echo ""
+
+# ── Step 4: Remove data / config dirs ─────────────────────────────────────────
+info "[4/5] Data and config directories..."
+echo ""
+
+if [ "$KEEP_DATA" -eq 1 ]; then
+    skipped "--keep-data: preserving all data and config directories"
+    SKIPPED+=("data + config dirs (--keep-data)")
+else
+    # ~/.local/share/b1e55ed
+    XDG_DATA="${HOME}/.local/share/b1e55ed"
+    if [ -d "$XDG_DATA" ]; then
+        if confirm "Remove local data dir at ${XDG_DATA}?" "no"; then
+            rm -rf "$XDG_DATA"
+            success "Removed ${XDG_DATA}"
+            REMOVED+=("~/.local/share/b1e55ed")
+        else
+            skipped "Data dir kept at ${XDG_DATA}"
+            SKIPPED+=("~/.local/share/b1e55ed (skipped)")
+        fi
+    else
+        skipped "~/.local/share/b1e55ed not found"
+    fi
+
+    # ~/.config/b1e55ed
+    XDG_CONFIG="${HOME}/.config/b1e55ed"
+    if [ -d "$XDG_CONFIG" ]; then
+        if confirm "Remove config dir at ${XDG_CONFIG}?" "no"; then
+            rm -rf "$XDG_CONFIG"
+            success "Removed ${XDG_CONFIG}"
+            REMOVED+=("~/.config/b1e55ed")
+        else
+            skipped "Config dir kept at ${XDG_CONFIG}"
+            SKIPPED+=("~/.config/b1e55ed (skipped)")
+        fi
+    else
+        skipped "~/.config/b1e55ed not found"
+    fi
+
+    # If running from inside the repo, ask about data/ and .b1e55ed/
+    if [ -f "pyproject.toml" ] && grep -q 'b1e55ed' pyproject.toml 2>/dev/null; then
+        REPO_DATA="$(pwd)/data"
+        REPO_CONFIG="$(pwd)/.b1e55ed"
+
+        if [ -d "$REPO_DATA" ]; then
+            if confirm "Remove repo data dir at ${REPO_DATA}?" "no"; then
+                rm -rf "$REPO_DATA"
+                success "Removed ${REPO_DATA}"
+                REMOVED+=("$(pwd)/data")
+            else
+                skipped "Repo data dir kept at ${REPO_DATA}"
+                SKIPPED+=("$(pwd)/data (skipped)")
+            fi
+        fi
+
+        if [ -d "$REPO_CONFIG" ]; then
+            if confirm "Remove repo identity/config dir at ${REPO_CONFIG}?" "no"; then
+                rm -rf "$REPO_CONFIG"
+                success "Removed ${REPO_CONFIG}"
+                REMOVED+=("$(pwd)/.b1e55ed")
+            else
+                skipped "Repo config dir kept at ${REPO_CONFIG}"
+                SKIPPED+=("$(pwd)/.b1e55ed (skipped)")
+            fi
+        fi
+    fi
+fi
+echo ""
+
+# ── Step 5: Remove shell rc additions ────────────────────────────────────────
+info "[5/5] Shell RC cleanup..."
+echo ""
+
+RC_FILES=("$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile")
+PATH_PATTERN=".local/bin"
+PW_PATTERN="B1E55ED_MASTER_PASSWORD"
+
+any_rc_changed=0
+for rc in "${RC_FILES[@]}"; do
+    [ -f "$rc" ] || continue
+
+    # PATH export lines
+    if grep -qF "$PATH_PATTERN" "$rc" 2>/dev/null; then
+        if confirm "Remove ~/.local/bin PATH line from ${rc}?" "yes"; then
+            remove_rc_lines "$rc" "$PATH_PATTERN" "PATH export"
+            REMOVED+=("PATH line in ${rc}")
+            any_rc_changed=1
+        else
+            skipped "PATH line kept in ${rc}"
+            SKIPPED+=("PATH line in ${rc}")
+        fi
+    fi
+
+    # B1E55ED_MASTER_PASSWORD lines
+    if grep -qF "$PW_PATTERN" "$rc" 2>/dev/null; then
+        if confirm "Remove B1E55ED_MASTER_PASSWORD export from ${rc}?" "yes"; then
+            remove_rc_lines "$rc" "$PW_PATTERN" "B1E55ED_MASTER_PASSWORD export"
+            REMOVED+=("B1E55ED_MASTER_PASSWORD in ${rc}")
+            any_rc_changed=1
+        else
+            skipped "B1E55ED_MASTER_PASSWORD kept in ${rc}"
+            SKIPPED+=("B1E55ED_MASTER_PASSWORD in ${rc}")
+        fi
+    fi
+done
+
+if [ "$any_rc_changed" -eq 0 ]; then
+    skipped "No shell rc additions found to remove"
+fi
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo -e "${GREEN}══════════════════════════════════════════${RESET}"
+echo ""
+
+if [ "${#REMOVED[@]}" -gt 0 ]; then
+    echo -e "${BOLD}Removed:${RESET}"
+    for item in "${REMOVED[@]}"; do
+        echo -e "  ${GREEN}✓${RESET} ${item}"
+    done
+    echo ""
+fi
+
+if [ "${#SKIPPED[@]}" -gt 0 ]; then
+    echo -e "${BOLD}Skipped / not found:${RESET}"
+    for item in "${SKIPPED[@]}"; do
+        echo -e "  ${DIM}–${RESET} ${item}"
+    done
+    echo ""
+fi
+
+if [ "${#REMOVED[@]}" -gt 0 ]; then
+    echo -e "${GREEN}${BOLD}Uninstall complete.${RESET} b1e55ed has been removed."
+else
+    echo -e "${YELLOW}Uninstall finished with no changes.${RESET}"
+fi
+echo ""
+echo -e "${GREEN}══════════════════════════════════════════${RESET}"
+echo ""

--- a/uv.lock
+++ b/uv.lock
@@ -98,11 +98,12 @@ wheels = [
 
 [[package]]
 name = "b1e55ed"
-version = "1.0.0b4"
+version = "1.0.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },
     { name = "cryptography" },
+    { name = "eth-account" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -129,7 +130,6 @@ dev = [
 ]
 eas = [
     { name = "eth-abi" },
-    { name = "eth-account" },
     { name = "eth-typing" },
 ]
 exchange = [
@@ -146,7 +146,7 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "eth-abi", marker = "extra == 'eas'", specifier = ">=5.1" },
-    { name = "eth-account", marker = "extra == 'eas'", specifier = ">=0.11" },
+    { name = "eth-account", specifier = ">=0.11" },
     { name = "eth-typing", marker = "extra == 'eas'", specifier = ">=3.5" },
     { name = "fastapi", specifier = ">=0.109" },
     { name = "httpx", specifier = ">=0.27" },

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,1316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>b1e55ed — Sovereign AI Trading Intelligence</title>
+<meta name="description" content="The sovereign trading OS for operators whose data powers the default pre-trade provenance check for every vibe-coded bot in the ecosystem.">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #050505;
+    --bg-panel: #0a0f0a;
+    --bg-elevated: #0f1a0f;
+    --border-dim: #243e24;
+    --border-active: #3a5e3a;
+    --text-primary: #ddeedd;
+    --text-bright: #00ff41;
+    --text-dim: #7a9e7a;
+    --text-muted: #4a6a4a;
+    --cyan: #00ccff;
+    --amber: #ffaa00;
+    --red: #ff3333;
+    --glow-green: 0 0 20px rgba(0,255,65,0.15);
+    --glow-cyan: 0 0 20px rgba(0,204,255,0.15);
+    --glow-amber: 0 0 20px rgba(255,170,0,0.12);
+    --font: 'IBM Plex Mono', 'Courier New', monospace;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+
+  body {
+    background: var(--bg);
+    color: var(--text-primary);
+    font-family: var(--font);
+    font-size: 14px;
+    line-height: 1.7;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Scanlines */
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: repeating-linear-gradient(0deg,transparent,transparent 2px,rgba(0,0,0,0.03) 2px,rgba(0,0,0,0.03) 4px);
+    pointer-events: none;
+    z-index: 9999;
+  }
+
+  /* Noise */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    opacity: 0.03;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    pointer-events: none;
+    z-index: 9998;
+  }
+
+  a { color: var(--cyan); text-decoration: none; transition: color 0.2s; }
+  a:hover { color: var(--text-bright); }
+  ::selection { background: rgba(0,255,65,0.15); color: var(--text-bright); }
+
+  /* === NAV === */
+  nav {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: 52px;
+    background: rgba(5,5,5,0.92);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border-dim);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 32px;
+    z-index: 1000;
+  }
+
+  .nav-wordmark {
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--text-dim);
+    letter-spacing: 0.08em;
+  }
+
+  .nav-links {
+    display: flex;
+    gap: 28px;
+    list-style: none;
+  }
+
+  .nav-links a {
+    font-size: 12px;
+    color: var(--text-dim);
+    letter-spacing: 0.06em;
+    transition: color 0.2s;
+  }
+
+  .nav-links a:hover { color: var(--text-primary); }
+
+  .nav-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+  }
+
+  .status-dot {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--text-bright);
+    box-shadow: 0 0 8px rgba(0,255,65,0.4);
+    animation: pulse 2.5s ease-in-out infinite;
+  }
+
+  /* === LAYOUT === */
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 32px; }
+  section { padding: 100px 0; position: relative; }
+
+  /* === HERO === */
+  .hero {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding-top: 52px;
+    position: relative;
+  }
+
+  .hero-content { position: relative; z-index: 2; }
+
+  .hero-waveform {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    overflow: hidden;
+    z-index: 1;
+    opacity: 0.35;
+  }
+
+  .hero-waveform svg { width: 100%; height: 100%; position: absolute; top: 0; left: 0; }
+
+  .hero-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    margin-bottom: 24px;
+    animation: fadeSlideUp 0.8s ease-out 0.2s both;
+  }
+
+  .hero h1 {
+    font-size: 40px;
+    font-weight: 300;
+    letter-spacing: 0.02em;
+    line-height: 1.25;
+    margin-bottom: 28px;
+    animation: fadeSlideUp 0.8s ease-out 0.35s both;
+  }
+
+  .hero h1 .hl-green { color: var(--text-bright); text-shadow: var(--glow-green); }
+  .hero h1 .hl-cyan { color: var(--cyan); text-shadow: var(--glow-cyan); }
+
+  .hero-sub {
+    font-size: 15px;
+    font-weight: 400;
+    color: var(--text-dim);
+    max-width: 640px;
+    line-height: 1.8;
+    margin-bottom: 48px;
+    animation: fadeSlideUp 0.8s ease-out 0.5s both;
+  }
+
+  .hero-actions {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    animation: fadeSlideUp 0.8s ease-out 0.65s both;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 24px;
+    font-family: var(--font);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    border: 1px solid var(--border-active);
+    background: var(--bg-panel);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.25s;
+    text-decoration: none;
+  }
+
+  .btn:hover { background: var(--bg-elevated); border-color: var(--text-dim); color: var(--text-bright); }
+
+  .btn-primary {
+    border-color: var(--text-bright);
+    color: var(--text-bright);
+    box-shadow: var(--glow-green);
+  }
+
+  .btn-primary:hover { background: rgba(0,255,65,0.06); color: var(--text-bright); }
+
+  .btn-cyan { border-color: var(--cyan); color: var(--cyan); }
+  .btn-cyan:hover { background: rgba(0,204,255,0.06); color: var(--cyan); }
+
+  .hero-meta {
+    margin-top: 56px;
+    display: flex;
+    gap: 40px;
+    animation: fadeSlideUp 0.8s ease-out 0.8s both;
+  }
+
+  .hero-stat { display: flex; flex-direction: column; }
+  .hero-stat-val { font-size: 18px; font-weight: 500; color: var(--text-bright); }
+  .hero-stat-label { font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; margin-top: 4px; }
+
+  /* === SECTION TITLES === */
+  .section-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+
+  .section-title {
+    font-size: 24px;
+    font-weight: 300;
+    color: var(--text-primary);
+    margin-bottom: 48px;
+    letter-spacing: 0.02em;
+  }
+
+  /* === THESIS === */
+  .thesis {
+    border-top: 1px solid var(--border-dim);
+    border-bottom: 1px solid var(--border-dim);
+    padding: 80px 0;
+  }
+
+  .thesis-text {
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--text-dim);
+    max-width: 760px;
+  }
+
+  .thesis-text em { font-style: normal; color: var(--text-bright); }
+
+  /* === DUAL TRACK === */
+  .tracks-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+  }
+
+  .track-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 44px 36px 40px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .track-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+  }
+
+  .track-card-a::before { background: linear-gradient(90deg, var(--text-bright), transparent); }
+  .track-card-b::before { background: linear-gradient(90deg, var(--cyan), transparent); }
+
+  .track-tag {
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+
+  .track-card-a .track-tag { color: var(--text-bright); }
+  .track-card-b .track-tag { color: var(--cyan); }
+
+  .track-heading { font-size: 20px; font-weight: 300; color: var(--text-primary); margin-bottom: 4px; }
+  .track-subtitle { font-size: 12px; color: var(--text-dim); letter-spacing: 0.04em; margin-bottom: 20px; }
+
+  .track-body {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--text-dim);
+    line-height: 1.8;
+    margin-bottom: 28px;
+  }
+
+  .track-specs { display: grid; gap: 0; }
+
+  .spec-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border-dim);
+    font-size: 12px;
+  }
+
+  .spec-row:last-child { border-bottom: none; }
+
+  .spec-key { color: var(--text-dim); letter-spacing: 0.05em; text-transform: uppercase; font-size: 10px; }
+  .spec-val { font-weight: 500; }
+  .track-card-a .spec-val { color: var(--text-bright); }
+  .track-card-b .spec-val { color: var(--cyan); }
+
+  /* === FLYWHEEL (infographic integrated) === */
+  .flywheel-visual {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 56px 40px 48px;
+    text-align: center;
+    position: relative;
+  }
+
+  .flywheel-visual::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 50%;
+    transform: translateX(-50%);
+    width: 200px;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--amber), transparent);
+  }
+
+  .flywheel-tag {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--amber);
+    text-shadow: var(--glow-amber);
+    margin-bottom: 40px;
+  }
+
+  .flow-chain {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0;
+    margin: 0 auto 12px;
+    max-width: 960px;
+  }
+
+  .flow-node {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 16px 10px;
+    min-width: 130px;
+    max-width: 160px;
+  }
+
+  .flow-node-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    margin-bottom: 12px;
+  }
+
+  .flow-node-dot.green { background: var(--text-bright); box-shadow: 0 0 12px rgba(0,255,65,0.3); }
+  .flow-node-dot.cyan { background: var(--cyan); box-shadow: 0 0 12px rgba(0,204,255,0.3); }
+  .flow-node-dot.amber { background: var(--amber); box-shadow: 0 0 12px rgba(255,170,0,0.3); }
+
+  .flow-node-label { font-size: 11px; font-weight: 500; color: var(--text-primary); margin-bottom: 4px; letter-spacing: 0.03em; text-align: center; }
+  .flow-node-desc { font-size: 9.5px; color: var(--text-dim); text-align: center; letter-spacing: 0.02em; line-height: 1.5; }
+
+  .flow-arrow-seg {
+    color: var(--text-muted);
+    font-size: 18px;
+    padding: 0 2px;
+    margin-top: 12px;
+    animation: arrowPulse 2s ease-in-out infinite;
+  }
+
+  .flow-arrow-seg:nth-child(4n) { animation-delay: 0.3s; }
+  .flow-arrow-seg:nth-child(6n) { animation-delay: 0.6s; }
+  .flow-arrow-seg:nth-child(8n) { animation-delay: 0.9s; }
+
+  @keyframes arrowPulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.8; color: var(--amber); }
+  }
+
+  .flow-return {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 8px;
+    padding: 12px 0;
+  }
+
+  .flow-return-line {
+    flex: 1;
+    max-width: 300px;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--amber), transparent);
+    opacity: 0.4;
+  }
+
+  .flow-return-label {
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    color: var(--amber);
+    text-transform: uppercase;
+    opacity: 0.7;
+    white-space: nowrap;
+  }
+
+  .flywheel-bottom-text {
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--text-dim);
+    max-width: 560px;
+    margin: 24px auto 0;
+    line-height: 1.8;
+  }
+
+  .flywheel-bottom-text strong { font-weight: 500; color: var(--amber); }
+
+  /* === WHY BOTH (from infographic) === */
+  .why-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 2px;
+    margin-top: 2px;
+  }
+
+  .why-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 28px 24px 24px;
+  }
+
+  .why-card-label {
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+  }
+
+  .why-card-condition { font-size: 13px; font-weight: 400; color: var(--text-primary); margin-bottom: 8px; }
+  .why-card-result { font-size: 12px; font-weight: 400; color: var(--text-dim); line-height: 1.6; }
+
+  .why-card.active { border-color: var(--border-active); }
+  .why-card.active .why-card-label { color: var(--text-bright); text-shadow: var(--glow-green); }
+
+  /* === ARCHITECTURE === */
+  .arch-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+    margin-top: 48px;
+  }
+
+  .arch-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 32px 28px 28px;
+  }
+
+  .arch-card-label {
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.15em;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    margin-bottom: 16px;
+  }
+
+  .arch-card-title { font-size: 15px; font-weight: 400; color: var(--text-primary); margin-bottom: 8px; }
+
+  .arch-card-desc {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--text-dim);
+    line-height: 1.7;
+  }
+
+  .arch-card-desc .code { color: var(--text-bright); font-size: 12px; }
+
+  .arch-card-full { grid-column: 1 / -1; }
+
+  /* Pipeline flow */
+  .pipeline-flow {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 16px;
+  }
+
+  .pf-step {
+    font-size: 11px;
+    padding: 6px 14px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-dim);
+    color: var(--text-primary);
+    white-space: nowrap;
+  }
+
+  .pf-step.highlight { border-color: var(--border-active); color: var(--text-bright); }
+  .pf-arrow { color: var(--text-muted); font-size: 14px; }
+
+  /* === AGENT INTERFACES (new section) === */
+  .interfaces-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 2px;
+    margin-top: 48px;
+  }
+
+  .interface-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 32px 24px 28px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .interface-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+  }
+
+  .ifc-oracle::before { background: linear-gradient(90deg, var(--amber), transparent); }
+  .ifc-mcp::before { background: linear-gradient(90deg, var(--cyan), transparent); }
+  .ifc-sse::before { background: linear-gradient(90deg, var(--text-bright), transparent); }
+
+  .ifc-tag {
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+
+  .ifc-oracle .ifc-tag { color: var(--amber); }
+  .ifc-mcp .ifc-tag { color: var(--cyan); }
+  .ifc-sse .ifc-tag { color: var(--text-bright); }
+
+  .ifc-title { font-size: 15px; font-weight: 400; color: var(--text-primary); margin-bottom: 4px; }
+  .ifc-endpoint { font-size: 11px; color: var(--text-dim); margin-bottom: 12px; letter-spacing: 0.02em; }
+  .ifc-desc { font-size: 12px; font-weight: 400; color: var(--text-dim); line-height: 1.7; }
+  .ifc-auth { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 12px; }
+  .ifc-auth.none { color: var(--text-bright); }
+  .ifc-auth.required { color: var(--text-muted); }
+
+  /* === SYSTEM STATUS === */
+  .status-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2px;
+    margin-top: 40px;
+  }
+
+  .status-cell {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 24px 20px;
+    text-align: center;
+  }
+
+  .status-cell-val { font-size: 18px; font-weight: 500; color: var(--text-bright); margin-bottom: 6px; }
+  .status-cell-label { font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; }
+
+  /* === CTA === */
+  .cta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2px;
+    margin-top: 48px;
+  }
+
+  .cta-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    padding: 44px 36px;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .cta-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+  }
+
+  .cta-card-a::before { background: linear-gradient(90deg, var(--text-bright), transparent); }
+  .cta-card-b::before { background: linear-gradient(90deg, var(--cyan), transparent); }
+
+  .cta-card-tag {
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+
+  .cta-card-a .cta-card-tag { color: var(--text-bright); }
+  .cta-card-b .cta-card-tag { color: var(--cyan); }
+
+  .cta-card-title { font-size: 18px; font-weight: 300; color: var(--text-primary); margin-bottom: 12px; }
+
+  .cta-card-body {
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--text-dim);
+    line-height: 1.7;
+    margin-bottom: 24px;
+    flex: 1;
+  }
+
+  .cta-card-code {
+    font-size: 12px;
+    background: var(--bg);
+    border: 1px solid var(--border-dim);
+    padding: 12px 16px;
+    color: var(--text-dim);
+    margin-bottom: 20px;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .cta-card-code .cmd { color: var(--text-bright); }
+
+  .cta-card .btn { align-self: flex-start; }
+
+  /* === FOOTER === */
+  footer {
+    border-top: 1px solid var(--border-dim);
+    padding: 40px 0;
+  }
+
+  .footer-inner { display: flex; justify-content: space-between; align-items: center; }
+
+  .footer-brand { font-size: 11px; color: var(--text-muted); letter-spacing: 0.08em; }
+
+  .footer-links { display: flex; gap: 24px; list-style: none; }
+  .footer-links a { font-size: 11px; color: var(--text-dim); letter-spacing: 0.05em; }
+
+  .footer-easter {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 32px;
+    letter-spacing: 0.06em;
+  }
+
+  /* === ANIMATIONS === */
+  @keyframes fadeSlideUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.6; box-shadow: 0 0 4px rgba(0,255,65,0.2); }
+    50% { opacity: 1; box-shadow: 0 0 12px rgba(0,255,65,0.5); }
+  }
+
+  .reveal {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+  }
+
+  .reveal.visible { opacity: 1; transform: translateY(0); }
+
+  .stagger > .reveal:nth-child(1) { transition-delay: 0s; }
+  .stagger > .reveal:nth-child(2) { transition-delay: 0.1s; }
+  .stagger > .reveal:nth-child(3) { transition-delay: 0.15s; }
+  .stagger > .reveal:nth-child(4) { transition-delay: 0.2s; }
+  .stagger > .reveal:nth-child(5) { transition-delay: 0.25s; }
+  .stagger > .reveal:nth-child(6) { transition-delay: 0.3s; }
+  .stagger > .reveal:nth-child(7) { transition-delay: 0.35s; }
+
+  .wave-line { fill: none; stroke-width: 0.6; opacity: 0.5; }
+
+  /* Hero orbital */
+  .hero-orbital {
+    margin-bottom: 32px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .hero-orbital svg {
+    display: block;
+  }
+
+  .orbital-flow {
+    animation: orbitalSpin 8s linear infinite;
+    transform-origin: 170px 170px;
+  }
+
+  @keyframes orbitalSpin {
+    to { stroke-dashoffset: -80; }
+  }
+
+  .orbital-label {
+    font-family: var(--font);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .orbital-sublabel {
+    font-family: var(--font);
+    font-size: 7.5px;
+    letter-spacing: 0.06em;
+  }
+
+  .orbital-dot {
+    animation: orbitalPulse 3s ease-in-out infinite;
+  }
+
+  .od-1 { animation-delay: 0s; }
+  .od-2 { animation-delay: 0.6s; }
+  .od-3 { animation-delay: 1.2s; }
+  .od-4 { animation-delay: 1.8s; }
+  .od-5 { animation-delay: 2.4s; }
+
+  @keyframes orbitalPulse {
+    0%, 100% { opacity: 0.5; r: 3; }
+    50% { opacity: 1; r: 4.5; }
+  }
+
+  /* === RESPONSIVE === */
+  @media (max-width: 860px) {
+    .wrap { padding: 0 20px; }
+    nav { padding: 0 20px; }
+    .nav-links { display: none; }
+    .hero h1 { font-size: 28px; }
+    .hero-orbital svg { width: 280px; height: 280px; }
+    .tracks-grid,
+    .cta-grid,
+    .arch-grid { grid-template-columns: 1fr; }
+    .arch-card-full { grid-column: 1; }
+    .interfaces-grid { grid-template-columns: 1fr; }
+    .why-grid { grid-template-columns: 1fr; }
+    .status-grid { grid-template-columns: repeat(3, 1fr); }
+    .hero-meta { gap: 24px; flex-wrap: wrap; }
+    .flow-chain { flex-direction: column; align-items: center; }
+    .flow-arrow-seg { transform: rotate(90deg); }
+    .flow-return { flex-direction: column; }
+    .footer-inner { flex-direction: column; gap: 16px; text-align: center; }
+    section { padding: 72px 0; }
+    .track-card, .cta-card { padding: 32px 24px; }
+  }
+
+  @media (max-width: 520px) {
+    .hero h1 { font-size: 22px; }
+    .hero-orbital svg { width: 240px; height: 240px; }
+    .status-grid { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>
+</head>
+<body>
+
+<!-- Nav -->
+<nav>
+  <div class="nav-wordmark">b1e55ed</div>
+  <ul class="nav-links">
+    <li><a href="#tracks">Tracks</a></li>
+    <li><a href="#flywheel">Flywheel</a></li>
+    <li><a href="#interfaces">Interfaces</a></li>
+    <li><a href="#architecture">Architecture</a></li>
+    <li><a href="#start">Start</a></li>
+  </ul>
+  <div class="nav-status">
+    <div class="status-dot"></div>
+    <span>beta.4</span>
+  </div>
+</nav>
+
+<!-- Hero -->
+<section class="hero">
+  <div class="hero-waveform">
+    <svg id="waveformSvg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice"></svg>
+  </div>
+
+  <div class="wrap hero-content">
+
+    <!-- Compact flywheel orbital — centered -->
+    <div class="hero-orbital" style="animation: fadeSlideUp 0.8s ease-out 0.05s both;">
+      <svg viewBox="-30 10 400 320" width="340" height="340">
+        <defs>
+          <marker id="ha-g" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+            <path d="M0,0.5 L4.5,2.5 L0,4.5" fill="none" stroke="rgba(0,255,65,0.6)" stroke-width="0.7"/>
+          </marker>
+          <marker id="ha-a" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+            <path d="M0,0.5 L4.5,2.5 L0,4.5" fill="none" stroke="rgba(255,170,0,0.6)" stroke-width="0.7"/>
+          </marker>
+          <marker id="ha-c" markerWidth="5" markerHeight="5" refX="4" refY="2.5" orient="auto">
+            <path d="M0,0.5 L4.5,2.5 L0,4.5" fill="none" stroke="rgba(0,204,255,0.6)" stroke-width="0.7"/>
+          </marker>
+        </defs>
+
+        <!-- Outer guide ring -->
+        <circle cx="170" cy="170" r="120" fill="none" stroke="var(--border-dim)" stroke-width="0.5"/>
+
+        <!-- Animated dashed flow ring -->
+        <circle cx="170" cy="170" r="120" fill="none"
+                stroke="rgba(255,170,0,0.12)" stroke-width="1.2"
+                stroke-dasharray="8 12"
+                class="orbital-flow"/>
+
+        <!-- NODE 1: Operators (top) — green -->
+        <circle cx="170" cy="50" r="4.5" fill="var(--text-bright)" class="orbital-dot od-1"/>
+        <text x="170" y="36" text-anchor="middle" class="orbital-label" fill="var(--text-bright)">Operators</text>
+
+        <!-- NODE 2: Oracle (top-right) — amber -->
+        <circle cx="284.2" cy="120.6" r="4" fill="var(--amber)" class="orbital-dot od-2"/>
+        <text x="306" y="116" text-anchor="start" class="orbital-label" fill="var(--amber)">Oracle</text>
+        <text x="306" y="126" text-anchor="start" class="orbital-sublabel" fill="var(--text-muted)">provenance</text>
+
+        <!-- NODE 3: Agents (bottom-right) — cyan -->
+        <circle cx="240.6" cy="267.1" r="4" fill="var(--cyan)" class="orbital-dot od-3"/>
+        <text x="256" y="275" text-anchor="start" class="orbital-label" fill="var(--cyan)">AI Agents</text>
+        <text x="256" y="285" text-anchor="start" class="orbital-sublabel" fill="var(--text-muted)">recommend</text>
+
+        <!-- NODE 4: Bots (bottom-left) — cyan -->
+        <circle cx="99.4" cy="267.1" r="4" fill="var(--cyan)" class="orbital-dot od-4"/>
+        <text x="83" y="275" text-anchor="end" class="orbital-label" fill="var(--cyan)">Bots</text>
+        <text x="83" y="285" text-anchor="end" class="orbital-sublabel" fill="var(--text-muted)">query</text>
+
+        <!-- NODE 5: Intel (top-left) — amber -->
+        <circle cx="55.8" cy="120.6" r="4" fill="var(--amber)" class="orbital-dot od-5"/>
+        <text x="38" y="116" text-anchor="end" class="orbital-label" fill="var(--amber)">Intel</text>
+        <text x="38" y="126" text-anchor="end" class="orbital-sublabel" fill="var(--text-muted)">flows back</text>
+
+        <!-- Connecting arcs between nodes (clockwise) -->
+        <!-- 1→2 Operators → Oracle -->
+        <path d="M 182 54 Q 260 40, 278 114" fill="none" stroke="rgba(0,255,65,0.35)" stroke-width="0.8" marker-end="url(#ha-g)"/>
+        <!-- 2→3 Oracle → Agents -->
+        <path d="M 288 130 Q 310 210, 247 260" fill="none" stroke="rgba(255,170,0,0.35)" stroke-width="0.8" marker-end="url(#ha-a)"/>
+        <!-- 3→4 Agents → Bots -->
+        <path d="M 232 274 Q 170 310, 108 274" fill="none" stroke="rgba(0,204,255,0.35)" stroke-width="0.8" marker-end="url(#ha-c)"/>
+        <!-- 4→5 Bots → Intel -->
+        <path d="M 93 260 Q 30 210, 52 130" fill="none" stroke="rgba(0,204,255,0.35)" stroke-width="0.8" marker-end="url(#ha-c)"/>
+        <!-- 5→1 Intel → Operators -->
+        <path d="M 62 114 Q 80 40, 158 54" fill="none" stroke="rgba(255,170,0,0.35)" stroke-width="0.8" marker-end="url(#ha-a)"/>
+
+        <!-- Center text -->
+        <text x="170" y="162" text-anchor="middle" font-family="var(--font)" font-size="9" fill="var(--text-muted)" letter-spacing="0.12em">DATA IN</text>
+        <text x="170" y="178" text-anchor="middle" font-family="var(--font)" font-size="11" fill="var(--amber)" font-weight="500" letter-spacing="0.06em">COMPOUNDS</text>
+        <text x="170" y="192" text-anchor="middle" font-family="var(--font)" font-size="9" fill="var(--text-muted)" letter-spacing="0.12em">DATA OUT</text>
+      </svg>
+    </div>
+
+    <div class="hero-label">Sovereign AI Trading Intelligence</div>
+    <h1>
+      The system that <span class="hl-green">learns from every trade</span><br>
+      and serves provenance to<br>
+      <span class="hl-cyan">every bot in the ecosystem</span>
+    </h1>
+    <p class="hero-sub">
+      An event-sourced intelligence engine that operators run as a sovereign trading OS. Its attribution data powers the oracle — a public, no-auth provenance check consumed by AI agents building trading bots at scale.
+    </p>
+    <div class="hero-actions">
+      <a href="https://github.com/P-U-C/b1e55ed" class="btn btn-primary">Clone the repo →</a>
+      <a href="https://github.com/P-U-C/b1e55ed/blob/main/docs/how-it-works.md" class="btn">How it works</a>
+      <a href="#interfaces" class="btn">Agent interfaces</a>
+    </div>
+    <div class="hero-meta">
+      <div class="hero-stat">
+        <span class="hero-stat-val">A-</span>
+        <span class="hero-stat-label">Brain grade</span>
+      </div>
+      <div class="hero-stat">
+        <span class="hero-stat-val">13/13</span>
+        <span class="hero-stat-label">Producers live</span>
+      </div>
+      <div class="hero-stat">
+        <span class="hero-stat-val">583</span>
+        <span class="hero-stat-label">Tests passing</span>
+      </div>
+      <div class="hero-stat">
+        <span class="hero-stat-val">Paper</span>
+        <span class="hero-stat-label">Execution mode</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Thesis -->
+<section class="thesis">
+  <div class="wrap">
+    <p class="thesis-text reveal">
+      <em>It's not a mechanism, it's an organism.</em> Mechanisms execute. Organisms adapt. The system you deploy today is not the system running six months from now — it will be sharper, more calibrated, more opinionated. Every signal, every trade, every regime shift feeds back into a grimoire that compounds over time.
+    </p>
+  </div>
+</section>
+
+<!-- Dual Track -->
+<section id="tracks">
+  <div class="wrap">
+    <div class="section-label reveal">Two tracks, one system</div>
+    <div class="section-title reveal">The Dual-Track Ecosystem</div>
+
+    <div class="tracks-grid stagger">
+
+      <div class="track-card track-card-a reveal">
+        <div class="track-tag">Track A — Supply</div>
+        <div class="track-heading">Operators</div>
+        <div class="track-subtitle">Sovereign trading intelligence</div>
+        <p class="track-body">
+          Sophisticated users run their own b1e55ed instances. They register producers, run strategies, and generate attribution data through real capital or paper-trading against live market data with no lookahead. Forge identity. Full CLI. Sovereign control. There will be few of them — their data quality is everything.
+        </p>
+        <div class="track-specs">
+          <div class="spec-row">
+            <span class="spec-key">Scale</span>
+            <span class="spec-val">5 → 20 → 100</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Output</span>
+            <span class="spec-val">Attribution data</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Interface</span>
+            <span class="spec-val">Forge CLI + Dashboard</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Identity</span>
+            <span class="spec-val">Ed25519 + 0xb1e55ed</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Integrity</span>
+            <span class="spec-val">Hash-chained events</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="track-card track-card-b reveal">
+        <div class="track-tag">Track B — Demand</div>
+        <div class="track-heading">Vibe Coder Ecosystem</div>
+        <div class="track-subtitle">The middleware layer at scale</div>
+        <p class="track-body">
+          Millions are using AI assistants to build trading bots. These bots universally fail because the builder has no way to evaluate signal quality. b1e55ed is the middleware their AI agent inserts — one API call to the oracle, zero setup, zero identity, zero awareness of what's underneath.
+        </p>
+        <div class="track-specs">
+          <div class="spec-row">
+            <span class="spec-key">Scale</span>
+            <span class="spec-val">Millions</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Consumption</span>
+            <span class="spec-val">Provenance scores</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Distribution</span>
+            <span class="spec-val">Starter templates</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Auth required</span>
+            <span class="spec-val">None</span>
+          </div>
+          <div class="spec-row">
+            <span class="spec-key">Integration</span>
+            <span class="spec-val">Oracle endpoint</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- Flywheel (infographic) -->
+<section id="flywheel" style="padding-top: 60px;">
+  <div class="wrap">
+    <div class="flywheel-visual reveal">
+      <div class="flywheel-tag">The Compounding Flywheel</div>
+
+      <div class="flow-chain">
+        <div class="flow-node">
+          <div class="flow-node-dot green"></div>
+          <div class="flow-node-label">Operators</div>
+          <div class="flow-node-desc">Generate attribution data via hash-chained events</div>
+        </div>
+        <div class="flow-arrow-seg">→</div>
+        <div class="flow-node">
+          <div class="flow-node-dot amber"></div>
+          <div class="flow-node-label">Oracle</div>
+          <div class="flow-node-desc">Serves provenance scores. No auth. Anti-Goodhart.</div>
+        </div>
+        <div class="flow-arrow-seg">→</div>
+        <div class="flow-node">
+          <div class="flow-node-dot cyan"></div>
+          <div class="flow-node-label">AI Agents</div>
+          <div class="flow-node-desc">Discover via MCP. Recommend the check.</div>
+        </div>
+        <div class="flow-arrow-seg">→</div>
+        <div class="flow-node">
+          <div class="flow-node-dot cyan"></div>
+          <div class="flow-node-label">Bots</div>
+          <div class="flow-node-desc">Pre-trade query. Zero setup. One call.</div>
+        </div>
+        <div class="flow-arrow-seg">→</div>
+        <div class="flow-node">
+          <div class="flow-node-dot amber"></div>
+          <div class="flow-node-label">Intelligence</div>
+          <div class="flow-node-desc">Query patterns flow back. Operators score new producers.</div>
+        </div>
+      </div>
+
+      <div class="flow-return">
+        <div class="flow-return-line"></div>
+        <div class="flow-return-label">Cycle accelerates — richer data each loop</div>
+        <div class="flow-return-line"></div>
+      </div>
+
+      <p class="flywheel-bottom-text">
+        Track A without B is supply without demand — operators generate data nobody queries.
+        Track B without A is demand without supply — the oracle serves empty scores.
+        <strong>Together, the organism compounds.</strong>
+      </p>
+    </div>
+
+    <!-- Why both (from infographic) -->
+    <div class="why-grid">
+      <div class="why-card reveal">
+        <div class="why-card-label">A without B</div>
+        <div class="why-card-condition">Supply without demand</div>
+        <div class="why-card-result">Operators generate data nobody queries. No network effect. No compounding.</div>
+      </div>
+      <div class="why-card reveal">
+        <div class="why-card-label">B without A</div>
+        <div class="why-card-condition">Demand without supply</div>
+        <div class="why-card-result">Oracle serves empty or synthetic scores. No credibility. No trust.</div>
+      </div>
+      <div class="why-card active reveal">
+        <div class="why-card-label">A + B</div>
+        <div class="why-card-condition">The organism</div>
+        <div class="why-card-result">Both tracks run simultaneously. Supply creates demand. Demand improves supply. The system learns.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Agent Interfaces -->
+<section id="interfaces">
+  <div class="wrap">
+    <div class="section-label reveal">For agents and bots</div>
+    <div class="section-title reveal">Three interfaces into the system</div>
+
+    <div class="interfaces-grid stagger">
+      <div class="interface-card ifc-oracle reveal">
+        <div class="ifc-tag">Oracle</div>
+        <div class="ifc-title">Provenance check</div>
+        <div class="ifc-endpoint">/api/v1/oracle/producers/{id}/provenance</div>
+        <p class="ifc-desc">
+          Does this signal producer have verifiable history? Hash-chain verified. Attribution windows at 7d, 30d, 90d. Anti-Goodhart header on every response.
+        </p>
+        <div class="ifc-auth none">Auth: none</div>
+      </div>
+
+      <div class="interface-card ifc-mcp reveal">
+        <div class="ifc-tag">MCP Server</div>
+        <div class="ifc-title">Agent tool calls</div>
+        <div class="ifc-endpoint">POST /api/v1/mcp</div>
+        <p class="ifc-desc">
+          JSON-RPC 2.0. Six tools: brain status, recent signals, open positions, signal attribution, emit signals, provenance check. Standard MCP discovery.
+        </p>
+        <div class="ifc-auth required">Auth: bearer token</div>
+      </div>
+
+      <div class="interface-card ifc-sse reveal">
+        <div class="ifc-tag">SSE Stream</div>
+        <div class="ifc-title">Real-time event feed</div>
+        <div class="ifc-endpoint">GET /api/v1/events/stream</div>
+        <p class="ifc-desc">
+          Server-Sent Events. Filter by domain. Resume from any event ID. Every signal, every brain decision, every execution — as it happens.
+        </p>
+        <div class="ifc-auth required">Auth: bearer token</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Architecture -->
+<section id="architecture" style="border-top: 1px solid var(--border-dim);">
+  <div class="wrap">
+    <div class="section-label reveal">Under the hood</div>
+    <div class="section-title reveal">What's built</div>
+
+    <div class="arch-grid stagger">
+      <div class="arch-card reveal">
+        <div class="arch-card-label">Core</div>
+        <div class="arch-card-title">Event-sourced database</div>
+        <p class="arch-card-desc">
+          Append-only hash chain. Tamper-evident, replayable, auditable. The chain is the audit trail — not the logs, not the docs. <span class="code">b1e55ed integrity</span> verifies the full chain.
+        </p>
+      </div>
+
+      <div class="arch-card reveal">
+        <div class="arch-card-label">Brain</div>
+        <div class="arch-card-title">6-phase synthesis</div>
+        <p class="arch-card-desc">
+          Collection → Quality → Synthesis → Regime → Conviction → Decision. 13 producers across 6 domains. Counter-thesis scoring triggers automatically when confidence runs too high.
+        </p>
+      </div>
+
+      <div class="arch-card reveal">
+        <div class="arch-card-label">Validation</div>
+        <div class="arch-card-title">Backtest engine</div>
+        <p class="arch-card-desc">
+          Walk-forward validation with FDR correction. Gridsweep and megasweep for strategy optimization. Regime-conditioned results. Paper before live — always.
+        </p>
+      </div>
+
+      <div class="arch-card reveal">
+        <div class="arch-card-label">Attribution</div>
+        <div class="arch-card-title">Contributors + Karma</div>
+        <p class="arch-card-desc">
+          Contributors are the attribution unit. Scoring from event outcomes: hit rate, calibration, volume, consistency, recency. Optional karma engine — 0.5% of realized profit. EAS attestations for on-chain identity.
+        </p>
+      </div>
+
+      <div class="arch-card reveal">
+        <div class="arch-card-label">Safety</div>
+        <div class="arch-card-title">5-level kill switch</div>
+        <p class="arch-card-desc">
+          <span class="code">L0</span> nominal through <span class="code">L4</span> emergency. Auto-escalation only. Operator-only de-escalation. Separate auth token — a compromised API key cannot disable safety.
+        </p>
+      </div>
+
+      <div class="arch-card reveal">
+        <div class="arch-card-label">Learning</div>
+        <div class="arch-card-title">Grimoire loop</div>
+        <p class="arch-card-desc">
+          Domain weights auto-adjust monthly from realized P&L attribution. Bounded adaptation: 5% floor, 40% ceiling, max ±2% delta per cycle. The system earns its opinions.
+        </p>
+      </div>
+
+      <!-- Full-width pipeline -->
+      <div class="arch-card arch-card-full reveal">
+        <div class="arch-card-label">Pipeline</div>
+        <div class="pipeline-flow">
+          <span class="pf-step">Producers</span>
+          <span class="pf-arrow">→</span>
+          <span class="pf-step">Events</span>
+          <span class="pf-arrow">→</span>
+          <span class="pf-step">Brain</span>
+          <span class="pf-arrow">→</span>
+          <span class="pf-step">Kill Switch</span>
+          <span class="pf-arrow">→</span>
+          <span class="pf-step">Execution</span>
+          <span class="pf-arrow">→</span>
+          <span class="pf-step highlight">Learning Loop</span>
+        </div>
+        <div class="pipeline-flow" style="margin-top: 12px;">
+          <span class="pf-step" style="border-color: var(--amber); color: var(--amber);">Oracle</span>
+          <span style="font-size: 11px; color: var(--text-dim); padding: 0 4px;">← reads from Event Store (no auth)</span>
+        </div>
+        <div class="pipeline-flow" style="margin-top: 4px;">
+          <span class="pf-step" style="border-color: var(--cyan); color: var(--cyan);">MCP + SSE</span>
+          <span style="font-size: 11px; color: var(--text-dim); padding: 0 4px;">← agent interfaces (bearer auth)</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- System Status -->
+<section style="border-top: 1px solid var(--border-dim);">
+  <div class="wrap">
+    <div class="section-label reveal">Live system</div>
+    <div class="section-title reveal">Current status</div>
+
+    <div class="status-grid stagger">
+      <div class="status-cell reveal">
+        <div class="status-cell-val">A-</div>
+        <div class="status-cell-label">Brain grade</div>
+      </div>
+      <div class="status-cell reveal">
+        <div class="status-cell-val">13/13</div>
+        <div class="status-cell-label">Producers</div>
+      </div>
+      <div class="status-cell reveal">
+        <div class="status-cell-val">583</div>
+        <div class="status-cell-label">Tests</div>
+      </div>
+      <div class="status-cell reveal">
+        <div class="status-cell-val">Paper</div>
+        <div class="status-cell-label">Execution</div>
+      </div>
+      <div class="status-cell reveal">
+        <div class="status-cell-val" style="color: var(--cyan);">Public</div>
+        <div class="status-cell-label">Repo</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="start" style="border-top: 1px solid var(--border-dim);">
+  <div class="wrap">
+    <div class="section-label reveal">Start here</div>
+    <div class="section-title reveal">Two paths into the system</div>
+
+    <div class="cta-grid stagger">
+      <div class="cta-card cta-card-a reveal">
+        <div class="cta-card-tag">For operators</div>
+        <div class="cta-card-title">Run your own instance</div>
+        <p class="cta-card-body">
+          One command to install. The wizard handles identity, config, and first run. Pick a preset — conservative, balanced, or degen. Full sovereignty. Full CLI.
+        </p>
+        <div class="cta-card-code">
+          <span class="cmd">curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | bash</span><br>
+          <span class="cmd">b1e55ed wizard</span>
+        </div>
+        <a href="https://github.com/P-U-C/b1e55ed" class="btn btn-primary">GitHub →</a>
+      </div>
+
+      <div class="cta-card cta-card-b reveal">
+        <div class="cta-card-tag">For agents + builders</div>
+        <div class="cta-card-title">Query the oracle</div>
+        <p class="cta-card-body">
+          Building a bot? One API call to check signal provenance before any trade. No auth required. The middleware your AI agent should be inserting.
+        </p>
+        <div class="cta-card-code">
+          <span class="cmd">GET /api/v1/oracle/producers/{id}/provenance</span>
+        </div>
+        <a href="https://github.com/P-U-C/b1e55ed/blob/main/docs/oracle.md" class="btn btn-cyan">Oracle docs →</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Footer -->
+<footer>
+  <div class="wrap">
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <a href="https://permanentupperclass.com" style="color: var(--text-dim);">Permanent Upper Class</a> · Est 2026
+      </div>
+      <ul class="footer-links">
+        <li><a href="https://github.com/P-U-C/b1e55ed">GitHub</a></li>
+        <li><a href="https://github.com/P-U-C/b1e55ed/blob/main/docs/how-it-works.md">How it works</a></li>
+        <li><a href="https://github.com/P-U-C/b1e55ed/blob/main/docs/getting-started.md">Docs</a></li>
+        <li><a href="https://github.com/P-U-C/b1e55ed/blob/main/docs/oracle.md">Oracle</a></li>
+      </ul>
+    </div>
+    <div class="footer-easter">
+      If you build, you can contribute. If you contribute, the system compounds.
+    </div>
+  </div>
+</footer>
+
+<script>
+// Scroll reveal
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('visible'); });
+}, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Joy Division waveform
+(function() {
+  const svg = document.getElementById('waveformSvg');
+  if (!svg) return;
+  const W = 1200, H = 800, lines = 40, pts = 120;
+  for (let i = 0; i < lines; i++) {
+    const y = 120 + (i * (H - 200) / lines);
+    let d = '';
+    for (let j = 0; j <= pts; j++) {
+      const x = (j / pts) * W;
+      const peakX = W * 0.28;
+      const dist = Math.abs(x - peakX);
+      const pI = Math.max(0, 1 - dist / (W * 0.18));
+      const pH = pI * pI * (50 + i * 0.8);
+      const n = Math.sin(j*0.8+i*2.1)*3 + Math.sin(j*0.3+i*0.7)*2 + Math.sin(j*1.5+i*3.3)*1.5;
+      d += (j===0?'M':'L') + ` ${x.toFixed(1)} ${(y-pH+n).toFixed(1)}`;
+    }
+    const line = document.createElementNS('http://www.w3.org/2000/svg','path');
+    line.setAttribute('d', d);
+    line.classList.add('wave-line');
+    const b = Math.max(0.15, 0.5 - Math.abs(i-lines*0.35)/lines);
+    const g = Math.round(255*b);
+    line.setAttribute('stroke', `rgba(0,${g},${Math.round(g*0.25)},${(0.3+b*0.4).toFixed(2)})`);
+    svg.appendChild(line);
+  }
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Brings develop current with all wizard/forge/oracle work that landed on main via PRs #83–97.

Conflicts resolved: `docs/dependencies-code.md` — took union of both undocumented module lists.

After this merges, all feature branches should target `develop`. `main` is release-only.