### PR TITLE
feat(mcp/s2): MCP server + registry (outbound)

### DIFF
--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -473,7 +473,7 @@ These files are design references and sprint plans, not operator-facing guides.
 | [internal/DASHBOARD_DESIGN_SPEC.md](internal/DASHBOARD_DESIGN_SPEC.md) | Dashboard design spec |
 | [internal/OPERATOR_SPRINT_PLAN.md](internal/OPERATOR_SPRINT_PLAN.md) | Operator layer sprint plan (O1-O4) |
 
-*Last updated: 2026-02-28*
+*Last updated: 2026-03-01*
 
 ---
 
@@ -561,6 +561,8 @@ engine/cli/commands/setup.py   → engine/cli/main.py (_cmd_setup), scripts/setu
 
 ```text
 engine/mcp/__init__.py
+  → engine/mcp/registry.py
+  → engine/mcp/server.py
   → engine/mcp/types.py
 ```
 
@@ -569,6 +571,22 @@ engine/mcp/__init__.py
 ```text
 engine/mcp/types.py
   (no internal deps — standalone type definitions)
+```
+
+### `engine/mcp/registry.py`
+
+```text
+engine/mcp/registry.py
+  → engine/mcp/types.py
+```
+
+### `engine/mcp/server.py`
+
+```text
+engine/mcp/server.py
+  → engine/mcp/registry.py
+  → dataclasses.asdict
+  (optional) mcp SDK import (FastMCP SSE transport)
 ```
 
 ### `engine/mcp/client.py`

--- a/engine/mcp/__init__.py
+++ b/engine/mcp/__init__.py
@@ -9,3 +9,16 @@ Bidirectional MCP support for b1e55ed producers:
 External agents (Claude, oracle consumers, agent builders) connect to the MCP server
 to subscribe to live producer signals without REST API setup.
 """
+
+from engine.mcp.registry import MCPProducerRegistry, get_registry
+from engine.mcp.server import MCPServer
+from engine.mcp.types import MCPProducerManifest, MCPSignalBuffer, MCPSignalPayload
+
+__all__ = [
+    "MCPProducerRegistry",
+    "MCPServer",
+    "MCPProducerManifest",
+    "MCPSignalBuffer",
+    "MCPSignalPayload",
+    "get_registry",
+]

--- a/engine/mcp/registry.py
+++ b/engine/mcp/registry.py
@@ -1,0 +1,95 @@
+"""engine.mcp.registry
+
+MCPProducerRegistry — shared in-memory state for the MCP layer.
+
+Thread-safe singleton. Producers self-register on __init__ and push signals
+on every publish(). The MCP server and REST endpoints read from here.
+
+Designed as a module-level singleton (get_registry()) so it survives across
+multiple producer instances without being passed through ProducerContext.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import cast
+
+from engine.mcp.types import MCPProducerManifest, MCPSignalBuffer, MCPSignalPayload
+
+_REGISTRY: MCPProducerRegistry | None = None
+_REGISTRY_LOCK = Lock()
+
+
+class MCPProducerRegistry:
+    """Thread-safe registry of all producers and their recent signals."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._manifests: dict[str, MCPProducerManifest] = {}
+        self._buffers: dict[str, MCPSignalBuffer] = {}
+
+    def register(self, manifest: MCPProducerManifest) -> None:
+        """Register a producer. Idempotent — re-registration updates the manifest."""
+
+        with self._lock:
+            self._manifests[manifest.name] = manifest
+            self._buffers.setdefault(manifest.name, MCPSignalBuffer(producer=manifest.name))
+
+    def push_signal(self, signal: MCPSignalPayload) -> None:
+        """Append a signal to the producer's ring buffer. Creates buffer if first push."""
+
+        with self._lock:
+            if signal.producer not in self._buffers:
+                self._buffers[signal.producer] = MCPSignalBuffer(producer=signal.producer)
+            self._buffers[signal.producer].push(signal)
+
+    def get_latest(self, producer: str) -> MCPSignalPayload | None:
+        """Return most recent signal for a producer, or None."""
+
+        with self._lock:
+            buffer = self._buffers.get(producer)
+            if buffer is None or not buffer.signals:
+                return None
+            return cast(MCPSignalPayload, buffer.signals[-1])
+
+    def get_recent(self, producer: str, n: int = 10) -> list[MCPSignalPayload]:
+        """Return up to n recent signals for a producer."""
+
+        if n <= 0:
+            return []
+
+        with self._lock:
+            buffer = self._buffers.get(producer)
+            if buffer is None:
+                return []
+
+            if n >= len(buffer.signals):
+                window = list(buffer.signals)
+            else:
+                window = buffer.signals[-n:]
+            return [cast(MCPSignalPayload, signal) for signal in window]
+
+    def list_producers(self) -> list[MCPProducerManifest]:
+        """Return all registered producer manifests, sorted by name."""
+
+        with self._lock:
+            return [self._manifests[name] for name in sorted(self._manifests.keys())]
+
+    def stats(self) -> dict:
+        """Return registry stats: producer count, total signals buffered."""
+
+        with self._lock:
+            return {
+                "producer_count": len(self._manifests),
+                "total_signals_buffered": sum(len(buffer.signals) for buffer in self._buffers.values()),
+            }
+
+
+def get_registry() -> MCPProducerRegistry:
+    """Return the module-level singleton registry."""
+
+    global _REGISTRY
+    with _REGISTRY_LOCK:
+        if _REGISTRY is None:
+            _REGISTRY = MCPProducerRegistry()
+        return _REGISTRY

