### PR TITLE
chore: sync main → develop (beta.5 + all hotfixes)

### DIFF
--- a/docs/dependencies-code.md
+++ b/docs/dependencies-code.md
@@ -298,32 +298,14 @@ See `docs/security.md` for enforcement details.
 
 ---
 
+---
+
 ## Undocumented (auto-detected)
 
 > Modules detected by CI but not yet assigned to a layer. Move each entry to the correct layer section and add a description.
 
 ```
 api/routes/metrics.py
-api/schemas/brain.py
-api/schemas/common.py
-api/schemas/positions.py
-api/schemas/signals.py
-dashboard/app.py
-dashboard/contributors.py
-dashboard/identity.py
-dashboard/producers.py
-dashboard/routes/home.py
-dashboard/routes/positions.py
-dashboard/routes/regime.py
-dashboard/routes/settings.py
-dashboard/routes/signals.py
-dashboard/routes/treasury.py
-dashboard/services/api_client.py
-dashboard/webhooks.py
-engine/cli/commands/uninstall.py
 engine/cli/commands/wizard.py
-engine/config/github_app_defaults.py
-engine/core/identity_gate.py
 engine/execution/recovery.py
-engine/integrations/github_app.py
 ```

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -449,6 +449,15 @@ def _auto_download_forge() -> str | None:
     try:
         urllib.request.urlretrieve(url, dest)  # noqa: S310
         dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        # macOS: clear quarantine bit so Gatekeeper doesn't silently kill the binary
+        import platform as _platform
+
+        if _platform.system() == "Darwin":
+            subprocess.run(
+                ["xattr", "-dr", "com.apple.quarantine", str(dest)],
+                check=False,
+                capture_output=True,
+            )
         print(f"  {_ok(f'Forge binary installed: {dest}')}")
         return str(dest)
     except Exception as e:  # noqa: BLE001

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -2024,31 +2024,43 @@ def _identity_forge(ctx: CliContext, args: argparse.Namespace) -> int:
         )
 
     if rust_binary:
-        proc = subprocess.Popen(
-            [rust_binary, "--prefix", prefix, "--threads", str(threads), "--json"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                msg = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+        # macOS: clear quarantine bit so Gatekeeper doesn't silently kill the binary
+        if sys.platform == "darwin":
+            subprocess.run(
+                ["xattr", "-dr", "com.apple.quarantine", rust_binary],
+                check=False,
+                capture_output=True,
+            )
+        try:
+            proc = subprocess.Popen(
+                [rust_binary, "--prefix", prefix, "--threads", str(threads), "--json"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
-            if msg.get("type") == "progress" and use_json:
-                print(_json_dumps(msg))
-            elif msg.get("type") == "progress" and not use_json:
-                _render_progress(msg)
-            elif msg.get("type") == "found":
-                result = msg
-                break
-        proc.wait()
-    else:
+                if msg.get("type") == "progress" and use_json:
+                    print(_json_dumps(msg))
+                elif msg.get("type") == "progress" and not use_json:
+                    _render_progress(msg)
+                elif msg.get("type") == "found":
+                    result = msg
+                    break
+            proc.wait()
+        except OSError:
+            # Binary can't be executed — fall through to Python
+            rust_binary = None
+
+    if not rust_binary:
         if not use_json:
             print("  (Rust grinder not found — using Python fallback. This will be slower.)")
             print()

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,8 @@
 # Idempotent: safe to re-run.
 set -euo pipefail
 
-# Branch to install from (default: main)
+# Branch to install from — pinned to main so changing the default branch
+# on GitHub doesn't accidentally install from develop.
 BRANCH="${BRANCH:-main}"
 
 BOLD='\033[1m'
@@ -154,9 +155,9 @@ if [ -f "pyproject.toml" ] && grep -q 'b1e55ed' pyproject.toml 2>/dev/null; then
         success "b1e55ed dependencies synced (use ./b1e55ed or uv run b1e55ed)"
     fi
 else
-    # Install from GitHub (respects BRANCH env var, default: main)
+    # Install from GitHub — always explicit branch (never relies on default branch)
     INSTALL_URL="git+https://github.com/P-U-C/b1e55ed.git@${BRANCH}"
-    info "Installing from: $INSTALL_URL (branch: ${BRANCH})"
+    info "Installing from: $INSTALL_URL"
     if uv tool install "$INSTALL_URL" 2>/dev/null; then
         success "b1e55ed installed as a uv tool"
     else
@@ -254,6 +255,10 @@ fi
 if [ -n "$FORGE_URL" ]; then
     if curl -fsSL "$FORGE_URL" -o "$FORGE_DIR/b1e55ed-forge" 2>/dev/null; then
         chmod +x "$FORGE_DIR/b1e55ed-forge"
+        # macOS: clear quarantine bit so Gatekeeper doesn't block execution
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            xattr -dr com.apple.quarantine "$FORGE_DIR/b1e55ed-forge" 2>/dev/null || true
+        fi
         success "Rust forge binary installed (~50M candidates/sec)"
     else
         warn "Could not download forge binary (no release yet) — Python fallback will be used"


### PR DESCRIPTION
Brings develop fully current with main.

Includes:
- Release v1.0.0-beta.5 squash
- #102: install.sh pinned to `@main` (BRANCH env var support)
- #103: macOS quarantine fix — forge binary was never running on macOS
- dep-graph updates

After this merges, dev testing workflow is:
```bash
b1e55ed uninstall
BRANCH=develop curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | bash
b1e55ed wizard
```