### PR TITLE
feat(p0a): Interpreter base class — forecast seam wired into BaseProducer

### DIFF
--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -654,3 +654,13 @@ engine/producers/polymarket.py
 ```text
 docs/FLYWHEEL_SPEC.md → docs/architecture.md, CHANGELOG.md
 ```
+
+## Interpreter seam
+
+### `engine/core/interpreter.py`
+
+```text
+engine/core/interpreter.py
+  → engine/core/events.py (ForecastPayload, AbstentionReason)
+  → engine/core/forecast.py (abstain)
+```

--- a/engine/core/interpreter.py
+++ b/engine/core/interpreter.py
@@ -1,0 +1,116 @@
+"""engine.core.interpreter
+
+The interpretation seam: converts domain signals into FORECAST_V1 events.
+
+An Interpreter sits between raw producer output and the forecast record.
+It answers one question per cycle: given what I observed, what is my call?
+
+Producers that implement interpret() are forecast-capable.
+Producers that don't default to abstention (no_forecast).
+The seam is additive -- existing producers need no changes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from engine.core.events import AbstentionReason, ForecastPayload
+from engine.core.forecast import abstain
+
+
+class Interpreter(ABC):
+    """Abstract base for producer-level forecast interpretation.
+
+    One Interpreter per producer. Converts the producer's domain
+    signals into a structured ForecastPayload each cycle.
+
+    Subclasses implement interpret(). The default fallback is abstention.
+    """
+
+    #: Set by the concrete producer. Used for source field in ForecastPayload.
+    producer_name: str = "unknown"
+    producer_version: str = "0.0.0"
+
+    @property
+    def source(self) -> str:
+        return f"{self.producer_name}@{self.producer_version}"
+
+    @abstractmethod
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        """Produce a ForecastPayload from the current cycle's signals.
+
+        Args:
+            asset: The asset symbol being forecasted (e.g. "BTC").
+            horizon: Forecast horizon string (e.g. "4h", "24h").
+            signals: Raw signal dicts from this producer's collect/normalize cycle.
+            regime_tag: Current regime label from the brain (risk-on/risk-off/chop/unknown).
+            visible_signal_refs: Event IDs of all events in the lookback window.
+
+        Returns:
+            A ForecastPayload. Return abstain() when there is no confident call.
+        """
+        ...
+
+    def safe_interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+        default_reason: AbstentionReason = AbstentionReason.INSUFFICIENT_DATA,
+    ) -> ForecastPayload:
+        """Call interpret() and fall back to abstention on any exception."""
+        try:
+            return self.interpret(
+                asset=asset,
+                horizon=horizon,
+                signals=signals,
+                regime_tag=regime_tag,
+                visible_signal_refs=visible_signal_refs,
+            )
+        except Exception:  # noqa: BLE001
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=default_reason,
+                regime_tag=regime_tag,
+                visible_signal_refs=visible_signal_refs or [],
+            )
+
+
+class NullInterpreter(Interpreter):
+    """Always abstains. Default for producers that have no interpretation logic yet.
+
+    Using NullInterpreter explicitly is better than omitting interpreter entirely --
+    it signals that the producer is forecast-aware but not yet forecast-capable.
+    """
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        return abstain(
+            source=self.source,
+            asset=asset,
+            horizon=horizon,
+            reason=AbstentionReason.INSUFFICIENT_DATA,
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs or [],
+        )

--- a/engine/producers/base.py
+++ b/engine/producers/base.py
@@ -30,6 +30,8 @@ from typing import Any, Protocol, runtime_checkable
 from engine.core.client import DataClient
 from engine.core.config import Config
 from engine.core.database import Database
+from engine.core.events import EventType, ForecastPayload
+from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.metrics import MetricsRegistry
 from engine.core.models import Event, compute_event_hash
 from engine.core.types import CANONICAL_DOMAINS, ProducerHealth, ProducerResult
@@ -79,6 +81,10 @@ class BaseProducer(ABC):
 
     # Class variable — override in subclasses that have an MCP source.
     mcp_source_url: str | None = None
+
+    #: Optional interpreter. Set to a NullInterpreter by default.
+    #: Override in subclasses that implement forecast-capable interpretation.
+    interpreter: Interpreter | NullInterpreter | None = None
 
     # Injected by registry after construction (set in S2).
     _mcp_client: Any | None = None
@@ -185,6 +191,47 @@ class BaseProducer(ABC):
             self.ctx.logger.warning("mcp_publish_failed", extra={"producer": self.name})
 
         return published
+
+    def emit_forecast(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict] | None = None,
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload | None:
+        """Emit a FORECAST_V1 event via this producer's interpreter.
+
+        Returns None if no interpreter is configured.
+        Returns a ForecastPayload (including abstentions) if one is.
+
+        The event is published to the DB automatically.
+        """
+
+        if self.interpreter is None:
+            return None
+
+        # Ensure source is wired up
+        if hasattr(self.interpreter, "producer_name"):
+            self.interpreter.producer_name = self.name
+
+        forecast = self.interpreter.safe_interpret(
+            asset=asset,
+            horizon=horizon,
+            signals=signals or [],
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs,
+        )
+
+        # Publish FORECAST_V1 to DB
+        self.ctx.db.append_event(
+            event_type=EventType.FORECAST_V1,
+            payload=forecast.model_dump(),
+            source=self.name,
+        )
+
+        return forecast
 
     def run(self) -> ProducerResult:
         start = time.perf_counter()

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from engine.core.client import DataClient
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import AbstentionReason, EventType, ForecastPayload
+from engine.core.forecast import make_forecast_id
+from engine.core.interpreter import Interpreter, NullInterpreter
+from engine.core.metrics import MetricsRegistry
+from engine.producers.base import BaseProducer, ProducerContext
+
+
+class _RaisingInterpreter(Interpreter):
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        raise RuntimeError("boom")
+
+
+class _LongInterpreter(Interpreter):
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        return ForecastPayload(
+            forecast_id=make_forecast_id(),
+            asset=asset,
+            horizon=horizon,
+            action="long",
+            confidence=0.8,
+            source=self.source,
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs or [],
+            used_signal_refs=["sig-1"] if signals else [],
+        )
+
+
+class _TestProducer(BaseProducer):
+    name = "test-producer"
+    domain = "events"
+    schedule = "continuous"
+
+    def collect(self) -> list[dict]:
+        return []
+
+    def normalize(self, raw: list[dict]):  # type: ignore[no-untyped-def]
+        return []
+
+
+def _make_ctx(tmp_path) -> ProducerContext:
+    db = Database(tmp_path / "events.db")
+    return ProducerContext(
+        config=Config(),
+        db=db,
+        client=DataClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+
+def test_null_interpreter_interpret_returns_no_forecast() -> None:
+    payload = NullInterpreter().interpret(asset="BTC", horizon="4h", signals=[])
+    assert isinstance(payload, ForecastPayload)
+    assert payload.action == "no_forecast"
+
+
+def test_null_interpreter_interpret_sets_insufficient_data_reason() -> None:
+    payload = NullInterpreter().interpret(asset="BTC", horizon="4h", signals=[])
+    assert payload.abstention_reason == AbstentionReason.INSUFFICIENT_DATA
+
+
+def test_safe_interpret_catches_exceptions_and_abstains() -> None:
+    payload = _RaisingInterpreter().safe_interpret(asset="BTC", horizon="4h", signals=[])
+    assert payload.action == "no_forecast"
+    assert payload.abstention_reason == AbstentionReason.INSUFFICIENT_DATA
+
+
+def test_safe_interpret_uses_default_reason_when_falling_back() -> None:
+    payload = _RaisingInterpreter().safe_interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[],
+        default_reason=AbstentionReason.REGIME_MISMATCH,
+    )
+    assert payload.abstention_reason == AbstentionReason.REGIME_MISMATCH
+
+
+def test_concrete_interpreter_can_return_long_forecast() -> None:
+    interpreter = _LongInterpreter()
+    interpreter.producer_name = "alpha"
+    interpreter.producer_version = "1.2.3"
+
+    payload = interpreter.safe_interpret(
+        asset="ETH",
+        horizon="24h",
+        signals=[{"id": "sig-1"}],
+        regime_tag="risk-on",
+        visible_signal_refs=["evt-1"],
+    )
+
+    assert payload.action == "long"
+    assert payload.source == "alpha@1.2.3"
+    assert payload.visible_signal_refs == ["evt-1"]
+
+
+def test_emit_forecast_returns_none_when_interpreter_is_none(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = None
+
+    forecast = producer.emit_forecast(asset="BTC", horizon="4h")
+
+    assert forecast is None
+    assert producer.ctx.db.get_events(event_type=EventType.FORECAST_V1, source=producer.name, limit=10) == []
+
+
+def test_emit_forecast_returns_payload_when_interpreter_is_set(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = NullInterpreter()
+
+    forecast = producer.emit_forecast(asset="BTC", horizon="4h", signals=[{"x": 1}])
+
+    assert isinstance(forecast, ForecastPayload)
+    assert forecast.action == "no_forecast"
+
+
+def test_emit_forecast_publishes_forecast_v1_event(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = _LongInterpreter()
+
+    forecast = producer.emit_forecast(asset="BTC", horizon="4h", signals=[{"signal": 1}])
+
+    events = producer.ctx.db.get_events(event_type=EventType.FORECAST_V1, source=producer.name, limit=10)
+    assert forecast is not None
+    assert len(events) == 1
+    assert events[0].type == EventType.FORECAST_V1
+    assert events[0].payload["forecast_id"] == forecast.forecast_id
+    assert events[0].payload["action"] == "long"
+
+
+def test_source_property_uses_producer_name_and_version() -> None:
+    interpreter = NullInterpreter()
+    interpreter.producer_name = "demo"
+    interpreter.producer_version = "9.9.9"
+
+    assert interpreter.source == "demo@9.9.9"
+
+
+def test_emit_forecast_wires_producer_name_into_interpreter_source(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = NullInterpreter()
+    producer.interpreter.producer_version = "2.0.0"
+
+    forecast = producer.emit_forecast(asset="SOL", horizon="1h")
+
+    assert forecast is not None
+    assert forecast.source == "test-producer@2.0.0"


### PR DESCRIPTION
## Summary

Adds the `Interpreter` abstraction (P0A.2) — the seam between producer signals and `FORECAST_V1` emission. Producers that implement `interpret()` become forecast-capable. Producers that do not default to abstention. Additive only: no existing producer is touched.

Closes #164

---

## Type of change

- [x] `feat` — new feature
- [ ] `fix`
- [ ] `docs`
- [ ] `refactor`
- [ ] `test`
- [ ] `chore`

---

## Labels
- [x] Labels applied ✅

---

## Changes

- `engine/core/interpreter.py` — new: `Interpreter` ABC, `NullInterpreter`, `safe_interpret()` fallback
- `engine/producers/base.py` — adds `interpreter` class var + `emit_forecast()` method; additive only
- `docs/dependencies-docs.md` — interpreter seam dependency entry
- `tests/unit/test_interpreter.py` — 9+ tests

---

## Tests

- [x] New tests added
- [x] All existing tests pass
- [x] Test count: `718` passing

---

## Checklist

- [x] Branch targets `develop`
- [x] No secrets in code
- [x] `engine/brain/orchestrator.py` **not modified**

## Design notes

- `interpreter = None` default: opt-in, not opt-out — silence is explicit
- `NullInterpreter` for producers that are forecast-aware but not yet forecast-capable
- `safe_interpret()` never raises — abstention is the safe fallback
- `emit_forecast()` publishes `FORECAST_V1` to DB automatically — one call, full pipeline
- P0B.1 will add `conviction_log` / `forecast_attribution` which reads from `FORECAST_V1` events