### PR TITLE
chore: beta.5 changelog, branch guard, BRANCH install support

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,31 @@
+name: Branch Guard
+
+# Block PRs targeting main from any branch except develop or release/*
+# All feature work must go through develop first.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    name: Enforce develop → main flow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          SOURCE="${{ github.head_ref }}"
+          echo "PR source branch: $SOURCE"
+
+          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == release/* ]] || [[ "$SOURCE" == hotfix/* ]]; then
+            echo "✓ Allowed: $SOURCE → main"
+          else
+            echo "✗ PRs to main must come from develop or release/* (got: $SOURCE)"
+            echo ""
+            echo "  Target your PR at 'develop' instead:"
+            echo "    • Feature work  → develop"
+            echo "    • Release prep  → release/vX.X.X → main"
+            echo "    • Hotfixes      → hotfix/... → main (and backport to develop)"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v1.0.0-beta.5 — 2026-02-26
+
+macOS onboarding, Rust forge binary distribution, and zero-credential contributor registration via oracle relay. 589 tests passing.
+
+### 🟡 Install & Onboarding
+
+- **macOS install fixed** — `install.sh` now bootstraps Python via `uv` if none found; suppressed stderr noise; `eth-account>=0.11` moved to default deps (no longer requires `[eas]` extra)
+- **Forge binary auto-download** — `install.sh` and wizard both auto-download the Rust forge binary for macOS (universal arm64+x86_64) and Linux x86_64 from the latest release
+- **Pre-release URL fix** — `/releases/latest` skips pre-releases; both installer and wizard now resolve the real latest tag via `GET /releases?per_page=1` and build explicit download URLs
+- **Universal macOS binary** — CI builds a single `b1e55ed-forge-macos` via `lipo` (arm64 + x86_64); works on both Apple Silicon and Intel without selecting the right binary
+- **`install.sh` supports `BRANCH` env var** — `BRANCH=develop curl -sSf .../install.sh | bash` installs from any branch for testing
+
+### 🟡 Wizard UX
+
+- **Symbol packs menu** — Interactive preset selection instead of raw comma list
+- **GitHub token prominence** — Token field highlighted; explains why it's needed
+- **Real version in banner** — Uses `importlib.metadata.version("b1e55ed")` instead of hardcoded `v1.x`
+- **Forge banner aligned** — Width matches wizard banner (42 chars), text centered
+- **Health check test step** — Step 5 now runs `b1e55ed health` (was `brain --symbols BTC --dry-run` which doesn't exist)
+
+### 🟡 Contributor Registration
+
+- **Auto-registration in wizard** — New step `[4b]` after config: inline `ContributorRegistry.register()` call; no subprocess, no PATH issues
+- **Oracle relay** — Wizard calls `oracle.b1e55ed.xyz/api/v1/oracle/contributors/register`; oracle holds GitHub App key and creates announcement issue server-side; new users need zero credentials
+- **New public oracle endpoint** — `POST /api/v1/oracle/contributors/register` (no auth); validates `eth:0xb1e55ed` prefix; idempotent (409 on duplicate)
+- **GitHub App auth wired** — `get_publisher()` and `_build_contributor_registry_with_eas()` now activate on `app_id > 0`, not just `token`; App auth was previously silently skipped
+
+### 🟡 CLI
+
+- **`b1e55ed uninstall`** — New CLI command + `uninstall.sh`; documented in `docs/cli-reference.md`
+- **GitHub App defaults** — App ID `2953603`, Installation ID `112556330` baked into `engine/config/github_app_defaults.py`
+- **Version sync** — `engine/__init__.py` uses `importlib.metadata.version("b1e55ed")` (no hardcoded version string)
+
+### 🔧 CI
+
+- **No direct pushes to main** — Workflows (`dep-graphs`, `b1e55ing-merge`) create PRs instead of committing directly
+- **Forge release permissions** — `forge-release.yml` now has `contents: write` permission
+- **Manual forge trigger** — `workflow_dispatch` on forge-release accepts `tag_name` input
+- **CLI doc coverage check** — CI fails if a new command is added without a `docs/cli-reference.md` entry
+
+---
+
 ## v1.0.0-beta.4 — 2026-02-25
 
 Customer readiness release. 8-reviewer audit (Stripe, Coinbase, Cloudflare, Palantir — two model sets). Every finding addressed. 583 tests passing.

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,14 @@
 # Usage: curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | bash
 # Or:    ./install.sh
 #
+# Test from a specific branch (e.g. develop):
+#   BRANCH=develop curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | bash
+#
 # Idempotent: safe to re-run.
 set -euo pipefail
+
+# Branch to install from (default: main)
+BRANCH="${BRANCH:-main}"
 
 BOLD='\033[1m'
 GREEN='\033[0;32m'
@@ -104,9 +110,9 @@ if [ -f "pyproject.toml" ] && grep -q 'b1e55ed' pyproject.toml 2>/dev/null; then
         success "b1e55ed dependencies synced (use ./b1e55ed or uv run b1e55ed)"
     fi
 else
-    # Install from GitHub
-    INSTALL_URL="git+https://github.com/P-U-C/b1e55ed.git"
-    info "Installing from: $INSTALL_URL"
+    # Install from GitHub (respects BRANCH env var, default: main)
+    INSTALL_URL="git+https://github.com/P-U-C/b1e55ed.git@${BRANCH}"
+    info "Installing from: $INSTALL_URL (branch: ${BRANCH})"
     if uv tool install "$INSTALL_URL" 2>/dev/null; then
         success "b1e55ed installed as a uv tool"
     else


### PR DESCRIPTION
Three housekeeping items:

1. **CHANGELOG.md** — Complete beta.5 section capturing all wizard/forge/oracle/CLI/CI changes
2. **Branch guard** — `.github/workflows/branch-guard.yml` blocks PRs targeting `main` from anything except `develop` or `release/*` / `hotfix/*`. From now on this is enforced by CI.
3. **BRANCH env var in install.sh** — Dev testing workflow is now:
   ```
   BRANCH=develop curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | bash
   ```
   Installs from any branch. Default is still `main`.