### PR TITLE
fix: oracle attestation repo — default to offchain-attestations

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -88,7 +88,7 @@ def get_publisher(request: Request) -> object | None:
     (publish.github.app_id + B1E55ED_GITHUB_APP_KEY env var).
     Fail-open — returns None on failure rather than raising.
     """
-    from engine.config.github_app_defaults import COMMUNITY_APP_ID
+    from engine.config.github_app_defaults import COMMUNITY_APP_ID, COMMUNITY_REPO
     from engine.integrations.github_publish import make_publisher
 
     cfg = get_config(request)
@@ -119,7 +119,7 @@ def get_publisher(request: Request) -> object | None:
 
     return make_publisher(
         owner=pub_cfg.owner,
-        repo=pub_cfg.repo,
+        repo=pub_cfg.repo or COMMUNITY_REPO,
         token=str(pub_cfg.token or ""),
         labels=pub_cfg.labels,
         app_auth=app_auth,

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -685,7 +685,7 @@ def _step4_configuration(repo_root: Path) -> None:
     # Set B1E55ED_GITHUB_APP_KEY env var to your app's private key PEM
     token: ""        # fallback PAT (used if app_id is 0)
     owner: "P-U-C"
-    repo: "b1e55ed"
+    repo: "offchain-attestations"
     labels: ["b1e55ed-attestation"]
 """
     else:
@@ -697,7 +697,7 @@ def _step4_configuration(repo_root: Path) -> None:
     # Set B1E55ED_GITHUB_APP_KEY env var to your app's private key PEM
     token: "{github_token_value}"        # fallback PAT (used if app_id is 0)
     owner: "P-U-C"
-    repo: "b1e55ed"
+    repo: "offchain-attestations"
     labels: ["b1e55ed-attestation"]
 """
 

--- a/engine/config/github_app_defaults.py
+++ b/engine/config/github_app_defaults.py
@@ -16,3 +16,4 @@ from __future__ import annotations
 # These are public info (visible in GitHub UI), not secrets.
 COMMUNITY_APP_ID: int = 2953603
 COMMUNITY_INSTALLATION_ID: int = 112556330
+COMMUNITY_REPO: str = "offchain-attestations"


### PR DESCRIPTION
## Summary

Default oracle attestation repo to `offchain-attestations` instead of `b1e55ed`. Fixes contributor registration — issues were being created in the wrong repo.

Closes #<!-- N/A — no issue tracked for this bug -->

---

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

- [x] Labels applied ✅

---

## Changes

- `engine/config/github_app_defaults.py` — added `COMMUNITY_REPO = "offchain-attestations"`
- `engine/cli/commands/wizard.py` — both `github_publish_block` templates now default `repo` to `offchain-attestations`
- `api/deps.py` — `get_publisher()` falls back to `COMMUNITY_REPO` when `pub_cfg.repo` is empty

---

## Tests

- [ ] New tests added (or explain why not needed) — config constant change, no new test needed
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `590` passing

---

## Checklist

- [x] Branch targets the correct base (`develop`)
- [ ] `docs/dependencies-docs.md` updated if new file dependencies introduced — N/A
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified**

## Migration note

Existing oracle operators with `repo: "b1e55ed"` in their config: uninstall, delete `~/.b1e55ed`, reinstall from script, re-run wizard.