### PR TITLE
feat(flywheel/s1): signal attribution layer

### DIFF
--- a/engine/brain/decision.py
+++ b/engine/brain/decision.py
@@ -12,7 +12,7 @@ This module ports the legacy decision matrix concept but adapts it to v3:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
 from engine.brain.kill_switch import KillSwitchLevel
@@ -28,6 +28,7 @@ class DecisionContext:
     pcs: float
     regime: str
     kill_level: KillSwitchLevel
+    source_event_ids: list[str] = field(default_factory=list)
 
 
 @runtime_checkable
@@ -83,6 +84,7 @@ class DefaultDecisionPolicy:
             rationale=rationale,
             stop_loss_pct=0.05,
             take_profit_pct=0.10,
+            source_event_ids=list(ctx.source_event_ids),
         )
 
 
@@ -107,8 +109,15 @@ class DecisionEngine:
         kill_level: KillSwitchLevel,
         source: str = "brain.decision",
         trace_id: str | None = None,
+        source_event_ids: list[str] | None = None,
     ) -> TradeIntent | None:
-        ctx = DecisionContext(symbol=str(symbol).upper(), pcs=float(pcs), regime=str(regime), kill_level=kill_level)
+        ctx = DecisionContext(
+            symbol=str(symbol).upper(),
+            pcs=float(pcs),
+            regime=str(regime),
+            kill_level=kill_level,
+            source_event_ids=list(source_event_ids or []),
+        )
         intent = self.policy.decide(ctx)
         if intent is None:
             return None

--- a/engine/core/types.py
+++ b/engine/core/types.py
@@ -59,6 +59,7 @@ class TradeIntent:
     take_profit_pct: float | None = None
     horizon: str | None = None
     invalidation: float | None = None
+    source_event_ids: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)

--- a/engine/execution/oms.py
+++ b/engine/execution/oms.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
 
 from engine.core.config import Config
 from engine.core.database import Database
-from engine.core.events import EventType, TradeIntentPayload
+from engine.core.events import EventType, SignalAcceptedPayload, TradeIntentPayload
 from engine.core.policy import TradingPolicyEngine
 from engine.core.types import TradeIntent
 from engine.execution.paper import PaperBroker
@@ -184,6 +184,12 @@ class OMS:
                 source="execution.oms",
             )
 
