### PR TITLE
fix: --refresh on uv tool install to avoid stale git cache

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ else
     # Install from GitHub — always explicit branch (never relies on default branch)
     INSTALL_URL="git+https://github.com/P-U-C/b1e55ed.git@${BRANCH}"
     info "Installing from: $INSTALL_URL"
-    if uv tool install "$INSTALL_URL" 2>/dev/null; then
+    if uv tool install --refresh "$INSTALL_URL" 2>/dev/null; then
         success "b1e55ed installed as a uv tool"
     else
         error "Installation failed. Clone the repo and run ./install.sh from inside it."


### PR DESCRIPTION
Without `--refresh`, uv caches the git clone and can serve a stale commit even after `b1e55ed uninstall` + reinstall. The branch ref (`@develop`, `@main`) resolves to whatever commit uv has cached locally.

Adding `--refresh` forces uv to re-fetch from GitHub on every install, ensuring users always get the latest code on the specified branch.

**Symptom**: `BRANCH=develop ... install.sh` installed old code because uv's git cache still had develop before recent PRs merged.