### PR TITLE
feat(flywheel/s3): smart tradfi producer — self-contained Binance + rule-based signals

### DIFF
--- a/engine/core/events.py
+++ b/engine/core/events.py
@@ -133,6 +133,11 @@ class TradFiSignalPayload(BaseModel):
     funding_annualized: float | None = None
     oi_change_pct: float | None = None
     meltup_score: float | None = None
+    direction: str | None = None
+    confidence: float | None = None
+    horizon: str = "swing"
+    invalidation: float | None = None
+    signal_reason: str | None = None
 
 
 class SocialSignalPayload(BaseModel):

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -3,11 +3,11 @@
 TradFi Basis Producer.
 
 Fetches carry/basis-style metrics (spot vs futures, funding proxy, OI changes)
-from a configured HTTP endpoint and emits
+from Binance public APIs and emits
 :class:`~engine.core.events.EventType.SIGNAL_TRADFI_V1`.
 
-The endpoint is configured via env and unit tests mock the injected
-``context.client``.
+Falls back to ``B1E55ED_TRADFI_BASIS_URL`` if that env var is set
+(legacy path).
 
 Easter egg:
 - Markets rhyme; basis keeps the meter.
@@ -17,14 +17,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import time
-from datetime import datetime
-
-try:
-    from datetime import UTC  # py311+
-except ImportError:  # pragma: no cover
-    UTC = UTC  # noqa: N806
-
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -35,10 +30,159 @@ from engine.core.types import ProducerHealth, ProducerResult
 from engine.producers.base import BaseProducer
 from engine.producers.registry import register
 
