### PR TITLE
docs(mcp/s5): MCP operator guide — connect Claude and external agents to live signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ cd b1e55ed && uv sync
 | [Configuration](docs/configuration.md) | All config keys |
 | [CLI reference](docs/cli-reference.md) | Full command reference |
 | [API reference](docs/api-reference.md) | REST endpoints |
+| [MCP integration](docs/mcp.md) | Connect Claude/external agents to live producer signals |
 | [Agent interfaces](docs/agent-interfaces.md) | SSE, MCP, signal attribution |
 | [Oracle](docs/oracle.md) | Producer provenance for agents |
 | [Curator pipeline](docs/curator.md) | Ingest operator intel |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -493,3 +493,65 @@ X-Attribution-Notice: Fields informational only. May change without notice. Opti
 ```
 
 See: [oracle.md](oracle.md).
+
+---
+
+## MCP
+
+### GET `/api/v1/mcp/producers`
+
+```http
+GET /api/v1/mcp/producers
+Authorization: Bearer <token>
+```
+
+Response:
+
+```json
+{
+  "producers": [
+    {
+      "name": "tradfi_basis",
+      "domain": "tradfi",
+      "mcp_source_url": null,
+      "description": "...",
+      "assets": ["BTC", "ETH", "SOL"],
+      "schedule": "*/15 * * * *",
+      "registered_at": "2026-03-01T05:00:00Z",
+      "latest_signal": {
+        "producer": "tradfi_basis",
+        "domain": "tradfi",
+        "asset": "BTC",
+        "direction": "long",
+        "confidence": 0.72,
+        "horizon": "4h",
+        "reason": "Basis unwound to 1.8%, funding 0.9% — re-leveraging setup",
+        "timestamp": "2026-03-01T05:00:00Z",
+        "raw_score": 7.2,
+        "metadata": {}
+      }
+    }
+  ],
+  "count": 1
+}
+```
+
+### GET `/api/v1/mcp/status`
+
+```http
+GET /api/v1/mcp/status
+Authorization: Bearer <token>
+```
+
+Response:
+
+```json
+{
+  "enabled": true,
+  "producer_count": 13,
+  "total_signals_buffered": 847,
+  "registry_ok": true
+}
+```
+
+If `mcp.require_auth=true`, include `X-MCP-Key: <key>` in addition to bearer auth.

--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -18,6 +18,7 @@ README.md
   → docs/configuration.md
   → docs/cli-reference.md
   → docs/api-reference.md
+  → docs/mcp.md
   → docs/contributors.md
   → docs/architecture.md
   → docs/agent-interfaces.md
@@ -73,6 +74,15 @@ api-reference.md
   → contributors.md
   → eas-integration.md
   → architecture.md
+```
+
+### `docs/mcp.md`
+
+```text
+mcp.md
+  → producers.md
+  → api-reference.md
+  → configuration.md
 ```
 
 ### `docs/contributors.md`
@@ -386,6 +396,7 @@ done
 - ✅ `docs/configuration.md`
 - ✅ `docs/deployment.md`
 - ✅ `docs/api-reference.md`
+- ✅ `docs/mcp.md`
 - ✅ `docs/architecture.md`
 - ✅ `docs/developers.md`
 - ✅ `docs/security.md`
@@ -472,6 +483,7 @@ These files are design references and sprint plans, not operator-facing guides.
 |----------|---------|
 | [internal/DASHBOARD_DESIGN_SPEC.md](internal/DASHBOARD_DESIGN_SPEC.md) | Dashboard design spec |
 | [internal/OPERATOR_SPRINT_PLAN.md](internal/OPERATOR_SPRINT_PLAN.md) | Operator layer sprint plan (O1-O4) |
+| [MCP_SPRINT_PLAN.md](MCP_SPRINT_PLAN.md) | MCP sprint implementation plan (S1-S5) |
 
 *Last updated: 2026-03-01*
 
