### PR TITLE
feat(mcp/s1): MCP client (inbound) + FinancialDatasetsMCPProducer

### DIFF
--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -570,3 +570,22 @@ engine/mcp/__init__.py
 engine/mcp/types.py
   (no internal deps — standalone type definitions)
 ```
+
+### `engine/mcp/client.py`
+
+```text
+engine/mcp/client.py
+  (optional) mcp SDK import
+  → httpx (HTTP transport)
+```
+
+### `engine/producers/financial_datasets.py`
+
+```text
+engine/producers/financial_datasets.py
+  → engine/mcp/client.py
+  → engine/producers/base.py
+  → engine/producers/registry.py
+  → engine/core/events.py
+  → engine/core/models.py
+```

--- a/engine/mcp/client.py
+++ b/engine/mcp/client.py
@@ -1,0 +1,166 @@
+"""engine.mcp.client
+
+MCP client abstraction for consuming external data sources.
+
+Design: Two-layer.
+  Layer 1 – MCPClient (abstract): defines the interface any data-source client must satisfy.
+  Layer 2 – HttpMCPClient (concrete): implements the interface over plain HTTP/REST.
+             Full MCP stdio/SSE protocol support is a follow-up (S2+).
+
+When an MCP server is available for a source, the subclass sets `mcp_source_url` and
+overrides `_call_tool()` to use the MCP protocol. Until then, HTTP is the transport.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    UTC = UTC  # noqa: N806
+
+from typing import Any
+
+import httpx
+
+try:  # pragma: no cover - optional dependency
+    from mcp import ClientSession as _MCPClientSession  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - optional dependency
+    _MCPClientSession = None
+
+MCP_SDK_AVAILABLE = _MCPClientSession is not None
+
+
+@dataclass(frozen=True, slots=True)
+class MCPToolResult:
+    """Normalized result from any MCP tool call."""
+
+    tool: str
+    data: list[dict]
+    source_url: str
+    fetched_at: str
+    raw: dict
+
+
+class MCPClient(ABC):
+    """Abstract MCP data source client."""
+
+    source_url: str
+
+    @abstractmethod
+    def call_tool(self, tool: str, arguments: dict) -> MCPToolResult:
+        """Call a tool on the upstream source and return normalized rows."""
+
+    def available(self) -> bool:
+        """Return True if the source is reachable. Default: always True."""
+
+        return True
+
+
+class HttpMCPClient(MCPClient):
+    """HTTP/REST adapter.
+
+    Speaks to REST APIs that mirror MCP tool interfaces.
+    """
+
+    def __init__(self, base_url: str, api_key: str | None = None, timeout: int = 10) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.source_url = self.base_url
+        self.timeout = timeout
+        self.api_key = api_key
+
+        headers = {"Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+            headers["X-API-Key"] = api_key
+        self._headers = headers
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(tz=UTC).isoformat()
+
+    @staticmethod
+    def _normalize_rows(payload: Any) -> list[dict]:
+        if isinstance(payload, list):
+            return [row for row in payload if isinstance(row, dict)]
+
+        if isinstance(payload, dict):
+            for key in ("data", "results", "rows", "items"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return [row for row in value if isinstance(row, dict)]
+                if isinstance(value, dict):
+                    return [value]
+
+            if "error" in payload:
+                return []
+
+            return [payload]
+
+        return []
+
+    @staticmethod
+    def _response_to_dict(response: httpx.Response) -> dict:
+        try:
+            body = response.json()
+        except ValueError:
+            body = {"text": response.text}
+
+        if isinstance(body, dict):
+            return body
+        if isinstance(body, list):
+            return {"data": body}
+        return {"value": body}
+
+    def call_tool(self, tool: str, arguments: dict) -> MCPToolResult:
+        """Call a mirrored MCP tool over HTTP.
+
+        POSTs to ``{base_url}/tools/{tool}`` with ``arguments`` as JSON body.
+        If POST returns 405, falls back to ``GET {base_url}/{tool}`` with query params.
+
+        Never raises: returns an empty ``data`` list on any error.
+        """
+
+        tool_name = tool.strip("/")
+        args = arguments or {}
+        fetched_at = self._now_iso()
+        post_url = f"{self.base_url}/tools/{tool_name}"
+        get_url = f"{self.base_url}/{tool_name}"
+
+        try:
+            with httpx.Client(timeout=self.timeout, headers=self._headers) as client:
+                response = client.post(post_url, json=args)
+                if response.status_code == 405:
+                    response = client.get(get_url, params=args)
+
+                response.raise_for_status()
+                raw = self._response_to_dict(response)
+                return MCPToolResult(
+                    tool=tool_name,
+                    data=self._normalize_rows(raw),
+                    source_url=self.source_url,
+                    fetched_at=fetched_at,
+                    raw=raw,
+                )
+        except Exception as exc:  # noqa: BLE001 - never raise to producer layer
+            return MCPToolResult(
+                tool=tool_name,
+                data=[],
+                source_url=self.source_url,
+                fetched_at=fetched_at,
+                raw={"error": f"{type(exc).__name__}: {exc}"},
+            )
+
+    def available(self) -> bool:
+        """HEAD request to base URL. Returns False on any error."""
+
+        try:
+            with httpx.Client(timeout=self.timeout, headers=self._headers) as client:
+                response = client.head(self.base_url)
+                response.raise_for_status()
+            return True
+        except Exception:  # noqa: BLE001
+            return False

--- a/engine/producers/base.py
+++ b/engine/producers/base.py
@@ -25,7 +25,7 @@ try:
 except ImportError:  # pragma: no cover
     UTC = UTC  # noqa: N806
 
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from engine.core.client import DataClient
 from engine.core.config import Config
@@ -77,8 +77,34 @@ class BaseProducer(ABC):
     domain: str
     schedule: str
 
+    # Class variable — override in subclasses that have an MCP source.
+    mcp_source_url: str | None = None
+
+    # Injected by registry after construction (set in S2).
+    _mcp_client: Any | None = None
+
     def __init__(self, ctx: ProducerContext) -> None:
         self.ctx = ctx
+
+    def _collect_via_mcp(self) -> list[dict]:
+        """Fetch raw data via MCP client. Returns [] on any failure."""
+
+        if self._mcp_client is None:
+            return []
+
+        try:
+            result = self._mcp_client.call_tool("get_signals", {"producer": self.name})
+            return result.data
+        except Exception:  # noqa: BLE001
+            self.ctx.logger.warning("mcp_collect_failed", extra={"producer": self.name})
+            return []
+
+    def _publish_to_mcp(self, events: list[Event]) -> None:
+        """Fire-and-forget: push events to MCP signal buffer. Never raises."""
+
+        # Populated in S2 when MCPProducerRegistry exists.
+        # Stub here so subclasses can call it safely.
+        del events
 
     @abstractmethod
     def collect(self) -> list[dict]:
@@ -108,6 +134,12 @@ class BaseProducer(ABC):
                 dedupe_key=ev.dedupe_key,
             )
             published += 1
+
+        try:
+            self._publish_to_mcp(events)
+        except Exception:  # noqa: BLE001
+            self.ctx.logger.warning("mcp_publish_failed", extra={"producer": self.name})
+
         return published
 
     def run(self) -> ProducerResult:

--- a/engine/producers/financial_datasets.py
+++ b/engine/producers/financial_datasets.py
@@ -1,0 +1,169 @@
+"""engine.producers.financial_datasets
+
+FinancialDatasetsMCPProducer — fundamentals signal producer.
+
+Data source: financialdatasets.ai REST API (mirrors their MCP server interface).
+MCP source URL set for when full MCP stdio protocol is implemented in S2+.
+
+Emits TRADFI_SIGNAL events when:
+- Earnings beat/miss vs consensus (PEAD signal)
+- Revenue growth acceleration/deceleration
+- P/E compression vs sector
+
+Scope: S&P 500 equities. Requires FINANCIAL_DATASETS_API_KEY env var.
+Skips gracefully if API key not set or API unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    UTC = UTC  # noqa: N806
+
+from typing import Any
+
+from engine.core.events import EventType
+from engine.core.models import Event
+from engine.mcp.client import HttpMCPClient
+from engine.producers.base import BaseProducer
+from engine.producers.registry import register
+
+
+class FinancialDatasetsMCPProducer(BaseProducer):
+    """MCP-inbound producer for earnings surprise signals."""
+
+    name = "financial_datasets"
+    domain = "tradfi"
+    schedule = "0 */6 * * *"  # every 6h
+    mcp_source_url = "https://github.com/financial-datasets/mcp-server"
+
+    _watchlist = ["NVDA", "MSFT", "AAPL", "META", "GOOGL"]
+    _api_base = "https://api.financialdatasets.ai"
+
+    @staticmethod
+    def _float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _iso_ts() -> datetime:
+        return datetime.now(tz=UTC)
+
+    def _client(self) -> HttpMCPClient | None:
+        api_key = os.getenv("FINANCIAL_DATASETS_API_KEY")
+        if not api_key:
+            return None
+        return HttpMCPClient(base_url=self._api_base, api_key=api_key, timeout=10)
+
+    def collect(self) -> list[dict]:
+        """Collect recent income statement rows for a fixed watchlist.
+
+        Returns [] if API key is missing or on any API/client error.
+        """
+
+        client = self._client()
+        if client is None:
+            return []
+
+        try:
+            out: list[dict] = []
+            for ticker in self._watchlist:
+                result = client.call_tool(
+                    "financials/income-statements/",
+                    {
+                        "ticker": ticker,
+                        "limit": 1,
+                    },
+                )
+
+                if "error" in result.raw:
+                    self.ctx.logger.warning(
+                        "financial_datasets_collect_failed",
+                        extra={"ticker": ticker, "error": result.raw.get("error")},
+                    )
+                    return []
+
+                for row in result.data:
+                    if not isinstance(row, dict):
+                        continue
+                    merged = dict(row)
+                    merged.setdefault("ticker", ticker)
+                    out.append(merged)
+
+            return out
+        except Exception:  # noqa: BLE001
+            self.ctx.logger.warning("financial_datasets_collect_failed", extra={"producer": self.name})
+            return []
+
+    def normalize(self, raw: list[dict]) -> list[Event]:
+        """Normalize earnings rows into TRADFI signal events."""
+
+        events: list[Event] = []
+        now = self._iso_ts()
+
+        for row in raw:
+            if not isinstance(row, dict):
+                continue
+
+            ticker = str(row.get("ticker") or row.get("symbol") or "").upper().strip()
+            if not ticker:
+                continue
+
+            actual_eps = self._float(row.get("actual_eps") or row.get("eps_actual") or row.get("eps") or row.get("eps_diluted") or row.get("eps_reported"))
+            estimated_eps = self._float(row.get("estimated_eps") or row.get("eps_estimate") or row.get("eps_consensus") or row.get("eps_diluted_estimate"))
+
+            if actual_eps is None or estimated_eps is None:
+                continue
+
+            denom = abs(estimated_eps) if abs(estimated_eps) > 1e-9 else max(abs(actual_eps), 1.0)
+            surprise_ratio = (actual_eps - estimated_eps) / denom
+
+            if abs(surprise_ratio) <= 0.02:
+                signal = "neutral"
+                confidence = max(0.0, 1.0 - min(1.0, abs(surprise_ratio) / 0.02))
+            elif actual_eps > estimated_eps:
+                signal = "earnings_beat"
+                confidence = min(1.0, abs(surprise_ratio) / 0.10)
+            else:
+                signal = "earnings_miss"
+                confidence = min(1.0, abs(surprise_ratio) / 0.10)
+
+            reason = f"EPS actual {actual_eps:.4g} vs estimate {estimated_eps:.4g} ({surprise_ratio:+.2%})."
+
+            as_of = str(row.get("report_period") or row.get("period_end") or row.get("fiscal_date") or row.get("date") or now.date().isoformat())
+            dedupe_key = f"{EventType.SIGNAL_TRADFI_V1}:{self.name}:{ticker}:{as_of}"
+
+            payload = {
+                "ticker": ticker,
+                "symbol": ticker,
+                "signal": signal,
+                "confidence": round(confidence, 4),
+                "reason": reason,
+                "producer": self.name,
+            }
+
+            events.append(
+                self.draft_event(
+                    event_type=EventType.SIGNAL_TRADFI_V1,
+                    payload=payload,
+                    ts=now,
+                    observed_at=now,
+                    source=self.name,
+                    dedupe_key=dedupe_key,
+                )
+            )
+
+        return events
+
+
+# Conditional registration: skip silently when API key is not configured.
+if os.getenv("FINANCIAL_DATASETS_API_KEY"):
+    register("financial_datasets", domain="tradfi")(FinancialDatasetsMCPProducer)

--- a/engine/producers/registry.py
+++ b/engine/producers/registry.py
@@ -13,6 +13,7 @@ Discovery is intentionally simple. The contract lives in events; this is just pl
 from __future__ import annotations
 
 import importlib
+import os
 import pkgutil
 from collections.abc import Callable
 from typing import Any
@@ -47,6 +48,8 @@ def discover() -> None:
     for m in pkgutil.iter_modules(pkg.__path__, prefix=f"{pkg_name}."):
         modname = m.name
         if modname.endswith(".base") or modname.endswith(".registry"):
+            continue
+        if modname.endswith(".financial_datasets") and not os.getenv("FINANCIAL_DATASETS_API_KEY"):
             continue
         importlib.import_module(modname)
 

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from engine.core.client import DataClient
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.metrics import MetricsRegistry
+from engine.mcp.client import HttpMCPClient, MCPToolResult
+from engine.producers.base import BaseProducer, ProducerContext
+from engine.producers.financial_datasets import FinancialDatasetsMCPProducer
+
+
+class _DummyProducer(BaseProducer):
+    name = "dummy"
+    domain = "events"
+    schedule = "continuous"
+
+    def collect(self) -> list[dict]:
+        return []
+
+    def normalize(self, raw: list[dict]):
+        return []
+
+
+def _ctx(tmp_path) -> ProducerContext:
+    return ProducerContext(
+        config=Config(),
+        db=Database(tmp_path / "events.db"),
+        client=DataClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+
+def test_mcp_tool_result_creation() -> None:
+    result = MCPToolResult(
+        tool="get_signals",
+        data=[{"ticker": "NVDA"}],
+        source_url="https://example.test",
+        fetched_at="2026-03-01T00:00:00+00:00",
+        raw={"data": [{"ticker": "NVDA"}]},
+    )
+
+    assert result.tool == "get_signals"
+    assert result.data == [{"ticker": "NVDA"}]
+    assert result.source_url == "https://example.test"
+
+
+def test_http_mcp_client_falls_back_to_get_on_405(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            del exc_type, exc, tb
+            return False
+
+        def post(self, url: str, json: dict):
+            del json
+            calls.append(("POST", url))
+            return httpx.Response(405, request=httpx.Request("POST", url))
+
+        def get(self, url: str, params: dict):
+            del params
+            calls.append(("GET", url))
+            return httpx.Response(200, json={"data": [{"ticker": "NVDA"}]}, request=httpx.Request("GET", url))
+
+        def head(self, url: str):
+            return httpx.Response(200, request=httpx.Request("HEAD", url))
+
+    monkeypatch.setattr("engine.mcp.client.httpx.Client", FakeClient)
+
+    client = HttpMCPClient(base_url="https://example.test", api_key="k")
+    result = client.call_tool("financials/income-statements/", {"ticker": "NVDA"})
+
+    assert result.data == [{"ticker": "NVDA"}]
+    assert calls[0] == ("POST", "https://example.test/tools/financials/income-statements")
+    assert calls[1] == ("GET", "https://example.test/financials/income-statements")
+
+
+def test_collect_via_mcp_returns_empty_without_client(tmp_path) -> None:
+    producer = _DummyProducer(_ctx(tmp_path))
+    producer._mcp_client = None
+
+    assert producer._collect_via_mcp() == []
+
+
+def test_collect_via_mcp_returns_empty_on_client_failure(tmp_path) -> None:
+    class FailingClient:
+        def call_tool(self, tool: str, arguments: dict):
+            del tool, arguments
+            raise RuntimeError("boom")
+
+    producer = _DummyProducer(_ctx(tmp_path))
+    producer._mcp_client = FailingClient()
+
+    assert producer._collect_via_mcp() == []
+
+
+def test_publish_to_mcp_stub_never_raises(tmp_path) -> None:
+    producer = _DummyProducer(_ctx(tmp_path))
+
+    producer._publish_to_mcp([])
+
+
+def test_financial_datasets_collect_returns_empty_without_api_key(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FINANCIAL_DATASETS_API_KEY", raising=False)
+    producer = FinancialDatasetsMCPProducer(_ctx(tmp_path))
+
+    assert producer.collect() == []
+
+
+def test_financial_datasets_normalize_earnings_row(tmp_path) -> None:
+    producer = FinancialDatasetsMCPProducer(_ctx(tmp_path))
+
+    events = producer.normalize(
+        [
+            {
+                "ticker": "NVDA",
+                "actual_eps": 2.20,
+                "estimated_eps": 2.00,
+                "report_period": "2025-12-31",
+            }
+        ]
+    )
+
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.type == EventType.SIGNAL_TRADFI_V1
+    assert ev.payload["ticker"] == "NVDA"
+    assert ev.payload["signal"] == "earnings_beat"
+    assert ev.payload["producer"] == "financial_datasets"
+    assert 0.0 <= ev.payload["confidence"] <= 1.0


### PR DESCRIPTION
S1 of MCP sprint.

- `engine/mcp/client.py` — `MCPClient` abstract base + `HttpMCPClient` REST adapter
- `engine/producers/base.py` — `mcp_source_url`, `_collect_via_mcp()`, `_publish_to_mcp()` (stub)
- `engine/producers/financial_datasets.py` — first MCP-inbound producer (financialdatasets.ai)
- `tests/unit/test_mcp_client.py` — 6+ unit tests

Part of #150.