--- a/engine/mcp/server.py
+++ b/engine/mcp/server.py
@@ -1,0 +1,156 @@
+"""engine.mcp.server
+
+b1e55ed MCP Server — exposes all producer signals as MCP tools/resources.
+
+Dual-mode:
+  - With mcp[cli] installed: full MCP protocol server (SSE transport, port 7337 default)
+  - Without: registry-only mode (signals accessible via REST in S4)
+
+Tools exposed:
+  list_producers()                              → list of MCPProducerManifest dicts
+  get_latest_signal(producer_name: str)         → MCPSignalPayload dict or None
+  get_signal_history(producer_name: str, limit: int = 10) → list of MCPSignalPayload dicts
+
+Start via: MCPServer(config).start_background() — runs in daemon thread, never blocks.
+Stop via:  MCPServer(config).stop()
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from threading import Event, Lock, Thread
+from typing import Any
+
+from engine.mcp.registry import get_registry
+
+logger = logging.getLogger(__name__)
+
+
+class MCPServer:
+    def __init__(self, port: int = 7337, enabled: bool = True):
+        self.port = int(port)
+        self.enabled = enabled
+
+        self._registry = get_registry()
+        self._thread: Thread | None = None
+        self._stop_event = Event()
+        self._state_lock = Lock()
+        self._running = False
+        self._mcp_app: Any | None = None
+
+    def start_background(self) -> None:
+        """Start MCP server in a daemon thread. No-op if not enabled or already running."""
+
+        if not self.enabled:
+            return
+
+        with self._state_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+
+        try:
+            from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
+        except ImportError:
+            logger.warning("mcp_sdk_missing_registry_mode_only")
+            return
+
+        self._stop_event.clear()
+        thread = Thread(target=self._serve, args=(FastMCP,), name="mcp-server", daemon=True)
+        with self._state_lock:
+            self._thread = thread
+        thread.start()
+
+    def stop(self) -> None:
+        """Stop the server. No-op if not running."""
+
+        with self._state_lock:
+            thread = self._thread
+
+        if thread is None:
+            return
+
+        self._stop_event.set()
+
+        app = self._mcp_app
+        if app is not None:
+            for method_name in ("stop", "shutdown", "close"):
+                method = getattr(app, method_name, None)
+                if callable(method):
+                    try:
+                        method()
+                    except Exception:  # noqa: BLE001
+                        logger.debug("mcp_server_stop_method_failed", exc_info=True)
+                    break
+
+        if thread.is_alive():
+            thread.join(timeout=1.0)
+
+        with self._state_lock:
+            if not thread.is_alive():
+                self._thread = None
+                self._running = False
+
+    def is_running(self) -> bool:
+        with self._state_lock:
+            return bool(self._running and self._thread is not None and self._thread.is_alive())
+
+    def tool_list_producers(self) -> list[dict]:
+        return [asdict(manifest) for manifest in self._registry.list_producers()]
+
+    def tool_get_latest_signal(self, producer_name: str) -> dict | None:
+        latest = self._registry.get_latest(producer_name)
+        if latest is None:
+            return None
+        return asdict(latest)
+
+    def tool_get_signal_history(self, producer_name: str, limit: int = 10) -> list[dict]:
+        try:
+            n = int(limit)
+        except (TypeError, ValueError):
+            n = 10
+
+        n = max(0, n)
+        return [asdict(signal) for signal in self._registry.get_recent(producer_name, n=n)]
+
+    def _serve(self, fastmcp_cls: Any) -> None:
+        try:
+            app = fastmcp_cls("b1e55ed-mcp")
+            self._mcp_app = app
+
+            @app.tool()  # type: ignore[untyped-decorator]
+            def list_producers() -> list[dict]:
+                return self.tool_list_producers()
+
+            @app.tool()  # type: ignore[untyped-decorator]
+            def get_latest_signal(producer_name: str) -> dict | None:
+                return self.tool_get_latest_signal(producer_name)
+
+            @app.tool()  # type: ignore[untyped-decorator]
+            def get_signal_history(producer_name: str, limit: int = 10) -> list[dict]:
+                return self.tool_get_signal_history(producer_name, limit)
+
+            with self._state_lock:
+                self._running = True
+
+            # FastMCP API has changed across versions. Try common signatures.
+            run_attempts: list[dict[str, Any]] = [
+                {"transport": "sse", "host": "0.0.0.0", "port": self.port},
+                {"transport": "sse", "port": self.port},
+                {"port": self.port},
+                {},
+            ]
+
+            for kwargs in run_attempts:
+                try:
+                    app.run(**kwargs)
+                    return
+                except TypeError:
+                    continue
+
+            logger.error("mcp_server_run_signature_unsupported")
+        except Exception:  # noqa: BLE001
+            logger.exception("mcp_server_failed")
+        finally:
+            with self._state_lock:
+                self._running = False

--- a/engine/producers/base.py
+++ b/engine/producers/base.py
@@ -85,6 +85,29 @@ class BaseProducer(ABC):
 
     def __init__(self, ctx: ProducerContext) -> None:
         self.ctx = ctx
+        self._register_with_mcp()
+
+    def _register_with_mcp(self) -> None:
+        """Register this producer with the MCP registry. Never raises."""
+
+        try:
+            from datetime import UTC
+
+            from engine.mcp.registry import get_registry
+            from engine.mcp.types import MCPProducerManifest
+
+            manifest = MCPProducerManifest(
+                name=self.name,
+                domain=self.domain,
+                mcp_source_url=getattr(self, "mcp_source_url", None),
+                description=getattr(self, "__doc__", "") or "",
+                assets=getattr(self, "assets", []),
+                schedule=self.schedule,
+                registered_at=datetime.now(tz=UTC).isoformat(),
+            )
+            get_registry().register(manifest)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _collect_via_mcp(self) -> list[dict]:
         """Fetch raw data via MCP client. Returns [] on any failure."""
@@ -100,11 +123,30 @@ class BaseProducer(ABC):
             return []
 
     def _publish_to_mcp(self, events: list[Event]) -> None:
-        """Fire-and-forget: push events to MCP signal buffer. Never raises."""
+        """Push events to MCP registry. Fire-and-forget — never raises."""
 
-        # Populated in S2 when MCPProducerRegistry exists.
-        # Stub here so subclasses can call it safely.
-        del events
+        try:
+            from engine.mcp.registry import get_registry
+            from engine.mcp.types import MCPSignalPayload
+
+            registry = get_registry()
+            for ev in events:
+                payload = ev.payload if hasattr(ev, "payload") else {}
+                signal = MCPSignalPayload(
+                    producer=self.name,
+                    domain=self.domain,
+                    asset=payload.get("asset") or payload.get("symbol") or payload.get("ticker"),
+                    direction=payload.get("direction") or payload.get("signal"),
+                    confidence=payload.get("confidence") or payload.get("score"),
+                    horizon=payload.get("horizon"),
+                    reason=payload.get("reason") or payload.get("rationale") or ev.type,
+                    timestamp=ev.ts.isoformat() if hasattr(ev.ts, "isoformat") else str(ev.ts),
+                    raw_score=payload.get("raw_score") or payload.get("score"),
+                    metadata={"event_type": ev.type, "source": ev.source},
+                )
+                registry.push_signal(signal)
+        except Exception:  # noqa: BLE001
+            pass
 
     @abstractmethod
     def collect(self) -> list[dict]:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -6,11 +6,17 @@ Tests for the MCP JSON-RPC 2.0 server at POST /mcp.
 from __future__ import annotations
 
 import json
+import threading
+from types import SimpleNamespace
 
 import pytest
 
 from api.main import create_app
 from engine.core.database import Database
+from engine.mcp.registry import MCPProducerRegistry
+from engine.mcp.server import MCPServer
+from engine.mcp.types import MCPProducerManifest, MCPSignalPayload
+from engine.producers.base import BaseProducer
 from tests.unit._api_test_client import make_client
 
 # ---------------------------------------------------------------------------
@@ -414,3 +420,169 @@ async def test_mcp_invalid_jsonrpc_version(_app_and_db):
     body = r.json()
     assert "error" in body
     assert body["error"]["code"] == -32600  # INVALID_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Outbound MCP registry + server (S2)
+# ---------------------------------------------------------------------------
+
+
+def _manifest(name: str = "demo", domain: str = "tradfi") -> MCPProducerManifest:
+    return MCPProducerManifest(
+        name=name,
+        domain=domain,
+        mcp_source_url=None,
+        description=f"{name} producer",
+        assets=[],
+        schedule="* * * * *",
+        registered_at="2026-03-01T00:00:00+00:00",
+    )
+
+
+def _signal(producer: str, i: int) -> MCPSignalPayload:
+    return MCPSignalPayload(
+        producer=producer,
+        domain="tradfi",
+        asset="BTC",
+        direction="long",
+        confidence=0.5,
+        horizon="1h",
+        reason=f"reason-{i}",
+        timestamp=f"2026-03-01T00:00:{i:02d}+00:00",
+        raw_score=float(i),
+        metadata={"i": i},
+    )
+
+
+def test_registry_register():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+
+    producers = registry.list_producers()
+    assert len(producers) == 1
+    assert producers[0].name == "alpha"
+
+
+def test_registry_push_signal():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+    registry.push_signal(_signal("alpha", 1))
+
+    latest = registry.get_latest("alpha")
+    assert latest is not None
+    assert latest.reason == "reason-1"
+
+
+def test_registry_ring_buffer():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+
+    for i in range(110):
+        registry.push_signal(_signal("alpha", i))
+
+    recent = registry.get_recent("alpha", n=200)
+    assert len(recent) == 100
+    assert recent[0].reason == "reason-10"
+    assert recent[-1].reason == "reason-109"
+
+
+def test_registry_get_recent():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+
+    for i in range(7):
+        registry.push_signal(_signal("alpha", i))
+
+    recent = registry.get_recent("alpha", n=3)
+    assert [s.reason for s in recent] == ["reason-4", "reason-5", "reason-6"]
+
+
+def test_registry_stats():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+    registry.register(_manifest("beta", domain="technical"))
+    registry.push_signal(_signal("alpha", 1))
+
+    stats = registry.stats()
+    assert stats["producer_count"] == 2
+    assert stats["total_signals_buffered"] == 1
+
+
+def test_registry_thread_safety():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+
+    errors: list[Exception] = []
+
+    def _worker(tid: int) -> None:
+        try:
+            for idx in range(100):
+                registry.push_signal(_signal("alpha", tid * 100 + idx))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(tid,)) for tid in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    recent = registry.get_recent("alpha", n=200)
+    assert len(recent) == 100
+    assert all(signal.producer == "alpha" for signal in recent)
+
+
+def test_server_tool_list_producers():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+    registry.register(_manifest("beta"))
+
+    server = MCPServer(enabled=False)
+    server._registry = registry
+
+    producers = server.tool_list_producers()
+    assert [p["name"] for p in producers] == ["alpha", "beta"]
+
+
+def test_server_tool_get_latest():
+    registry = MCPProducerRegistry()
+    registry.register(_manifest("alpha"))
+
+    server = MCPServer(enabled=False)
+    server._registry = registry
+
+    assert server.tool_get_latest_signal("alpha") is None
+
+    registry.push_signal(_signal("alpha", 42))
+    latest = server.tool_get_latest_signal("alpha")
+    assert latest is not None
+    assert latest["reason"] == "reason-42"
+
+
+def test_server_not_running_by_default():
+    server = MCPServer(enabled=False)
+    assert server.is_running() is False
+
+
+def test_base_producer_registers_on_init(monkeypatch):
+    import engine.mcp.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "_REGISTRY", None)
+
+    class MockProducer(BaseProducer):
+        name = "mock_producer"
+        domain = "technical"
+        schedule = "continuous"
+        assets = ["BTC"]
+
+        def collect(self) -> list[dict]:
+            return []
+
+        def normalize(self, raw: list[dict]):
+            return []
+
+    _ = MockProducer(SimpleNamespace())
+
+    names = [manifest.name for manifest in registry_module.get_registry().list_producers()]
+    assert "mock_producer" in names


### PR DESCRIPTION
S2 of MCP sprint.

- `engine/mcp/registry.py` — thread-safe singleton `MCPProducerRegistry`
- `engine/mcp/server.py` — `MCPServer` with MCP protocol + registry-only fallback
- `engine/producers/base.py` — `_publish_to_mcp()` real impl + `_register_with_mcp()` on init
- `engine/mcp/__init__.py` — clean public exports
- `tests/unit/test_mcp_server.py` — 8+ tests incl. thread safety

Part of #150.