@@ -545,7 +557,7 @@ docs/contributing/how-to-contribute.mdx
 ```text
 docs/operator-standalone.md → getting-started.md, configuration.md, cli-reference.md
 docs/operator-agent.md      → operator-standalone.md, openclaw-integration.md
-docs/producers.md           → configuration.md, api-reference.md, producers/overview.mdx
+docs/producers.md           → configuration.md, api-reference.md, mcp.md, producers/overview.mdx
 ```
 
 ## CLI setup command modules

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,211 @@
+# MCP Integration
+
+b1e55ed exposes producer signals over MCP (Model Context Protocol), so AI agents can consume live market intelligence through a standard tool interface.
+
+## What it is
+
+b1e55ed exposes all producer signals via the Model Context Protocol (MCP) — a standard interface that lets AI agents, Claude sessions, and external tools subscribe to live market intelligence without REST API setup.
+
+## Architecture
+
+- Every producer auto-registers with the `MCPProducerRegistry` on startup.
+- Signals are pushed to an in-memory ring buffer (last 100 per producer) on every publish cycle.
+- The MCP server exposes these as tools: `list_producers`, `get_latest_signal`, `get_signal_history`.
+- REST endpoints at `/api/v1/mcp/*` provide HTTP access to the same registry (no MCP client required).
+
+## Quick start: HTTP access
+
+These endpoints expose the in-memory MCP producer registry over plain HTTP.
+
+> If your instance uses API auth, include `Authorization: Bearer <token>`.
+> If `mcp.require_auth=true`, also include `X-MCP-Key: <key>`.
+
+### List MCP producers
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:5050/api/v1/mcp/producers
+```
+
+Example response:
+
+```json
+{
+  "producers": [
+    {
+      "name": "tradfi-basis",
+      "domain": "tradfi",
+      "mcp_source_url": null,
+      "description": "Produce basis/carry signals for the configured universe.",
+      "assets": ["BTC", "ETH", "SOL"],
+      "schedule": "*/30 * * * *",
+      "registered_at": "2026-03-01T05:00:00+00:00",
+      "latest_signal": {
+        "producer": "tradfi-basis",
+        "domain": "tradfi",
+        "asset": "BTC",
+        "direction": "long",
+        "confidence": 0.72,
+        "horizon": "4h",
+        "reason": "Basis unwound to 1.8%, funding 0.9% — re-leveraging setup",
+        "timestamp": "2026-03-01T05:00:00+00:00",
+        "raw_score": 7.2,
+        "metadata": {
+          "event_type": "signal.tradfi_basis.v1",
+          "source": "tradfi-basis"
+        }
+      }
+    },
+    {
+      "name": "social-intel",
+      "domain": "social",
+      "mcp_source_url": null,
+      "description": "",
+      "assets": [],
+      "schedule": "*/15 * * * *",
+      "registered_at": "2026-03-01T05:00:01+00:00",
+      "latest_signal": null
+    }
+  ],
+  "count": 2
+}
+```
+
+### Check MCP registry status
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:5050/api/v1/mcp/status
+```
+
+Example response:
+
+```json
+{
+  "enabled": true,
+  "producer_count": 13,
+  "total_signals_buffered": 847,
+  "registry_ok": true
+}
+```
+
+## Connecting Claude Desktop
+
+1. Install b1e55ed with MCP extras:
+
+   ```bash
+   pip install "b1e55ed[mcp]"
+   ```
+
+2. Start b1e55ed:
+
+   ```bash
+   b1e55ed start
+   ```
+
+3. Add a Claude Desktop MCP server entry in `claude_desktop_config.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "b1e55ed": {
+         "command": "npx",
+         "args": [
+           "-y",
+           "mcp-remote",
+           "http://127.0.0.1:7337/sse"
+         ]
+       }
+     }
+   }
+   ```
+
+4. Restart Claude Desktop.
+
+You can now ask things like:
+
+- "What’s the current TradFi signal?"
+- "List all producers."
+- "Show the last 10 onchain signals."
+- "What changed in social signals in the last hour?"
+
+## MCP tools reference
+
+| Tool | Description | Arguments | Return shape |
+|---|---|---|---|
+| `list_producers()` | List producer manifests currently registered in memory. | None | `list[MCPProducerManifest]` |
+| `get_latest_signal(producer_name)` | Return the newest signal for one producer. | `producer_name: str` | `MCPSignalPayload \| null` |
+| `get_signal_history(producer_name, limit=10)` | Return the most recent N signals for one producer. | `producer_name: str`, `limit: int = 10` | `list[MCPSignalPayload]` |
+
+`MCPProducerManifest` entries include:
+`name`, `domain`, `mcp_source_url`, `description`, `assets`, `schedule`, `registered_at`.
+
+## MCPSignalPayload schema
+
+| Field | Type | Description |
+|---|---|---|
+| `producer` | `str` | Producer name (example: `tradfi-basis`). |
+| `domain` | `str` | Signal domain (`technical`, `onchain`, `tradfi`, `social`, `events`, `curator`). |
+| `asset` | `str \| null` | Asset symbol when signal is asset-specific. |
+| `direction` | `str \| null` | Directional intent (`long`, `short`, `flat`) when available. |
+| `confidence` | `float \| null` | Confidence in 0.0–1.0 when provided by producer. |
+| `horizon` | `str \| null` | Time horizon (example: `4h`, `1d`). |
+| `reason` | `str` | Human-readable rationale. |
+| `timestamp` | `str` | ISO8601 UTC timestamp. |
+| `raw_score` | `float \| null` | Original producer score when applicable. |
+| `metadata` | `dict` | Producer-specific extra fields (event type, source, etc.). |
+
+## Configuration
+
+Add MCP settings to `config/user.yaml`:
+
+```yaml
+mcp:
+  enabled: true
+  port: 7337
+  require_auth: false
+  api_keys: []
+```
+
+Field behavior:
+
+- `enabled`: starts the MCP server/registry integration.
+- `port`: FastMCP server port (default `7337`).
+- `require_auth`: if `true`, `/api/v1/mcp/*` endpoints require `X-MCP-Key`.
+- `api_keys`: allowed key list for `X-MCP-Key` validation.
+
+> If port `7337` is publicly exposed, set `require_auth: true` and define strong API keys.
+
+## Adding MCP data sources (for producer authors)
+
+Producer authors can declare upstream MCP capability via `mcp_source_url` on the producer class.
+
+Example (`FinancialDatasetsMCPProducer`):
+
+```python
+class FinancialDatasetsMCPProducer(BaseProducer):
+    name = "financial_datasets"
+    domain = "tradfi"
+    schedule = "0 */6 * * *"
+    mcp_source_url = "https://github.com/financial-datasets/mcp-server"
+```
+
+Semantics:
+
+- `mcp_source_url = null` → producer currently uses REST/WebSocket-style data collection.
+- `mcp_source_url = <url>` → producer has an upstream MCP server available.
+
+Today, this is a declaration + compatibility hook. When full MCP stdio protocol support lands, producers with `mcp_source_url` set will auto-switch from REST transport to direct MCP transport.
+
+## Security
+
+- Default `require_auth=false` is safe for local/operator deployments where port `7337` is not exposed.
+- For public deployments: set `require_auth=true`, populate `api_keys`, and firewall port `7337`.
+- Authenticated registry requests use the `X-MCP-Key` header.
+
+Related docs:
+- [producers.md](producers.md)
+- [api-reference.md](api-reference.md)
+- [configuration.md](configuration.md)

--- a/docs/producers.md
+++ b/docs/producers.md
@@ -56,6 +56,31 @@ Defined in `engine/core/config.py` (`DomainWeights`). Defaults:
 | `price-alerts` | technical | Price/bid/ask/venue (polling “ws-like” feed) | Medium (endpoint; **every 1 min**) | 0.10 | When you need fast price state for technical context |
 | `market-events` | events | Catalyst list + headline sentiment + impact score + count | Medium (endpoint; NLP/news) | 0.05 | When catalysts/news drive discontinuities |
 
+## MCP signal access
+
+Every producer auto-registers with the MCP registry on startup.
+
+| Producer | Domain | `mcp_source_url` | Description |
+|---|---|---|---|
+| TechnicalAnalysis (`technical-analysis`) | technical | `null` | Technical indicators and structure signals for configured symbols. |
+| Onchain (`onchain-flows`) | onchain | `null` | On-chain flow and activity metrics. |
+| TradFiBasis (`tradfi-basis`) | tradfi | `null` | Basis/funding/open-interest carry regime signals. |
+| Sentiment (`market-sentiment`) | social | `null` | Market sentiment and fear/greed risk appetite. |
+| Social (`social-intel`) | social | `null` | Narrative/attention-driven social intelligence pipeline. |
+| Whale (`whale-tracking`) | onchain | `null` | Whale and smart-money positioning changes. |
+| Stablecoin (`stablecoin-supply`) | onchain | `null` | Stablecoin expansion/contraction liquidity proxy. |
+| ETF (`etf-flows`) | tradfi | `null` | Spot ETF flow pressure and streak dynamics. |
+| Orderbook (`orderbook-depth`) | technical | `null` | Orderbook imbalance and liquidity-depth conditions. |
+| Events (`market-events`) | events | `null` | Event/catalyst sentiment and impact scoring. |
+| Curator (`curator-intel`) | curator | `null` | Operator/curator directional thesis ingestion. |
+| ACI (`ai-consensus`) | curator | `null` | AI consensus directional score from model output. |
+| FinancialDatasets (`financial_datasets`) | tradfi | `https://github.com/financial-datasets/mcp-server` | MCP-enabled earnings surprise and fundamentals stream (registered when API key is configured). |
+
+- `mcp_source_url: null` = producer uses REST/WebSocket-style data collection.
+- `mcp_source_url: <url>` = producer has an upstream MCP server (for now: `financial_datasets`).
+
+See [mcp.md](mcp.md) for the full operator guide.
+
 ---
 
 ### Producer details (what it uses, catches/misses, tuning knobs)


### PR DESCRIPTION
S5 (final) of MCP sprint.

- `docs/mcp.md` — full operator guide: HTTP access, Claude Desktop setup, tools reference, schema, config, security
- `docs/producers.md` — MCP signal access section + producer MCP table
- `docs/api-reference.md` — `/api/v1/mcp/producers` + `/api/v1/mcp/status` documented
- `docs/dependencies-docs.md` — `docs/mcp.md` registered

Completes #150 — all 6 sprints done. `feat/mcp` ready for review.