### PR TITLE
fix(b1e55ing): swap Anthropic → Grok — XAI_API_KEY always available

### DIFF
--- a/scripts/b1e55ing.py
+++ b/scripts/b1e55ing.py
@@ -4,7 +4,7 @@ Analyzes PR diffs and adds brand-appropriate cultural references as
 comments/docstrings to changed Python files. Blessings scale logarithmically
 with PR size: small PRs get focused attention, large PRs get signal not noise.
 
-Agent usage (primary path — local, uses ANTHROPIC_API_KEY from env):
+Agent usage (primary path — local, uses XAI_API_KEY from env):
     python scripts/b1e55ing.py \\
         --pr-number 77 \\
         --github-token $GH_TOKEN \\
@@ -47,7 +47,8 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 REPO = "P-U-C/b1e55ed"
-ANTHROPIC_MODEL = "claude-3-5-haiku-20241022"
+XAI_MODEL = "grok-3-mini"
+XAI_BASE_URL = "https://api.x.ai/v1"
 MAX_EGGS_PER_FILE = 2
 REFERENCE_PATH = Path(__file__).parent.parent / "docs" / "EASTER_EGG_REFERENCE.md"
 
@@ -130,46 +131,48 @@ def max_blessings(n_files: int) -> int:
 
 
 # ---------------------------------------------------------------------------
-# LLM abstraction — agent (Anthropic) only
+# LLM abstraction — agent (XAI) only
 # ---------------------------------------------------------------------------
 
 
 class LLMClient:
-    """Thin wrapper around the Anthropic Claude API.
+    """Thin wrapper around the XAI (Grok) chat completions API.
 
