### PR TITLE
fix: accurate forge timing messaging — seconds to ~2 min, not ~2 seconds

### DIFF
--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -491,7 +491,7 @@ def _step3_identity(repo_root: Path) -> None:
     if rust_binary:
         # Fast path: Rust binary available
         print(f"  {_ok(f'Rust grinder found: {rust_binary}')}")
-        print("  Forging a vanity address takes ~2 seconds with the Rust binary.")
+        print("  Forging a vanity address takes seconds to ~2 min depending on hardware.")
         print()
 
         try:

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -2000,7 +2000,7 @@ def _identity_forge(ctx: CliContext, args: argparse.Namespace) -> int:
         print("  Yours is being derived now.")
         print()
         if rust_binary:
-            print("  This takes ~2 seconds with the Rust grinder.")
+            print("  This takes seconds to ~2 min with the Rust grinder (hardware dependent).")
         else:
             print("  Rust grinder not found — using Python fallback (~90 min).")
         print()

--- a/install.sh
+++ b/install.sh
@@ -259,7 +259,7 @@ if [ -n "$FORGE_URL" ]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
             xattr -dr com.apple.quarantine "$FORGE_DIR/b1e55ed-forge" 2>/dev/null || true
         fi
-        success "Rust forge binary installed (~50M candidates/sec)"
+        success "Rust forge binary installed (much faster than Python fallback)"
     else
         warn "Could not download forge binary (no release yet) — Python fallback will be used"
         warn "Run 'b1e55ed identity forge' after a release is published, or use random identity"


### PR DESCRIPTION
The `~2 seconds` claim was benchmarked on Apple Silicon M-series.

On Intel Macs (2015–2019 era), the Rust binary runs significantly slower due to lower single-thread IPC and older architecture. Actual observed times are 30 seconds to 2+ minutes.

Python fallback is ~30 minutes, so Rust is still a massive improvement — just not instant.

**Updated messaging:**
- wizard: `seconds to ~2 min depending on hardware`
- identity forge banner: `seconds to ~2 min (hardware dependent)`
- install.sh: removed bogus `~50M candidates/sec` claim