### PR TITLE
fix: oracle contributor registration — fall back to baked-in GitHub App constants

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -88,12 +88,17 @@ def get_publisher(request: Request) -> object | None:
     (publish.github.app_id + B1E55ED_GITHUB_APP_KEY env var).
     Fail-open — returns None on failure rather than raising.
     """
+    from engine.config.github_app_defaults import COMMUNITY_APP_ID
     from engine.integrations.github_publish import make_publisher
 
     cfg = get_config(request)
     pub_cfg = cfg.publish.github
     has_token = bool(pub_cfg.token)
     has_app = int(pub_cfg.app_id or 0) > 0
+
+    # Fall back to baked-in community app constants if config has app_id: 0
+    if not has_app and COMMUNITY_APP_ID > 0:
+        has_app = True
 
     if not has_token and not has_app:
         return None
@@ -104,8 +109,13 @@ def get_publisher(request: Request) -> object | None:
             from engine.integrations.github_app import GitHubAppAuth
 
             app_auth = GitHubAppAuth.from_env()
-        except Exception:
-            pass
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).warning("get_publisher: GitHubAppAuth.from_env() failed: %s", e)
+            # If app auth fails and no token, bail
+            if not has_token:
+                return None
 
     return make_publisher(
         owner=pub_cfg.owner,

--- a/engine/integrations/github_app.py
+++ b/engine/integrations/github_app.py
@@ -203,20 +203,24 @@ class GitHubAppAuth:
         """Construct a GitHubAppAuth from environment variables.
 
         Required env vars:
+          B1E55ED_GITHUB_APP_KEY         — PEM private key (raw or path to .pem file)
+
+        Optional env vars (fall back to baked-in community defaults):
           B1E55ED_GITHUB_APP_ID          — numeric App ID
           B1E55ED_GITHUB_INSTALLATION_ID — numeric Installation ID
-          B1E55ED_GITHUB_APP_KEY         — PEM private key (raw or path to .pem file)
 
         Raises:
             RuntimeError: If any required env var is missing or invalid.
         """
+        from engine.config.github_app_defaults import COMMUNITY_APP_ID, COMMUNITY_INSTALLATION_ID
+
         missing: list[str] = []
 
-        app_id_raw = os.environ.get("B1E55ED_GITHUB_APP_ID", "")
+        app_id_raw = os.environ.get("B1E55ED_GITHUB_APP_ID", "") or (str(COMMUNITY_APP_ID) if COMMUNITY_APP_ID else "")
         if not app_id_raw:
             missing.append("B1E55ED_GITHUB_APP_ID")
 
-        installation_id_raw = os.environ.get("B1E55ED_GITHUB_INSTALLATION_ID", "")
+        installation_id_raw = os.environ.get("B1E55ED_GITHUB_INSTALLATION_ID", "") or (str(COMMUNITY_INSTALLATION_ID) if COMMUNITY_INSTALLATION_ID else "")
         if not installation_id_raw:
             missing.append("B1E55ED_GITHUB_INSTALLATION_ID")
 

--- a/tests/unit/test_api_producer_capabilities.py
+++ b/tests/unit/test_api_producer_capabilities.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+from types import SimpleNamespace
 
 try:
     from datetime import UTC  # py311+
@@ -23,6 +24,7 @@ from pathlib import Path
 
 import pytest
 
+from api.deps import get_publisher
 from api.main import create_app
 from engine.core.database import Database
 from tests.unit._api_test_client import make_client
@@ -179,3 +181,17 @@ async def test_capabilities_empty_when_no_producers(tmp_path: Path, test_config)
     assert r.status_code == 200
     assert r.json() == []
     db.close()
+
+
+def test_get_publisher_uses_community_app_when_config_app_id_zero(test_config, monkeypatch) -> None:
+    github_cfg = test_config.publish.github.model_copy(update={"app_id": 0, "token": ""})
+    cfg = test_config.model_copy(update={"publish": test_config.publish.model_copy(update={"github": github_cfg})})
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(config=cfg)))
+
+    monkeypatch.delenv("B1E55ED_GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("B1E55ED_GITHUB_INSTALLATION_ID", raising=False)
+    monkeypatch.setenv("B1E55ED_GITHUB_APP_KEY", "dummy-private-key")
+
+    publisher = get_publisher(request)
+
+    assert publisher is not None

--- a/tests/unit/test_github_publish.py
+++ b/tests/unit/test_github_publish.py
@@ -9,6 +9,8 @@ import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from engine.config.github_app_defaults import COMMUNITY_APP_ID, COMMUNITY_INSTALLATION_ID
+from engine.integrations.github_app import GitHubAppAuth
 from engine.integrations.github_publish import publish_attestation_to_github
 
 FAKE_ATTESTATION: dict[str, Any] = {
@@ -235,3 +237,14 @@ class TestPublishTokenSafety:
 
         assert result is None
         mock_client.post.assert_not_called()
+
+
+def test_from_env_uses_baked_in_defaults_when_env_vars_missing(monkeypatch) -> None:
+    monkeypatch.delenv("B1E55ED_GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("B1E55ED_GITHUB_INSTALLATION_ID", raising=False)
+    monkeypatch.setenv("B1E55ED_GITHUB_APP_KEY", "dummy-private-key")
+
+    auth = GitHubAppAuth.from_env()
+
+    assert auth._app_id == COMMUNITY_APP_ID
+    assert auth._installation_id == COMMUNITY_INSTALLATION_ID


### PR DESCRIPTION
## Problem

New contributor registration via `POST /api/v1/oracle/contributors/register` always returns `issue_url: null`. No GitHub issue is ever created.

## Root cause (two silent failures)

**Layer 1** — `get_publisher()` in `api/deps.py` checks `cfg.publish.github.app_id`. Oracle server config has `app_id: 0` (set up manually, not via wizard) → `has_app = False` → returns `None` immediately.

**Layer 2** — `GitHubAppAuth.from_env()` requires `B1E55ED_GITHUB_APP_ID` and `B1E55ED_GITHUB_INSTALLATION_ID` env vars. Only `B1E55ED_GITHUB_APP_KEY` was configured on the oracle server. `RuntimeError` is swallowed silently.

## Fix

Both layers now fall back to the baked-in community constants from `engine/config/github_app_defaults.py` (`COMMUNITY_APP_ID = 2953603`, `COMMUNITY_INSTALLATION_ID = 112556330`). These are public identifiers — not secrets. The oracle only needs `B1E55ED_GITHUB_APP_KEY` in its environment.

## After merging

Oracle server needs a `git pull` + service restart — no config changes required.