-    Lazy import — anthropic is not a hard dependency at import time.
-    If the agent is offline, b1e55ing-merge.yml posts an on-brand curse instead.
+    Uses the OpenAI-compatible endpoint at https://api.x.ai/v1.
+    httpx is already a dependency — no new imports needed.
     """
 
     def __init__(self, mode: str, api_key: str = "") -> None:
         if mode not in ("agent",):
             raise ValueError(f"Unknown mode: {mode!r} — only 'agent' is supported")
         self.mode = mode
-        self.api_key = api_key
+        self.api_key = api_key or os.environ.get("XAI_API_KEY", "")
+        if not self.api_key:
+            raise RuntimeError("XAI_API_KEY is not set — cannot proceed in agent mode")
 
-    def complete(self, system: str, user: str) -> str:
-        """Return LLM text completion given *system* and *user* prompts."""
-        return self._call_anthropic(system, user)
-
-    def _call_anthropic(self, system: str, user: str) -> str:
-        """Anthropic Claude via the official SDK. API key from env."""
-        try:
-            import anthropic  # lazy — not a hard dep at import time
-        except ImportError as exc:
-            raise RuntimeError("anthropic package not installed — run: pip install anthropic") from exc
-
-        key = self.api_key or os.environ.get("ANTHROPIC_API_KEY", "")
-        if not key:
-            raise RuntimeError("ANTHROPIC_API_KEY is not set — cannot proceed in agent mode")
-
-        client = anthropic.Anthropic(api_key=key)
-        message = client.messages.create(
-            model=ANTHROPIC_MODEL,
-            max_tokens=2048,
-            system=system,
-            messages=[{"role": "user", "content": user}],
+    def generate(self, *, system: str, user: str) -> str:
+        """Call XAI chat completions. Returns the assistant message text."""
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        body = {
+            "model": XAI_MODEL,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "temperature": 0.7,
+            "max_tokens": 2048,
+        }
+        resp = httpx.post(
+            f"{XAI_BASE_URL}/chat/completions",
+            headers=headers,
+            json=body,
+            timeout=60.0,
         )
-        return str(message.content[0].text)  # type: ignore[union-attr]
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"]
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +446,7 @@ def main(argv: list[str] | None = None) -> int:
         "--mode",
         required=True,
         choices=["agent"],
-        help="LLM backend: 'agent' (Anthropic via heartbeat — only supported mode)",
+        help="LLM backend: 'agent' (Grok/XAI via heartbeat — only supported mode)",
     )
     parser.add_argument("--base-branch", default="", help="Base branch (informational, optional)")
     parser.add_argument("--dry-run", action="store_true", help="Print suggestions without writing files")
@@ -454,9 +457,9 @@ def main(argv: list[str] | None = None) -> int:
 
     # Resolve API key from environment
     if args.mode == "agent":
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        api_key = os.environ.get("XAI_API_KEY", "")
         if not api_key:
-            log.error("ANTHROPIC_API_KEY is not set — cannot proceed in agent mode")
+            log.error("XAI_API_KEY is not set — cannot proceed in agent mode")
             return 1
 
     llm = LLMClient(mode=args.mode, api_key=api_key)
@@ -505,7 +508,7 @@ def main(argv: list[str] | None = None) -> int:
     user_prompt = build_user_prompt(pr_title, pr_body, file_contexts, reference_text, budget)
     log.info("calling %s (budget: %d)", args.mode, budget)
     try:
-        raw_response = llm.complete(SYSTEM_PROMPT, user_prompt)
+        raw_response = llm.generate(system=SYSTEM_PROMPT, user=user_prompt)
     except Exception as exc:  # noqa: BLE001
         exc_str = str(exc)
         if "429" in exc_str or "RESOURCE_EXHAUSTED" in exc_str or "quota" in exc_str.lower():

--- a/tests/unit/test_b1e55ing.py
+++ b/tests/unit/test_b1e55ing.py
@@ -19,8 +19,6 @@ import ast
 import json
 import sys
 from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -95,34 +93,50 @@ def test_max_blessings_negative() -> None:
 
 
 # ---------------------------------------------------------------------------
-# LLMClient — agent mode (Anthropic)
+# LLMClient — agent mode (XAI)
 # ---------------------------------------------------------------------------
 
 
 def test_llm_client_agent_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    """agent mode calls anthropic.Anthropic with the correct model."""
-    # Build a fake anthropic module
-    fake_content = SimpleNamespace(text="mock response")
-    fake_message = SimpleNamespace(content=[fake_content])
-    fake_create = MagicMock(return_value=fake_message)
-    fake_client_instance = MagicMock()
-    fake_client_instance.messages.create = fake_create
-    fake_anthropic_cls = MagicMock(return_value=fake_client_instance)
+    """agent mode calls XAI chat completions with the correct payload."""
 
-    fake_anthropic_module = MagicMock()
-    fake_anthropic_module.Anthropic = fake_anthropic_cls
+    called: dict[str, object] = {}
 
-    monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic_module)
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-agent")
+    class _FakeResp:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "mock response"}}]}
+
+    def _fake_post(url: str, *, headers: dict[str, str], json: dict[str, object], timeout: float) -> _FakeResp:
+        called["url"] = url
+        called["headers"] = headers
+        called["json"] = json
+        called["timeout"] = timeout
+        return _FakeResp()
+
+    monkeypatch.setenv("XAI_API_KEY", "test-key-agent")
+    monkeypatch.setattr(hook.httpx, "post", _fake_post)
 
     client = hook.LLMClient(mode="agent", api_key="test-key-agent")
-    result = client.complete("system", "user")
+    result = client.generate(system="system", user="user")
 
     assert result == "mock response"
-    fake_anthropic_cls.assert_called_once_with(api_key="test-key-agent")
-    call_kwargs = fake_create.call_args
-    assert call_kwargs.kwargs["model"] == hook.ANTHROPIC_MODEL
-    assert call_kwargs.kwargs["system"] == "system"
+    assert called["url"] == f"{hook.XAI_BASE_URL}/chat/completions"
+    assert called["timeout"] == 60.0
+
+    headers = called["headers"]
+    assert isinstance(headers, dict)
+    assert headers["Authorization"] == "Bearer test-key-agent"
+
+    payload = called["json"]
+    assert isinstance(payload, dict)
+    assert payload["model"] == hook.XAI_MODEL
+    assert payload["messages"] == [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "user"},
+    ]
 
 
 def test_llm_client_unsupported_modes() -> None:


### PR DESCRIPTION
## Summary

Swaps `scripts/b1e55ing.py` from Anthropic SDK usage to direct XAI (Grok) chat completions via `httpx`, using `XAI_API_KEY`, and updates unit coverage for the new client call shape.

Closes <!-- N/A -->

---

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

- `scripts/b1e55ing.py`
  - Replaced `ANTHROPIC_MODEL` usage with `XAI_MODEL` + `XAI_BASE_URL`
  - Rewrote `LLMClient` to call `https://api.x.ai/v1/chat/completions` via `httpx`
  - Switched env var checks from `ANTHROPIC_API_KEY` to `XAI_API_KEY`
  - Updated mode help text to Grok/XAI wording
- `tests/unit/test_b1e55ing.py`
  - Updated `LLMClient` unit test to mock `httpx.post` and assert XAI payload fields

---

## Tests

- [ ] New tests added (or explain why not needed) — no new tests; updated existing unit test for migrated client behavior
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `719` passing

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [x] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified**