### PR TITLE
Release v1.0.0-beta.6

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,29 @@
+name: Branch Guard
+
+# Block PRs targeting main from any branch except develop or release/*
+# All work goes through develop. main is release-only.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    name: Enforce develop → main flow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          SOURCE="${{ github.head_ref }}"
+          echo "PR source branch: $SOURCE"
+
+          if [[ "$SOURCE" == "develop" ]] || [[ "$SOURCE" == release/* ]]; then
+            echo "✓ Allowed: $SOURCE → main"
+          else
+            echo "✗ PRs to main must come from develop or release/* (got: $SOURCE)"
+            echo ""
+            echo "  Target your PR at 'develop' instead."
+            echo "  main is release-only — all work goes through develop first."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## v1.0.0-beta.6 — 2026-02-27
+
+macOS install fixes: stale uv git cache, shell env var scoping bug, EAS on by default, API root info page, dashboard identity path when installed as a uv tool. 589 tests passing.
+
+### 🔴 Bug Fixes
+
+- **Branch install syntax** — `BRANCH=develop curl ... | bash` was wrong: the env var only applies to `curl`, not `bash`. Correct form: `curl ... | BRANCH=develop bash`. install.sh comment, docs, and CHANGELOG all updated.
+- **uv git cache** — `install.sh` now passes `--refresh` to `uv tool install`; prevents stale cached git clone from serving old code after `uninstall` + reinstall on a branch
+- **Dashboard identity gate** — `_repo_root()` in all dashboard modules was using `Path(__file__).resolve().parents[1]` (uv tool install dir, not user's cwd); always showed "forge required" even after identity already forged. Fixed to use `B1E55ED_REPO_ROOT` env var or `Path.cwd()` (same as CLI)
+- **EAS enabled by default** — `EASConfig.enabled = True` (was `False`); off-chain attestations need no `rpc_url` and should always be on. Startup log now shows helpful hint instead of scary DISABLED warning
+- **Forge timing** — Banner and wizard said "~2 seconds" (Apple Silicon benchmark); Intel Macs take 30s–2min. Updated to "seconds to ~2 min depending on hardware"
+
+### 🟡 API
+
+- **`GET /` info page** — API root was 404; now returns JSON with version, docs link, and key endpoint map
+
+### 🔧 CI / Workflow
+
+- **Branch guard added** — `.github/workflows/branch-guard.yml` blocks PRs to `main` from any branch except `develop` or `release/*`; enforces the develop → main release flow
+
+## v1.0.0-beta.5 — 2026-02-26
+
+macOS onboarding, Rust forge binary distribution, and zero-credential contributor registration via oracle relay. 589 tests passing.
+
+### 🟡 Install & Onboarding
+
+- **macOS install fixed** — `install.sh` now bootstraps Python via `uv` if none found; suppressed stderr noise; `eth-account>=0.11` moved to default deps (no longer requires `[eas]` extra)
+- **Forge binary auto-download** — `install.sh` and wizard both auto-download the Rust forge binary for macOS (universal arm64+x86_64) and Linux x86_64 from the latest release
+- **Pre-release URL fix** — `/releases/latest` skips pre-releases; both installer and wizard now resolve the real latest tag via `GET /releases?per_page=1` and build explicit download URLs
+- **Universal macOS binary** — CI builds a single `b1e55ed-forge-macos` via `lipo` (arm64 + x86_64); works on both Apple Silicon and Intel without selecting the right binary
+- **`install.sh` supports `BRANCH` env var** — `curl -sSf .../install.sh | BRANCH=develop bash` installs from any branch for testing
+
+### 🟡 Wizard UX
+
+- **Symbol packs menu** — Interactive preset selection instead of raw comma list
+- **GitHub token prominence** — Token field highlighted; explains why it's needed
+- **Real version in banner** — Uses `importlib.metadata.version("b1e55ed")` instead of hardcoded `v1.x`
+- **Forge banner aligned** — Width matches wizard banner (42 chars), text centered
+- **Health check test step** — Step 5 now runs `b1e55ed health` (was `brain --symbols BTC --dry-run` which doesn't exist)
+
+### 🟡 Contributor Registration
+
+- **Auto-registration in wizard** — New step `[4b]` after config: inline `ContributorRegistry.register()` call; no subprocess, no PATH issues
+- **Oracle relay** — Wizard calls `oracle.b1e55ed.xyz/api/v1/oracle/contributors/register`; oracle holds GitHub App key and creates announcement issue server-side; new users need zero credentials
+- **New public oracle endpoint** — `POST /api/v1/oracle/contributors/register` (no auth); validates `eth:0xb1e55ed` prefix; idempotent (409 on duplicate)
+- **GitHub App auth wired** — `get_publisher()` and `_build_contributor_registry_with_eas()` now activate on `app_id > 0`, not just `token`; App auth was previously silently skipped
+
+### 🟡 CLI
+
+- **`b1e55ed uninstall`** — New CLI command + `uninstall.sh`; documented in `docs/cli-reference.md`
+- **GitHub App defaults** — App ID `2953603`, Installation ID `112556330` baked into `engine/config/github_app_defaults.py`
+- **Version sync** — `engine/__init__.py` uses `importlib.metadata.version("b1e55ed")` (no hardcoded version string)
+
+### 🔧 CI
+
+- **No direct pushes to main** — Workflows (`dep-graphs`, `b1e55ing-merge`) create PRs instead of committing directly
+- **Forge release permissions** — `forge-release.yml` now has `contents: write` permission
+- **Manual forge trigger** — `workflow_dispatch` on forge-release accepts `tag_name` input
+- **CLI doc coverage check** — CI fails if a new command is added without a `docs/cli-reference.md` entry
+
+---
+
 ## v1.0.0-beta.4 — 2026-02-25
 
 Customer readiness release. 8-reviewer audit (Stripe, Coinbase, Cloudflare, Palantir — two model sets). Every finding addressed. 583 tests passing.

--- a/api/main.py
+++ b/api/main.py
@@ -134,11 +134,11 @@ def create_app() -> FastAPI:
 
         import logging as _log
 
-        if not getattr(config.eas, "enabled", False):
-            _log.getLogger("b1e55ed.startup").warning(
-                "EAS attestation is DISABLED (eas.enabled=false). "
-                "No on-chain proofs will be created. Set eas.enabled=true and configure eas.rpc_url to activate."
-            )
+        if getattr(config.eas, "enabled", True):
+            if not getattr(config.eas, "rpc_url", ""):
+                _log.getLogger("b1e55ed.startup").info("EAS off-chain attestations enabled. Set eas.rpc_url to also enable on-chain proofs.")
+        else:
+            _log.getLogger("b1e55ed.startup").warning("EAS attestation is DISABLED (eas.enabled=false in config).")
 
         from engine.core.database import Database
 
@@ -279,6 +279,30 @@ def create_app() -> FastAPI:
     from api.routes.mcp import router as mcp_router
 
     app.include_router(mcp_router)
+
+    @app.get("/", include_in_schema=False)
+    def root() -> dict:
+        """API info page — lists key endpoints."""
+        import engine as _engine
+
+        return {
+            "name": "b1e55ed",
+            "version": _engine.__version__,
+            "docs": "/docs",
+            "health": "/api/v1/health",
+            "endpoints": {
+                "contributors": "/api/v1/contributors",
+                "signals": "/api/v1/signals",
+                "producers": "/api/v1/producers",
+                "karma": "/api/v1/karma",
+                "positions": "/api/v1/positions",
+                "brain": "/api/v1/brain",
+                "oracle": "/api/v1/oracle/producers/{id}/provenance",
+                "config": "/api/v1/config",
+                "metrics": "/api/v1/metrics",
+                "mcp": "/mcp",
+            },
+        }
 
     return app
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -27,7 +27,10 @@ templates = Jinja2Templates(directory=_HERE / "templates")
 
 
 def _repo_root() -> Path:
-    return _HERE.parent
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 @app.middleware("http")

--- a/dashboard/contributors.py
+++ b/dashboard/contributors.py
@@ -13,7 +13,12 @@ from fastapi.templating import Jinja2Templates
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    import os
+
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _db_path() -> Path:

--- a/dashboard/identity.py
+++ b/dashboard/identity.py
@@ -13,7 +13,10 @@ from engine.core.config import Config
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _identity_path() -> Path:

--- a/dashboard/producers.py
+++ b/dashboard/producers.py
@@ -12,7 +12,12 @@ from fastapi.templating import Jinja2Templates
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    import os
+
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _db_path() -> Path:

--- a/dashboard/webhooks.py
+++ b/dashboard/webhooks.py
@@ -13,7 +13,12 @@ from fastapi.templating import Jinja2Templates
 
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    import os
+
+    override = os.environ.get("B1E55ED_REPO_ROOT")
+    if override:
+        return Path(override)
+    return Path.cwd()
 
 
 def _db_path() -> Path:

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -491,7 +491,7 @@ def _step3_identity(repo_root: Path) -> None:
     if rust_binary:
         # Fast path: Rust binary available
         print(f"  {_ok(f'Rust grinder found: {rust_binary}')}")
-        print("  Forging a vanity address takes ~2 seconds with the Rust binary.")
+        print("  Forging a vanity address takes seconds to ~2 min depending on hardware.")
         print()
 
         try:

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -2000,7 +2000,7 @@ def _identity_forge(ctx: CliContext, args: argparse.Namespace) -> int:
         print("  Yours is being derived now.")
         print()
         if rust_binary:
-            print("  This takes ~2 seconds with the Rust grinder.")
+            print("  This takes seconds to ~2 min with the Rust grinder (hardware dependent).")
         else:
             print("  Rust grinder not found — using Python fallback (~90 min).")
         print()

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -117,7 +117,7 @@ class DashboardConfig(BaseModel):
 
 
 class EASConfig(BaseModel):
-    enabled: bool = False
+    enabled: bool = True  # off-chain attestations work without rpc_url; on-chain needs rpc_url
     rpc_url: str = "https://eth.llamarpc.com"  # Free public RPC
     eas_contract: str = "0xA1207F3BBa224E2c9c3c6D5aF63D0eb1582Ce587"
     schema_registry: str = "0xA7b39296258348C78294F95B872b282326A97BDF"

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@
 # Or:    ./install.sh
 #
 # Test from a specific branch (e.g. develop):
-#   BRANCH=develop curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | bash
+#   curl -sSf https://raw.githubusercontent.com/P-U-C/b1e55ed/main/install.sh | BRANCH=develop bash
+#   NOTE: BRANCH=... must prefix 'bash', not 'curl' — env vars only apply to the command they prefix.
 #
 # Idempotent: safe to re-run.
 set -euo pipefail
@@ -158,7 +159,7 @@ else
     # Install from GitHub — always explicit branch (never relies on default branch)
     INSTALL_URL="git+https://github.com/P-U-C/b1e55ed.git@${BRANCH}"
     info "Installing from: $INSTALL_URL"
-    if uv tool install "$INSTALL_URL" 2>/dev/null; then
+    if uv tool install --refresh "$INSTALL_URL" 2>/dev/null; then
         success "b1e55ed installed as a uv tool"
     else
         error "Installation failed. Clone the repo and run ./install.sh from inside it."
@@ -259,7 +260,7 @@ if [ -n "$FORGE_URL" ]; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
             xattr -dr com.apple.quarantine "$FORGE_DIR/b1e55ed-forge" 2>/dev/null || true
         fi
-        success "Rust forge binary installed (~50M candidates/sec)"
+        success "Rust forge binary installed (much faster than Python fallback)"
     else
         warn "Could not download forge binary (no release yet) — Python fallback will be used"
         warn "Run 'b1e55ed identity forge' after a release is published, or use random identity"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "b1e55ed"
-version = "1.0.0-beta.5"
+version = "1.0.0-beta.6"
 description = "Sovereign AI trading intelligence with compound learning"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "b1e55ed"
-version = "1.0.0b5"
+version = "1.0.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
## v1.0.0-beta.6

589 tests passing. Clean squash onto main HEAD — no conflicts.

### 🔴 Bug Fixes

- **Branch install syntax** — `BRANCH=develop curl ... | bash` was wrong: env var only applies to `curl`. Correct: `curl ... | BRANCH=develop bash`. Docs + comment updated.
- **uv git cache** — `--refresh` on `uv tool install` so reinstall always gets fresh git fetch, not stale cached clone
- **Dashboard identity gate** — `_repo_root()` across all dashboard modules was `Path(__file__).parents[1]` (uv tool install dir); always showed forge-required wall even after identity forged. Now `Path.cwd()` like the CLI.
- **EAS enabled by default** — `EASConfig.enabled = True` (was `False`); off-chain attestations need no `rpc_url` and should be on by default
- **Forge timing** — `~2 seconds` → `seconds to ~2 min depending on hardware` (Intel Macs are slower than the M-series benchmark)

### 🟡 API

- **`GET /` info page** — was 404; now returns JSON with version, docs link, and all key endpoint paths

### 🔧 CI

- **Branch guard** — `.github/workflows/branch-guard.yml` blocks PRs to `main` from anything except `develop` or `release/*`