### PR TITLE
feat(mcp/s3): wire all producers — mcp_source_url + integration tests

### DIFF
--- a/engine/producers/aci.py
+++ b/engine/producers/aci.py
@@ -86,6 +86,7 @@ def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
 @register("ai-consensus", domain="curator")
 class ACIProducer(BaseProducer):
     schedule = "*/30 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_ACI_URL") or os.getenv("ACI_URL")

--- a/engine/producers/curator.py
+++ b/engine/producers/curator.py
@@ -48,6 +48,7 @@ def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
 @register("curator-intel", domain="curator")
 class CuratorIntelProducer(BaseProducer):
     schedule = "*/10 * * * *"  # 10m
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_CURATOR_URL") or os.getenv("CURATOR_URL")

--- a/engine/producers/etf.py
+++ b/engine/producers/etf.py
@@ -46,6 +46,7 @@ class ETFFlowsProducer(BaseProducer):
     """Produce ETF flow signals for the configured universe."""
 
     schedule = "0 */1 * * *"  # hourly
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_ETF_FLOWS_URL") or os.getenv("ETF_FLOWS_URL")

--- a/engine/producers/events.py
+++ b/engine/producers/events.py
@@ -45,6 +45,7 @@ def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
 @register("market-events", domain="events")
 class MarketEventsProducer(BaseProducer):
     schedule = "*/30 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_EVENTS_URL") or os.getenv("EVENTS_URL")

--- a/engine/producers/onchain.py
+++ b/engine/producers/onchain.py
@@ -44,6 +44,7 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
 @register("onchain-flows", domain="onchain")
 class OnchainFlowsProducer(BaseProducer):
     schedule = "*/30 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_ONCHAIN_FLOWS_URL") or os.getenv("ONCHAIN_FLOWS_URL")

--- a/engine/producers/orderbook.py
+++ b/engine/producers/orderbook.py
@@ -42,6 +42,7 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
 @register("orderbook-depth", domain="technical")
 class OrderbookDepthProducer(BaseProducer):
     schedule = "*/5 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_ORDERBOOK_URL") or os.getenv("ORDERBOOK_URL")

--- a/engine/producers/price_ws.py
+++ b/engine/producers/price_ws.py
@@ -45,6 +45,7 @@ class PriceAlertsProducer(BaseProducer):
     """Polling producer that mimics a websocket price feed."""
 
     schedule = "*/1 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_PRICE_WS_URL") or os.getenv("PRICE_WS_URL")

--- a/engine/producers/sentiment.py
+++ b/engine/producers/sentiment.py
@@ -47,6 +47,7 @@ class MarketSentimentProducer(BaseProducer):
     """Produce market sentiment signals for the configured universe."""
 
     schedule = "0 */1 * * *"  # hourly
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_SENTIMENT_URL") or os.getenv("SENTIMENT_URL")

--- a/engine/producers/social.py
+++ b/engine/producers/social.py
@@ -41,6 +41,7 @@ def _dedupe_key(*, producer: str, payload: dict[str, Any]) -> str:
 @register("social-intel", domain="social")
 class SocialIntelProducer(BaseProducer):
     schedule = "*/15 * * * *"  # 15m
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def collect(self) -> list[dict[str, Any]]:
         rows = pipeline.run(ctx=self.ctx)

--- a/engine/producers/stablecoin.py
+++ b/engine/producers/stablecoin.py
@@ -38,6 +38,7 @@ def _dedupe_key(*, producer: str, stablecoin: str, ts: datetime) -> str:
 @register("stablecoin-supply", domain="onchain")
 class StablecoinSupplyProducer(BaseProducer):
     schedule = "0 */2 * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_STABLECOIN_SUPPLY_URL") or os.getenv("STABLECOIN_SUPPLY_URL")

--- a/engine/producers/ta.py
+++ b/engine/producers/ta.py
@@ -44,6 +44,7 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
 @register("technical-analysis", domain="technical")
 class TechnicalAnalysisProducer(BaseProducer):
     schedule = "*/15 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_TA_URL") or os.getenv("TA_URL")

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -47,6 +47,7 @@ class TradFiBasisProducer(BaseProducer):
     """Produce basis/carry signals for the configured universe."""
 
     schedule = "*/30 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_TRADFI_BASIS_URL") or os.getenv("TRADFI_BASIS_URL")

--- a/engine/producers/whale.py
+++ b/engine/producers/whale.py
@@ -39,6 +39,7 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
 @register("whale-tracking", domain="onchain")
 class WhaleTrackingProducer(BaseProducer):
     schedule = "*/30 * * * *"
+    mcp_source_url: str | None = None  # override with MCP server URL when available
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_WHALE_TRACKING_URL") or os.getenv("WHALE_TRACKING_URL")

