### PR TITLE
fix: clear macOS quarantine on forge binary — Gatekeeper was silently killing it

### DIFF
--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -449,6 +449,15 @@ def _auto_download_forge() -> str | None:
     try:
         urllib.request.urlretrieve(url, dest)  # noqa: S310
         dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        # macOS: clear quarantine bit so Gatekeeper doesn't silently kill the binary
+        import platform as _platform
+
+        if _platform.system() == "Darwin":
+            subprocess.run(
+                ["xattr", "-dr", "com.apple.quarantine", str(dest)],
+                check=False,
+                capture_output=True,
+            )
         print(f"  {_ok(f'Forge binary installed: {dest}')}")
         return str(dest)
     except Exception as e:  # noqa: BLE001

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -2024,31 +2024,43 @@ def _identity_forge(ctx: CliContext, args: argparse.Namespace) -> int:
         )
 
     if rust_binary:
-        proc = subprocess.Popen(
-            [rust_binary, "--prefix", prefix, "--threads", str(threads), "--json"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                msg = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+        # macOS: clear quarantine bit so Gatekeeper doesn't silently kill the binary
+        if sys.platform == "darwin":
+            subprocess.run(
+                ["xattr", "-dr", "com.apple.quarantine", rust_binary],
+                check=False,
+                capture_output=True,
+            )
+        try:
+            proc = subprocess.Popen(
+                [rust_binary, "--prefix", prefix, "--threads", str(threads), "--json"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
-            if msg.get("type") == "progress" and use_json:
-                print(_json_dumps(msg))
-            elif msg.get("type") == "progress" and not use_json:
-                _render_progress(msg)
-            elif msg.get("type") == "found":
-                result = msg
-                break
-        proc.wait()
-    else:
+                if msg.get("type") == "progress" and use_json:
+                    print(_json_dumps(msg))
+                elif msg.get("type") == "progress" and not use_json:
+                    _render_progress(msg)
+                elif msg.get("type") == "found":
+                    result = msg
+                    break
+            proc.wait()
+        except OSError:
+            # Binary can't be executed — fall through to Python
+            rust_binary = None
+
+    if not rust_binary:
         if not use_json:
             print("  (Rust grinder not found — using Python fallback. This will be slower.)")
             print()

--- a/install.sh
+++ b/install.sh
@@ -255,6 +255,10 @@ fi
 if [ -n "$FORGE_URL" ]; then
     if curl -fsSL "$FORGE_URL" -o "$FORGE_DIR/b1e55ed-forge" 2>/dev/null; then
         chmod +x "$FORGE_DIR/b1e55ed-forge"
+        # macOS: clear quarantine bit so Gatekeeper doesn't block execution
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            xattr -dr com.apple.quarantine "$FORGE_DIR/b1e55ed-forge" 2>/dev/null || true
+        fi
         success "Rust forge binary installed (~50M candidates/sec)"
     else
         warn "Could not download forge binary (no release yet) — Python fallback will be used"


### PR DESCRIPTION
## Root cause

The Rust forge binary has never actually run on macOS. `curl` downloads set the `com.apple.quarantine` extended attribute. Gatekeeper silently kills unsigned binaries when executed via Python subprocess — no error, no output, just empty stdout.

Result: `identity forge` saw empty stdout from the binary, fell through to Python fallback, 30-minute forge.

## Fix

- **`install.sh`**: `xattr -dr com.apple.quarantine` after download on macOS
- **`wizard._auto_download_forge()`**: same after download
- **`_identity_forge()`**: clear quarantine before Popen; catch `OSError` (wrong arch, perms) and fall back to Python gracefully instead of crashing
- **Restructured rust/python fallback**: `if not rust_binary:` instead of `else:` — so OSError during Popen correctly falls through to Python