### PR TITLE
feat(mcp/s4): auth + external access — /api/v1/mcp/* endpoints

### DIFF
--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -10,6 +10,7 @@ from api.routes import (
     health,
     karma,
     kill_switch,
+    mcp,
     metrics,
     oracle,
     positions,
@@ -41,5 +42,6 @@ def get_api_router() -> APIRouter:
 
     # Oracle: public-facing provenance endpoint (no auth dependency)
     router.include_router(oracle.router, prefix="/oracle", tags=["oracle"])
+    router.include_router(mcp.router, tags=["mcp"])
 
     return router

--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -23,10 +23,21 @@ _SENSITIVE_RE = re.compile(
 # Phil Zimmermann distributed PGP for free in 1991 because he believed
 # people should be able to keep secrets without asking permission.
 # This function exists for the same reason.
+def _redact_sensitive_value(value: Any) -> Any:
+    """Redact sensitive values while preserving list/dict container shapes."""
+
+    if isinstance(value, dict):
+        return {k: _redact_sensitive_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return ["***REDACTED***" for _ in value]
+    return "***REDACTED***"
+
+
 def _redact(obj: Any) -> Any:
     """Recursively walk a config dict and redact sensitive fields."""
+
     if isinstance(obj, dict):
-        return {k: ("***REDACTED***" if _SENSITIVE_RE.search(k) else _redact(v)) for k, v in obj.items()}
+        return {k: (_redact_sensitive_value(v) if _SENSITIVE_RE.search(k) else _redact(v)) for k, v in obj.items()}
     if isinstance(obj, list):
         return [_redact(item) for item in obj]
     return obj

--- a/api/routes/mcp.py
+++ b/api/routes/mcp.py
@@ -1,10 +1,15 @@
 """api.routes.mcp
 
-Minimal JSON-RPC 2.0 MCP (Model Context Protocol) server.
+MCP signal registry + JSON-RPC endpoints.
 
-Allows Claude, GPT, and other MCP-aware agents to use b1e55ed as native tools.
+Exposes the MCPProducerRegistry over HTTP so external agents and dashboards
+can discover live producer signals without a direct MCP protocol connection.
 
-Spec: https://spec.modelcontextprotocol.io/specification/2024-11-05/
+GET /api/v1/mcp/producers  — list all registered producers + latest signal
+GET /api/v1/mcp/status     — registry health and stats
+
+Also serves the JSON-RPC MCP endpoint used by MCP-aware clients:
+POST /mcp
 """
 
 from __future__ import annotations
@@ -12,6 +17,7 @@ from __future__ import annotations
 import hmac
 import json
 import logging
+from dataclasses import asdict
 from datetime import datetime
 
 try:
@@ -21,12 +27,14 @@ except ImportError:  # pragma: no cover
 
 from typing import Any
 
-from fastapi import APIRouter, Header, Request
+from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 
 from api.deps import get_config, get_db
 from engine.core.config import Config
 from engine.core.database import Database
+from engine.mcp.auth import get_mcp_auth_dependency
+from engine.mcp.registry import get_registry as get_mcp_registry
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +93,52 @@ def _check_auth(request: Request, x_api_key: str | None) -> bool:
             return True
 
     return False
+
+
+def _require_mcp_registry_auth(
+    request: Request,
+    x_mcp_key: str | None = Header(default=None, alias="X-MCP-Key"),
+) -> None:
+    """Optional API-key gate for /api/v1/mcp/* registry endpoints."""
+
+    config: Config = get_config(request)
+    auth_dependency = get_mcp_auth_dependency(config)
+    auth_dependency(x_mcp_key)
+
+
+@router.get("/mcp/producers", dependencies=[Depends(_require_mcp_registry_auth)])
+def list_mcp_producers() -> dict:
+    """List all producers with their manifest and latest signal (if available)."""
+
+    registry = get_mcp_registry()
+    producers: list[dict[str, Any]] = []
+
+    for manifest in registry.list_producers():
+        latest_signal = registry.get_latest(manifest.name)
+        manifest_payload = asdict(manifest)
+        manifest_payload["latest_signal"] = asdict(latest_signal) if latest_signal is not None else None
+        producers.append(manifest_payload)
+
+    return {
+        "producers": producers,
+        "count": len(producers),
+    }
+
+
+@router.get("/mcp/status", dependencies=[Depends(_require_mcp_registry_auth)])
+def mcp_status(request: Request) -> dict:
+    """Return MCP registry availability and buffer stats."""
+
+    registry = get_mcp_registry()
+    stats = registry.stats()
+    config: Config = get_config(request)
+
+    return {
+        "enabled": bool(config.mcp.enabled),
+        "producer_count": int(stats.get("producer_count", 0)),
+        "total_signals_buffered": int(stats.get("total_signals_buffered", 0)),
+        "registry_ok": True,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -589,12 +589,30 @@ engine/mcp/server.py
   (optional) mcp SDK import (FastMCP SSE transport)
 ```
 
+### `engine/mcp/auth.py`
+
+```text
+engine/mcp/auth.py
+  → hmac.compare_digest
+  → fastapi (Header, HTTPException)
+```
+
 ### `engine/mcp/client.py`
 
 ```text
 engine/mcp/client.py
   (optional) mcp SDK import
   → httpx (HTTP transport)
+```
+
+### `api/routes/mcp.py`
+
+```text
+api/routes/mcp.py
+  → api/deps.py (get_config, get_db)
+  → engine/mcp/auth.py
+  → engine/mcp/registry.py
+  → engine/core/database.py
 ```
 
 ### `engine/producers/financial_datasets.py`

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -116,6 +116,13 @@ class DashboardConfig(BaseModel):
     auth_token: str = ""
 
 
+class MCPConfig(BaseModel):
+    enabled: bool = True
+    port: int = 7337
+    require_auth: bool = False  # set True in production if port is public
+    api_keys: list[str] = Field(default_factory=list)
+
+
 class EASConfig(BaseModel):
     enabled: bool = True  # off-chain attestations work without rpc_url; on-chain needs rpc_url
     rpc_url: str = "https://eth.llamarpc.com"  # Free public RPC
@@ -163,6 +170,7 @@ class Config(BaseSettings):
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     api: ApiConfig = Field(default_factory=ApiConfig)
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
+    mcp: MCPConfig = Field(default_factory=MCPConfig)
     eas: EASConfig = Field(default_factory=EASConfig)
     publish: PublishConfig = Field(default_factory=PublishConfig)
     github_publish: PublishGithubConfig = Field(default_factory=PublishGithubConfig)

--- a/engine/mcp/auth.py
+++ b/engine/mcp/auth.py
@@ -1,0 +1,42 @@
+"""engine.mcp.auth
+
+Optional API key authentication for MCP endpoints.
+
+When `config.mcp.require_auth = True`, all /api/v1/mcp/* endpoints require
+an `X-MCP-Key` header matching one of the configured API keys.
+
+When `require_auth = False` (default), endpoints are open — suitable for
+local/operator deployments where the port is not publicly exposed.
+"""
+
+from __future__ import annotations
+
+import hmac
+from collections.abc import Callable
+
+from fastapi import Header, HTTPException, status
+
+
+def validate_mcp_key(key: str, allowed_keys: list[str]) -> bool:
+    """Constant-time comparison against allowed keys. Returns True if valid."""
+
+    return any(hmac.compare_digest(key, k) for k in allowed_keys)
+
+
+def get_mcp_auth_dependency(config) -> Callable[[str | None], None]:
+    """Return a FastAPI dependency for optional MCP API-key authentication."""
+
+    if not getattr(config.mcp, "require_auth", False):
+
+        def _allow_all(_x_mcp_key: str | None = Header(default=None, alias="X-MCP-Key")) -> None:
+            return None
+
+        return _allow_all
+
+    allowed_keys = list(getattr(config.mcp, "api_keys", []) or [])
+
+    def _require_valid_key(x_mcp_key: str | None = Header(default=None, alias="X-MCP-Key")) -> None:
+        if not x_mcp_key or not validate_mcp_key(x_mcp_key, allowed_keys):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid MCP API key")
+
+    return _require_valid_key

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import engine.mcp.registry as registry_module
+from api.main import create_app
+from engine.core.database import Database
+from engine.mcp.auth import validate_mcp_key
+from engine.mcp.registry import MCPProducerRegistry, get_registry
+from engine.mcp.types import MCPProducerManifest, MCPSignalPayload
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry(monkeypatch: pytest.MonkeyPatch) -> MCPProducerRegistry:
+    registry = MCPProducerRegistry()
+    monkeypatch.setattr(registry_module, "_REGISTRY", registry)
+    return registry
+
+
+@pytest.fixture()
+def client(temp_dir, test_config):
+    app = create_app()
+    db = Database(temp_dir / "brain.db")
+    app.state.config = test_config
+    app.state.db = db
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    db.close()
+
+
+def _manifest(name: str) -> MCPProducerManifest:
+    return MCPProducerManifest(
+        name=name,
+        domain="technical",
+        mcp_source_url=None,
+        description=f"{name} producer",
+        assets=["BTC"],
+        schedule="*/5 * * * *",
+        registered_at="2026-03-01T00:00:00+00:00",
+    )
+
+
+def _signal(producer: str) -> MCPSignalPayload:
+    return MCPSignalPayload(
+        producer=producer,
+        domain="technical",
+        asset="BTC",
+        direction="long",
+        confidence=0.9,
+        horizon="4h",
+        reason="test",
+        timestamp="2026-03-01T00:01:00+00:00",
+        raw_score=9.0,
+        metadata={"source": "test"},
+    )
+
+
+def test_mcp_producers_empty(client: TestClient) -> None:
+    response = client.get("/api/v1/mcp/producers")
+
+    assert response.status_code == 200
+    assert response.json() == {"producers": [], "count": 0}
+
+
+def test_mcp_producers_with_data(client: TestClient) -> None:
+    registry = get_registry()
+    registry.register(_manifest("alpha"))
+    registry.push_signal(_signal("alpha"))
+
+    response = client.get("/api/v1/mcp/producers")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+    assert body["producers"][0]["name"] == "alpha"
+    assert body["producers"][0]["latest_signal"]["producer"] == "alpha"
+
+
+def test_mcp_status_ok(client: TestClient) -> None:
+    response = client.get("/api/v1/mcp/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is True
+    assert body["registry_ok"] is True
+
+
+def test_mcp_status_producer_count(client: TestClient) -> None:
+    registry = get_registry()
+    registry.register(_manifest("alpha"))
+    registry.register(_manifest("beta"))
+
+    response = client.get("/api/v1/mcp/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["producer_count"] == 2
+
+
+def test_validate_mcp_key_valid() -> None:
+    assert validate_mcp_key("abc", ["abc", "xyz"]) is True
+
+
+def test_validate_mcp_key_invalid() -> None:
+    assert validate_mcp_key("bad", ["abc"]) is False


### PR DESCRIPTION
S4 of MCP sprint.

- `engine/mcp/auth.py` — `validate_mcp_key()` + FastAPI auth dependency
- `engine/core/config.py` — `MCPConfig` (enabled, port, require_auth, api_keys)
- `api/routes/mcp.py` — `GET /api/v1/mcp/producers` + `GET /api/v1/mcp/status`
- `api/routes/__init__.py` — wired mcp router
- `tests/test_mcp_routes.py` — 5+ route tests

Part of #150.