+            # Emit SIGNAL_ACCEPTED_V1 for each contributing signal (flywheel attribution)
+            self._emit_signal_accepted(
+                trade_id=fill.order_id,
+                intent=intent,
+            )
+
             return OMSResult(
                 status="filled",
                 mode=mode,
@@ -196,6 +202,52 @@ class OMS:
             raise NotImplementedError("live execution adapter not implemented in Sprint 2A")
 
         return OMSResult(status="error", mode=mode, reasons=[f"unknown_mode:{mode}"])
+
+    def _emit_signal_accepted(self, *, trade_id: str, intent: TradeIntent) -> None:
+        """Emit SIGNAL_ACCEPTED_V1 for each source event that contributed to this trade."""
+        from engine.brain.synthesis import FeatureExtractor
+
+        if not intent.source_event_ids:
+            return
+
+        extractor = FeatureExtractor()
+
+        for event_id in intent.source_event_ids:
+            # Look up the original event to get producer/domain info
+            row = self.db.conn.execute(
+                "SELECT type, source FROM events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if row is None:
+                continue
+
+            event_type_str = str(row["type"])
+            source = str(row["source"]) if row["source"] else "unknown"
+
+            # Derive domain from event type
+            try:
+                et = EventType(event_type_str)
+                domain = extractor.DOMAIN_BY_EVENT_TYPE.get(et, "unknown")
+            except ValueError:
+                domain = "unknown"
+
+            payload = SignalAcceptedPayload(
+                trade_id=trade_id,
+                producer_id=source,
+                domain=domain,
+                signal_event_id=event_id,
+                contribution_weight=1.0,  # Phase 0: equal weights
+                direction=intent.direction,
+                confidence=float(intent.conviction_score),
+                horizon=intent.horizon,
+                invalidation=intent.invalidation,
+            ).model_dump(mode="json")
+
+            self.db.append_event(
+                event_type=EventType.SIGNAL_ACCEPTED_V1,
+                payload=payload,
+                source="execution.oms",
+            )
 
 
 def default_sizer_from_config(cfg: Config) -> CorrelationAwareSizer:

--- a/tests/unit/test_signal_attribution.py
+++ b/tests/unit/test_signal_attribution.py
@@ -1,0 +1,165 @@
+"""Tests for flywheel S1 — signal attribution layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.brain.decision import DecisionContext, DefaultDecisionPolicy
+from engine.brain.kill_switch import KillSwitchLevel
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.types import TradeIntent
+
+
+@pytest.fixture
+def db(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    return db
+
+
+@pytest.fixture
+def config():
+    return Config()
+
+
+class TestSourceEventIdsPropagation:
+    """Test that source_event_ids flow through synthesis → conviction → decision → TradeIntent."""
+
+    def test_trade_intent_carries_source_event_ids(self):
+        ti = TradeIntent(
+            symbol="BTC",
+            direction="long",
+            size_pct=0.05,
+            leverage=1.0,
+            conviction_score=80.0,
+            regime="TRENDING",
+            rationale="test",
+            source_event_ids=["evt-1", "evt-2", "evt-3"],
+        )
+        assert ti.source_event_ids == ["evt-1", "evt-2", "evt-3"]
+
+    def test_trade_intent_defaults_empty(self):
+        ti = TradeIntent(
+            symbol="BTC",
+            direction="long",
+            size_pct=0.05,
+            leverage=1.0,
+            conviction_score=80.0,
+            regime="TRENDING",
+            rationale="test",
+        )
+        assert ti.source_event_ids == []
+
+    def test_decision_context_carries_source_event_ids(self):
+        ctx = DecisionContext(
+            symbol="BTC",
+            pcs=80.0,
+            regime="TRENDING",
+            kill_level=KillSwitchLevel.SAFE,
+            source_event_ids=["evt-1"],
+        )
+        assert ctx.source_event_ids == ["evt-1"]
+
+    def test_decision_policy_passes_source_event_ids(self, config):
+        policy = DefaultDecisionPolicy(config)
+        ctx = DecisionContext(
+            symbol="BTC",
+            pcs=80.0,
+            regime="TRENDING",
+            kill_level=KillSwitchLevel.SAFE,
+            source_event_ids=["evt-1", "evt-2"],
+        )
+        intent = policy.decide(ctx)
+        assert intent is not None
+        assert intent.source_event_ids == ["evt-1", "evt-2"]
+
+    def test_source_event_ids_propagate_through_synthesis(self, db):
+        """Verify FeatureSnapshot captures source_event_ids during synthesis."""
+        from engine.brain.synthesis import VectorSynthesis
+
+        # Insert a TA signal event
+        ev = db.append_event(
+            event_type=EventType.SIGNAL_TA_V1,
+            payload={"symbol": "BTC", "rsi_14": 55.0, "ema_20": 50000.0},
+            source="test.producer",
+        )
+
+        synth = VectorSynthesis(config=Config(), db=db)
+        snapshot = synth.build_snapshot(cycle_id="test-cycle", symbol="BTC")
+        assert ev.id in snapshot.source_event_ids
+
+
+def _make_oms(db, config):
+    """Helper to construct an OMS with all required dependencies."""
+    from engine.brain.kill_switch import KillSwitch
+    from engine.core.policy import TradingPolicy, TradingPolicyEngine
+    from engine.execution.oms import OMS, default_sizer_from_config
+    from engine.execution.paper import PaperBroker
+    from engine.execution.preflight import Preflight
+
+    ks = KillSwitch(config=config, db=db)
+    policy_engine = TradingPolicyEngine(policy=TradingPolicy())
+    preflight = Preflight(policy=policy_engine, kill_switch=ks)
+    sizer = default_sizer_from_config(config)
+    paper = PaperBroker(db=db)
+    return OMS(config=config, db=db, preflight=preflight, sizer=sizer, paper_broker=paper)
+
+
+class TestSignalAcceptedEmission:
+    """Test that OMS emits SIGNAL_ACCEPTED_V1 after paper trade."""
+
+    def test_signal_accepted_emitted_on_paper_trade(self, db, config):
+        # Insert a signal event so we have a valid source_event_id
+        ev = db.append_event(
+            event_type=EventType.SIGNAL_TA_V1,
+            payload={"symbol": "BTC", "rsi_14": 55.0},
+            source="test.ta_producer",
+        )
+
+        oms = _make_oms(db, config)
+
+        intent = TradeIntent(
+            symbol="BTC",
+            direction="long",
+            size_pct=0.05,
+            leverage=1.0,
+            conviction_score=80.0,
+            regime="TRENDING",
+            rationale="test",
+            source_event_ids=[ev.id],
+        )
+
+        result = oms.submit(intent, mid_price=50000.0, equity_usd=10000.0)
+        assert result.status == "filled"
+
+        # Check SIGNAL_ACCEPTED_V1 was emitted
+        accepted_events = db.get_events(event_type=EventType.SIGNAL_ACCEPTED_V1)
+        assert len(accepted_events) >= 1
+
+        payload = accepted_events[0].payload
+        assert payload["trade_id"] == result.order_id
+        assert payload["signal_event_id"] == ev.id
+        assert payload["direction"] == "long"
+        assert payload["domain"] == "technical"
+        assert payload["producer_id"] == "test.ta_producer"
+
+    def test_no_signal_accepted_when_no_source_events(self, db, config):
+        oms = _make_oms(db, config)
+
+        intent = TradeIntent(
+            symbol="BTC",
+            direction="long",
+            size_pct=0.05,
+            leverage=1.0,
+            conviction_score=80.0,
+            regime="TRENDING",
+            rationale="test",
+        )
+
+        result = oms.submit(intent, mid_price=50000.0, equity_usd=10000.0)
+        assert result.status == "filled"
+
+        # No SIGNAL_ACCEPTED_V1 should be emitted
+        accepted_events = db.get_events(event_type=EventType.SIGNAL_ACCEPTED_V1)
+        assert len(accepted_events) == 0


### PR DESCRIPTION
S1: source_event_ids flows through synthesis→conviction→decision→TradeIntent→OMS. OMS emits SIGNAL_ACCEPTED_V1 per contributing signal after paper fill. 611 tests (+7 new).