### PR TITLE
fix: EAS enabled by default + API root page + dashboard identity path

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -134,11 +134,11 @@ def create_app() -> FastAPI:
 
         import logging as _log
 
-        if not getattr(config.eas, "enabled", False):
-            _log.getLogger("b1e55ed.startup").warning(
-                "EAS attestation is DISABLED (eas.enabled=false). "
-                "No on-chain proofs will be created. Set eas.enabled=true and configure eas.rpc_url to activate."
-            )
+        if getattr(config.eas, "enabled", True):
+            if not getattr(config.eas, "rpc_url", ""):
+                _log.getLogger("b1e55ed.startup").info("EAS off-chain attestations enabled. Set eas.rpc_url to also enable on-chain proofs.")
+        else:
+            _log.getLogger("b1e55ed.startup").warning("EAS attestation is DISABLED (eas.enabled=false in config).")
 
         from engine.core.database import Database
 
@@ -279,6 +279,30 @@ def create_app() -> FastAPI:
     from api.routes.mcp import router as mcp_router
 
     app.include_router(mcp_router)
+
+    @app.get("/", include_in_schema=False)
+    def root() -> dict:
+        """API info page — lists key endpoints."""
+        import engine as _engine
+
+        return {
+            "name": "b1e55ed",
+            "version": _engine.__version__,
+            "docs": "/docs",
+            "health": "/api/v1/health",
+            "endpoints": {
+                "contributors": "/api/v1/contributors",
+                "signals": "/api/v1/signals",
+                "producers": "/api/v1/producers",
+                "karma": "/api/v1/karma",
+                "positions": "/api/v1/positions",
+                "brain": "/api/v1/brain",
+                "oracle": "/api/v1/oracle/producers/{id}/provenance",
+                "config": "/api/v1/config",
+                "metrics": "/api/v1/metrics",
+                "mcp": "/mcp",
+            },
+        }
 
     return app
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -27,7 +27,10 @@ templates = Jinja2Templates(directory=_HERE / "templates")
 
 
 def _repo_root() -> Path:
-    return _HERE.parent
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 @app.middleware("http")

--- a/dashboard/contributors.py
+++ b/dashboard/contributors.py
@@ -13,7 +13,12 @@ from fastapi.templating import Jinja2Templates
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    import os
+
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _db_path() -> Path:

--- a/dashboard/identity.py
+++ b/dashboard/identity.py
@@ -13,7 +13,10 @@ from engine.core.config import Config
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _identity_path() -> Path:

--- a/dashboard/producers.py
+++ b/dashboard/producers.py
@@ -12,7 +12,12 @@ from fastapi.templating import Jinja2Templates
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    import os
+
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _db_path() -> Path:

--- a/dashboard/webhooks.py
+++ b/dashboard/webhooks.py
@@ -13,7 +13,12 @@ from fastapi.templating import Jinja2Templates
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    import os
+
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _db_path() -> Path:

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -117,7 +117,7 @@ class DashboardConfig(BaseModel):
 
 
 class EASConfig(BaseModel):
-    enabled: bool = False
+    enabled: bool = True  # off-chain attestations work without rpc_url; on-chain needs rpc_url
     rpc_url: str = "https://eth.llamarpc.com"  # Free public RPC
     eas_contract: str = "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587"
     schema_registry: str = "0xA7b39296258348C78294F95B872b282326A97BDF"


### PR DESCRIPTION
Three UX fixes reported by zoz after first real install:

**1. EAS enabled by default**
- `EASConfig.enabled = True` (was `False`)
- Off-chain attestations need no `rpc_url` — should always be on
- Startup log now says `EAS off-chain enabled, set rpc_url for on-chain`

**2. API root `GET /` returns info page**
- Was: 404
- Now: JSON with version, docs link, and key endpoint map

**3. Dashboard always showed forge page even with identity present**
- Root cause: `_repo_root()` used `Path(__file__).resolve().parents[1]` — the uv tool install directory, not the user's working directory
- Fixed across `app.py`, `identity.py`, `contributors.py`, `webhooks.py`, `producers.py`
- Now uses `B1E55ED_REPO_ROOT` env var or `Path.cwd()` (same as CLI)