### PR TITLE
fix(b1e55ing): apply-eggs now commits after patching

### DIFF
--- a/scripts/b1e55ing.py
+++ b/scripts/b1e55ing.py
@@ -356,7 +356,34 @@ def main(argv: list[str] | None = None) -> int:
         if apply_egg(abs_path, egg, dry_run=False):
             applied += 1
 
-    log.info("%d egg(s) applied — commit message: 'chore: a b1e55ing [skip ci]'", applied)
+    if applied == 0:
+        log.info("no eggs applied — nothing to commit")
+        return 0
+
+    log.info("%d egg(s) applied — committing", applied)
+    import subprocess  # noqa: PLC0415
+
+    result = subprocess.run(
+        ["git", "add", "-A"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        log.error("git add failed: %s", result.stderr)
+        return 1
+
+    result = subprocess.run(
+        ["git", "commit", "-m", "chore: a b1e55ing [skip ci]"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        log.error("git commit failed: %s", result.stderr)
+        return 1
+
+    log.info("committed: %s", result.stdout.strip())
     return 0
 
 


### PR DESCRIPTION
## Summary

`apply-eggs` mode was staging file changes and logging the commit message, but never actually running `git commit`. Fixed by adding `subprocess.run(["git", "add", "-A"])` + `subprocess.run(["git", "commit", ...])` after all eggs are applied.

---

## Type of change

- [ ] `feat`
- [x] `fix`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `chore`

---

## Labels
- [x] Labels applied ✅

---

## Changes
- `scripts/b1e55ing.py` — add `git add -A` + `git commit` subprocess calls at end of apply-eggs mode

---

## Tests
- [ ] New tests added (not needed — behaviour change is a missing subprocess call)
- [x] All existing tests pass

---

## Checklist
- [x] Branch targets `develop`
- [x] No secrets in code
- [x] `engine/brain/orchestrator.py` not modified