--- a/tests/integration/test_mcp_wire.py
+++ b/tests/integration/test_mcp_wire.py
@@ -1,0 +1,163 @@
+"""Integration tests: all producers register with MCPProducerRegistry on init."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import engine.mcp.registry as registry_module
+from engine.core.events import EventType
+from engine.mcp.registry import MCPProducerRegistry, get_registry
+from engine.producers.aci import ACIProducer
+from engine.producers.base import BaseProducer
+from engine.producers.curator import CuratorIntelProducer
+from engine.producers.etf import ETFFlowsProducer
+from engine.producers.events import MarketEventsProducer
+from engine.producers.financial_datasets import FinancialDatasetsMCPProducer
+from engine.producers.onchain import OnchainFlowsProducer as OnchainProducer
+from engine.producers.orderbook import OrderbookDepthProducer
+from engine.producers.price_ws import PriceAlertsProducer
+from engine.producers.sentiment import MarketSentimentProducer as SentimentProducer
+from engine.producers.social import SocialIntelProducer
+from engine.producers.stablecoin import StablecoinSupplyProducer
+from engine.producers.ta import TechnicalAnalysisProducer as TaProducer
+from engine.producers.tradfi import TradFiBasisProducer
+from engine.producers.whale import WhaleTrackingProducer
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry(monkeypatch):
+    """Reset MCP singleton state for each test."""
+
+    registry = MCPProducerRegistry()
+    monkeypatch.setattr(registry_module, "_REGISTRY", registry)
+    yield registry
+
+
+@pytest.fixture()
+def mock_producer_context():
+    """Mock ProducerContext with all expected fields."""
+
+    ctx = SimpleNamespace(
+        config=MagicMock(name="config"),
+        db=MagicMock(name="db"),
+        client=MagicMock(name="client"),
+        metrics=MagicMock(name="metrics"),
+        logger=MagicMock(name="logger"),
+    )
+    ctx.config.universe = SimpleNamespace(symbols=["BTC", "ETH"])
+    return ctx
+
+
+def test_producers_register_with_mcp(mock_producer_context):
+    _ = TaProducer(mock_producer_context)
+    _ = OnchainProducer(mock_producer_context)
+    _ = SentimentProducer(mock_producer_context)
+
+    registry = get_registry()
+    registered_names = {manifest.name for manifest in registry.list_producers()}
+
+    assert TaProducer.name in registered_names
+    assert OnchainProducer.name in registered_names
+    assert SentimentProducer.name in registered_names
+    assert registry.stats()["producer_count"] >= 3
+
+
+def test_publish_pushes_to_mcp(mock_producer_context):
+    class MockProducer(BaseProducer):
+        name = "mock-producer"
+        domain = "technical"
+        schedule = "continuous"
+
+        def collect(self) -> list[dict]:
+            return []
+
+        def normalize(self, raw: list[dict]):
+            return []
+
+    producer = MockProducer(mock_producer_context)
+    event = producer.draft_event(
+        event_type=EventType.SIGNAL_TA_V1,
+        payload={
+            "symbol": "BTC",
+            "direction": "long",
+            "confidence": 0.91,
+            "reason": "test signal",
+        },
+    )
+
+    producer.publish([event])
+
+    latest = get_registry().get_latest(producer.name)
+    assert latest is not None
+    assert latest.producer == producer.name
+
+
+def test_all_producers_have_mcp_source_url_attr():
+    producer_classes = [
+        ACIProducer,
+        CuratorIntelProducer,
+        ETFFlowsProducer,
+        MarketEventsProducer,
+        OnchainProducer,
+        OrderbookDepthProducer,
+        PriceAlertsProducer,
+        SentimentProducer,
+        SocialIntelProducer,
+        StablecoinSupplyProducer,
+        TaProducer,
+        TradFiBasisProducer,
+        WhaleTrackingProducer,
+    ]
+
+    for producer_class in producer_classes:
+        assert hasattr(producer_class, "mcp_source_url"), f"{producer_class.__name__} missing mcp_source_url"
+
+
+def test_mcp_source_url_financial_datasets():
+    assert FinancialDatasetsMCPProducer.mcp_source_url is not None
+
+
+def test_registry_survives_multiple_inits(mock_producer_context):
+    _ = TaProducer(mock_producer_context)
+    _ = TaProducer(mock_producer_context)
+
+    manifests = get_registry().list_producers()
+    names = [manifest.name for manifest in manifests]
+
+    assert names.count(TaProducer.name) == 1
+    assert get_registry().stats()["producer_count"] == 1
+
+
+def test_signal_buffer_fills_on_publish(mock_producer_context):
+    class MockProducer(BaseProducer):
+        name = "mock-buffer-producer"
+        domain = "technical"
+        schedule = "continuous"
+
+        def collect(self) -> list[dict]:
+            return []
+
+        def normalize(self, raw: list[dict]):
+            return []
+
+    producer = MockProducer(mock_producer_context)
+    events = [
+        producer.draft_event(
+            event_type=EventType.SIGNAL_TA_V1,
+            payload={
+                "symbol": "BTC",
+                "direction": "long",
+                "confidence": 0.5,
+                "reason": f"signal-{i}",
+            },
+        )
+        for i in range(5)
+    ]
+
+    producer.publish(events)
+
+    recent = get_registry().get_recent(producer.name, n=10)
+    assert len(recent) == 5


### PR DESCRIPTION
S3 of MCP sprint.

- All producer classes annotated with `mcp_source_url: str | None = None`
- `tests/integration/test_mcp_wire.py` — 6+ integration tests proving full flow
- `financial_datasets.py` left as-is (already has MCP source URL set)

Part of #150.