+# ---------------------------------------------------------------------------
+# Signal logic
+# ---------------------------------------------------------------------------
+
+
+def _compute_signal(
+    basis_ann: float | None,
+    funding_ann: float | None,
+    meltup_score: float | None,
+) -> tuple[str, float, str]:
+    """Rule-based direction / confidence from TradFi metrics."""
+
+    if meltup_score is not None and meltup_score == 4:
+        return "long", 0.75, "meltup_score=4: full setup"
+
+    if basis_ann is not None:
+        if basis_ann > 8.0:
+            return "short", 0.60, f"basis crowded ({basis_ann:.1f}% ann) \u2014 unwind risk"
+        if basis_ann < 2.0 and (funding_ann is None or funding_ann < 0):
+            return (
+                "short",
+                0.65,
+                f"basis unwound ({basis_ann:.1f}%) + negative funding \u2014 risk-off",
+            )
+        if 3.0 <= basis_ann <= 6.0:
+            if funding_ann is not None and 5.0 <= funding_ann <= 20.0:
+                return "long", 0.55, f"basis healthy ({basis_ann:.1f}%) + funding normal"
+            return "long", 0.45, f"basis healthy ({basis_ann:.1f}%) \u2014 early setup"
+
+    return "flat", 0.0, "no clear regime signal"
+
+
+# ---------------------------------------------------------------------------
+# Binance helpers
+# ---------------------------------------------------------------------------
+
+_QUARTERLY_RE = re.compile(r"^(BTC|ETH)USD_\d{6}$")
+_QUARTERLY_ASSETS = {"BTC", "ETH"}
+_PERP_SYMBOLS = {"BTC": "BTCUSDT", "ETH": "ETHUSDT", "SOL": "SOLUSDT"}
+_SPOT_SYMBOLS = {"BTC": "BTCUSDT", "ETH": "ETHUSDT", "SOL": "SOLUSDT"}
+
+
+def _days_to_expiry(symbol: str) -> float:
+    """Parse YYMMDD from e.g. BTCUSD_250328 and return days to expiry."""
+    suffix = symbol.split("_")[1]
+    year = 2000 + int(suffix[:2])
+    month = int(suffix[2:4])
+    day = int(suffix[4:6])
+    expiry = datetime(year, month, day, tzinfo=UTC)
+    delta = (expiry - datetime.now(tz=UTC)).total_seconds() / 86400
+    return max(delta, 1.0)
+
+
+async def _fetch_binance(client: httpx.AsyncClient, universe: list[str]) -> list[dict[str, Any]]:
+    """Fetch basis, funding, OI from Binance for each symbol in *universe*."""
+
+    results: list[dict[str, Any]] = []
+
+    # 1. Coin-M quarterly tickers (for BTC/ETH basis)
+    quarterly_prices: dict[str, tuple[float, float]] = {}
+    need_quarterly = [s for s in universe if s in _QUARTERLY_ASSETS]
+    if need_quarterly:
+        resp = await client.get("https://dapi.binance.com/dapi/v1/ticker/price", timeout=10)
+        resp.raise_for_status()
+        for tick in resp.json():
+            sym = tick.get("symbol", "")
+            if _QUARTERLY_RE.match(sym):
+                asset = sym.split("USD_")[0]
+                if asset in need_quarterly:
+                    price = float(tick["price"])
+                    days = _days_to_expiry(sym)
+                    if asset not in quarterly_prices or days < quarterly_prices[asset][1]:
+                        quarterly_prices[asset] = (price, days)
+
+    # 2. Spot prices
+    spot_prices: dict[str, float] = {}
+    for asset in universe:
+        spot_sym = _SPOT_SYMBOLS.get(asset)
+        if not spot_sym:
+            continue
+        resp = await client.get(
+            "https://api.binance.com/api/v3/ticker/price",
+            params={"symbol": spot_sym},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        spot_prices[asset] = float(resp.json()["price"])
+
+    # 3. Funding rates
+    funding_rates: dict[str, float] = {}
+    for asset in universe:
+        perp_sym = _PERP_SYMBOLS.get(asset)
+        if not perp_sym:
+            continue
+        resp = await client.get(
+            "https://fapi.binance.com/fapi/v1/fundingRate",
+            params={"symbol": perp_sym, "limit": 1},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if data:
+            rate = float(data[0]["fundingRate"])
+            funding_rates[asset] = rate * 3 * 365 * 100
+
+    # 4. Open interest
+    oi_values: dict[str, float] = {}
+    for asset in universe:
+        perp_sym = _PERP_SYMBOLS.get(asset)
+        if not perp_sym:
+            continue
+        resp = await client.get(
+            "https://fapi.binance.com/fapi/v1/openInterest",
+            params={"symbol": perp_sym},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        oi_values[asset] = float(resp.json()["openInterest"])
+
+    # 5. Assemble per-asset rows
+    for asset in universe:
+        row: dict[str, Any] = {"symbol": asset}
+
+        if asset in quarterly_prices and asset in spot_prices:
+            fut_price, days = quarterly_prices[asset]
+            spot = spot_prices[asset]
+            basis_pct = (fut_price / spot - 1) * 100
+            row["basis_annualized"] = basis_pct * (365 / days)
+        else:
+            row["basis_annualized"] = None
+
+        row["funding_annualized"] = funding_rates.get(asset)
+        row["oi_change_pct"] = None
+        row["oi_value"] = oi_values.get(asset)
+
+        score = 0
+        if row.get("basis_annualized") is not None and 3.0 <= row["basis_annualized"] <= 6.0:
+            score += 1
+        if row.get("funding_annualized") is not None and row["funding_annualized"] > 0:
+            score += 1
+        if row.get("funding_annualized") is not None and row["funding_annualized"] < 30:
+            score += 1
+        if oi_values.get(asset) is not None:
+            score += 1
+        row["meltup_score"] = score
+
+        results.append(row)
+
+    return results
+
 
 def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
     """Symbol + timestamp (+ producer) dedupe key."""
-
     return f"{EventType.SIGNAL_TRADFI_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
 
 
@@ -52,18 +196,29 @@ class TradFiBasisProducer(BaseProducer):
         return os.getenv("B1E55ED_TRADFI_BASIS_URL") or os.getenv("TRADFI_BASIS_URL")
 
     def collect(self) -> list[dict[str, Any]]:
+        # Legacy fallback: if endpoint env var is set, use old HTTP path
         url = self._endpoint()
-        if not url:
-            self.ctx.logger.warning("tradfi_basis_endpoint_missing")
+        if url:
+            symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+            data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
+            if isinstance(data, dict) and "data" in data:
+                data = data["data"]
+            if not isinstance(data, list):
+                return []
+            return [row for row in data if isinstance(row, dict)]
+
+        # Direct Binance API path (default)
+        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        universe = [s for s in symbols if s in _PERP_SYMBOLS]
+        if not universe:
+            self.ctx.logger.warning("tradfi_no_supported_symbols")
             return []
 
-        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
-        data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
-        if isinstance(data, dict) and "data" in data:
-            data = data["data"]
-        if not isinstance(data, list):
+        try:
+            return asyncio.run(_fetch_binance(httpx.AsyncClient(), universe))
+        except Exception:
+            self.ctx.logger.exception("tradfi_binance_fetch_failed")
             return []
-        return [row for row in data if isinstance(row, dict)]
 
     def normalize(self, raw: list[dict[str, Any]]) -> list[Event]:
         ts = datetime.now(tz=UTC)
@@ -74,12 +229,21 @@ class TradFiBasisProducer(BaseProducer):
             if not sym:
                 continue
 
+            basis_ann = row.get("basis_annualized")
+            funding_ann = row.get("funding_annualized")
+            meltup = row.get("meltup_score")
+
+            direction, confidence, reason = _compute_signal(basis_ann, funding_ann, meltup)
+
             payload_obj = TradFiSignalPayload(
                 symbol=sym,
-                basis_annualized=row.get("basis_annualized"),
-                funding_annualized=row.get("funding_annualized"),
+                basis_annualized=basis_ann,
+                funding_annualized=funding_ann,
                 oi_change_pct=row.get("oi_change_pct"),
-                meltup_score=row.get("meltup_score"),
+                meltup_score=meltup,
+                direction=direction,
+                confidence=confidence,
+                signal_reason=reason,
             )
             payload = payload_obj.model_dump(mode="json")
             out.append(

--- a/tests/test_tradfi_smart.py
+++ b/tests/test_tradfi_smart.py
@@ -1,0 +1,242 @@
+"""Tests for S3 Smart TradFi Producer — self-contained Binance + rule-based signals."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from engine.core.events import TradFiSignalPayload
+from engine.producers.tradfi import (
+    TradFiBasisProducer,
+    _compute_signal,
+    _fetch_binance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(symbols=None):
+    ctx = MagicMock()
+    ctx.config.universe.symbols = symbols or ["BTC", "ETH", "SOL"]
+    ctx.logger = MagicMock()
+    ctx.db = MagicMock()
+    ctx.metrics = MagicMock()
+    ctx.client = MagicMock()
+    return ctx
+
+
+def _make_producer(symbols=None) -> TradFiBasisProducer:
+    ctx = _make_ctx(symbols)
+    p = TradFiBasisProducer.__new__(TradFiBasisProducer)
+    p.ctx = ctx
+    p.name = "tradfi-basis"
+    p._bus = None
+    return p
+
+
+def _binance_response(url, **kwargs):
+    """Route mock responses based on URL."""
+    url_str = str(url)
+
+    if "dapi.binance.com" in url_str and "ticker/price" in url_str:
+        return httpx.Response(
+            200,
+            json=[
+                {"symbol": "BTCUSD_250328", "price": "105000.0", "ps": "BTCUSD"},
+                {"symbol": "ETHUSD_250328", "price": "4200.0", "ps": "ETHUSD"},
+                {"symbol": "BTCUSD_250627", "price": "108000.0", "ps": "BTCUSD"},
+            ],
+            request=httpx.Request("GET", url_str),
+        )
+    if "api.binance.com" in url_str and "ticker/price" in url_str:
+        params = kwargs.get("params", {})
+        sym = params.get("symbol", "")
+        prices = {"BTCUSDT": "100000.0", "ETHUSDT": "4000.0", "SOLUSDT": "200.0"}
+        return httpx.Response(
+            200,
+            json={"symbol": sym, "price": prices.get(sym, "0")},
+            request=httpx.Request("GET", url_str),
+        )
+    if "fapi.binance.com" in url_str and "fundingRate" in url_str:
+        return httpx.Response(
+            200,
+            json=[{"fundingRate": "0.0001", "fundingTime": 1700000000000}],
+            request=httpx.Request("GET", url_str),
+        )
+    if "fapi.binance.com" in url_str and "openInterest" in url_str:
+        return httpx.Response(
+            200,
+            json={"symbol": "BTCUSDT", "openInterest": "50000.0"},
+            request=httpx.Request("GET", url_str),
+        )
+    return httpx.Response(200, json={}, request=httpx.Request("GET", url_str))
+
+
+class MockAsyncClient:
+    """Mock httpx.AsyncClient that routes by URL."""
+
+    async def get(self, url, **kwargs):
+        return _binance_response(url, **kwargs)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Signal logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSignal:
+    def test_tradfi_meltup_score_4_is_long_0_75(self):
+        d, c, r = _compute_signal(5.0, 10.0, 4)
+        assert d == "long"
+        assert c == 0.75
+        assert "meltup_score=4" in r
+
+    def test_tradfi_basis_crowded_is_short(self):
+        d, c, r = _compute_signal(9.5, 10.0, None)
+        assert d == "short"
+        assert c == 0.60
+        assert "crowded" in r
+
+    def test_tradfi_basis_unwound_negative_funding(self):
+        d, c, r = _compute_signal(1.5, -5.0, None)
+        assert d == "short"
+        assert c == 0.65
+        assert "unwound" in r
+
+    def test_tradfi_basis_healthy_with_funding(self):
+        d, c, r = _compute_signal(4.5, 10.0, None)
+        assert d == "long"
+        assert c == 0.55
+        assert "healthy" in r and "funding normal" in r
+
+    def test_tradfi_basis_healthy_early_setup(self):
+        d, c, r = _compute_signal(4.5, None, None)
+        assert d == "long"
+        assert c == 0.45
+        assert "early setup" in r
+
+    def test_tradfi_no_signal_is_flat(self):
+        d, c, r = _compute_signal(None, None, None)
+        assert d == "flat"
+        assert c == 0.0
+        assert "no clear" in r
+
+
+# ---------------------------------------------------------------------------
+# Producer integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestTradFiProducer:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_tradfi_self_contained_no_env_var(self):
+        """Producer runs without B1E55ED_TRADFI_BASIS_URL using Binance."""
+        p = _make_producer()
+        with patch(
+            "engine.producers.tradfi.httpx.AsyncClient",
+            return_value=MockAsyncClient(),
+        ):
+            raw = p.collect()
+        assert len(raw) >= 1
+        assert all("symbol" in r for r in raw)
+
+    @patch.dict(
+        "os.environ",
+        {"B1E55ED_TRADFI_BASIS_URL": "http://legacy.test/basis"},
+        clear=False,
+    )
+    def test_tradfi_fallback_to_env_url_if_set(self):
+        """If env var set, uses old HTTP path."""
+        p = _make_producer()
+        p.ctx.client.request_json = AsyncMock(
+            return_value=[
+                {
+                    "symbol": "BTC",
+                    "basis_annualized": 5.0,
+                    "funding_annualized": 10.0,
+                }
+            ]
+        )
+        raw = p.collect()
+        assert len(raw) == 1
+        assert raw[0]["symbol"] == "BTC"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_tradfi_binance_calls_mocked(self):
+        """Verify correct Binance endpoints are called."""
+        calls: list[str] = []
+
+        class TrackingClient:
+            async def get(self, url, **kwargs):
+                calls.append(str(url))
+                return _binance_response(url, **kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+        result = asyncio.run(_fetch_binance(TrackingClient(), ["BTC", "ETH", "SOL"]))
+        assert len(result) == 3
+
+        urls_joined = " ".join(calls)
+        assert "dapi.binance.com" in urls_joined
+        assert "api.binance.com" in urls_joined
+        assert "fapi.binance.com" in urls_joined
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_tradfi_normalize_wires_signal(self):
+        """normalize() sets direction/confidence/signal_reason on payload."""
+        p = _make_producer()
+        raw = [
+            {
+                "symbol": "BTC",
+                "basis_annualized": 9.0,
+                "funding_annualized": 5.0,
+                "meltup_score": None,
+            }
+        ]
+        events = p.normalize(raw)
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload["direction"] == "short"
+        assert payload["confidence"] == 0.60
+        assert payload["signal_reason"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Payload model tests
+# ---------------------------------------------------------------------------
+
+
+class TestTradFiSignalPayload:
+    def test_new_fields_defaults(self):
+        p = TradFiSignalPayload(symbol="BTC")
+        assert p.direction is None
+        assert p.confidence is None
+        assert p.horizon == "swing"
+        assert p.invalidation is None
+        assert p.signal_reason is None
+
+    def test_new_fields_set(self):
+        p = TradFiSignalPayload(
+            symbol="ETH",
+            direction="long",
+            confidence=0.55,
+            horizon="intraday",
+            invalidation=3800.0,
+            signal_reason="test",
+        )
+        assert p.direction == "long"
+        assert p.confidence == 0.55


### PR DESCRIPTION
Closes S3 of the flywheel sprint plan. Replaces dead endpoint dependency with direct Binance calls. Adds direction/confidence/horizon/invalidation to TradFiSignalPayload.