### PR TITLE
feat(p0b): TradFi dual-write — SIGNAL_TRADFI_V1 + FORECAST_V1

### DIFF
--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -24,7 +24,15 @@ from typing import Any
 
 import httpx
 
-from engine.core.events import EventType, TradFiSignalPayload
+from engine.core.events import (
+    AbstentionReason,
+    EventType,
+    ForecastLifecycleState,
+    ForecastPayload,
+    TradFiSignalPayload,
+)
+from engine.core.forecast import abstain, compute_reasoning_hash, make_forecast_id
+from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.models import Event
 from engine.core.types import ProducerHealth, ProducerResult
 from engine.producers.base import BaseProducer
@@ -186,12 +194,80 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
     return f"{EventType.SIGNAL_TRADFI_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
 
 
+class TradFiBasisInterpreter(Interpreter):
+    """Rule-based interpreter for TradFi basis/carry signals → FORECAST_V1."""
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        asset_signals = [s for s in signals if str(s.get("symbol", "")).upper() == asset.upper()]
+
+        if not asset_signals:
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.INSUFFICIENT_DATA,
+                regime_tag=regime_tag,
+                visible_signal_refs=visible_signal_refs or [],
+            )
+
+        sig = asset_signals[0]
+        direction = sig.get("direction", "flat")
+        raw_confidence = float(sig.get("confidence", 0.0))
+
+        if direction == "long" and raw_confidence >= 0.3:
+            action = "long"
+        elif direction == "short" and raw_confidence >= 0.3:
+            action = "short"
+        else:
+            action = "flat"
+
+        if raw_confidence < 0.3 or action == "flat":
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.INSUFFICIENT_DATA,
+                regime_tag=regime_tag,
+                visible_signal_refs=visible_signal_refs or [],
+            )
+
+        reasoning_hash = compute_reasoning_hash(
+            candidate={"action": action, "confidence": raw_confidence, "asset": asset},
+            critique="",
+            rationale=sig.get("signal_reason", ""),
+        )
+
+        return ForecastPayload(
+            forecast_id=make_forecast_id(),
+            asset=asset,
+            horizon=horizon,
+            action=action,
+            confidence=raw_confidence,
+            calibrated=False,
+            source=self.source,
+            regime_tag=regime_tag,
+            lifecycle_state=ForecastLifecycleState.NEW,
+            reasoning_hash=reasoning_hash,
+            visible_signal_refs=visible_signal_refs or [],
+            used_signal_refs=[r for r in (visible_signal_refs or []) if r],
+        )
+
+
 @register("tradfi-basis", domain="tradfi")
 class TradFiBasisProducer(BaseProducer):
     """Produce basis/carry signals for the configured universe."""
 
     schedule = "*/30 * * * *"
     mcp_source_url: str | None = None  # override with MCP server URL when available
+    interpreter: Interpreter | NullInterpreter | None = TradFiBasisInterpreter()
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_TRADFI_BASIS_URL") or os.getenv("TRADFI_BASIS_URL")
@@ -272,8 +348,18 @@ class TradFiBasisProducer(BaseProducer):
             raw = self.collect()
             if not raw:
                 health = ProducerHealth.DEGRADED
-            events = self.normalize(raw)
-            published = self.publish(events)
+            normalized_events = self.normalize(raw)
+            published = self.publish(normalized_events)
+
+            symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+            for symbol in symbols:
+                self.emit_forecast(
+                    asset=symbol,
+                    horizon="4h",
+                    signals=[e.payload for e in normalized_events],
+                    regime_tag="unknown",
+                    visible_signal_refs=[],
+                )
         except httpx.HTTPStatusError as e:
             code = getattr(e.response, "status_code", None)
             health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR

--- a/tests/unit/test_producer_tradfi.py
+++ b/tests/unit/test_producer_tradfi.py
@@ -7,11 +7,11 @@ import httpx
 
 from engine.core.config import Config
 from engine.core.database import Database
-from engine.core.events import EventType
+from engine.core.events import AbstentionReason, EventType, ForecastPayload
 from engine.core.metrics import MetricsRegistry
 from engine.core.types import ProducerHealth
 from engine.producers.base import ProducerContext
-from engine.producers.tradfi import TradFiBasisProducer
+from engine.producers.tradfi import TradFiBasisInterpreter, TradFiBasisProducer
 
 
 class DummyClient:
@@ -28,6 +28,55 @@ class DummyClient:
     async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
         resp = await self.request(method, url, **kwargs)
         return resp.json()
+
+
+def _signal(*, symbol: str, direction: str, confidence: float, reason: str = "signal") -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "basis_annualized": 4.0,
+        "funding_annualized": 10.0,
+        "meltup_score": 2,
+        "direction": direction,
+        "confidence": confidence,
+        "signal_reason": reason,
+    }
+
+
+def test_tradfi_interpreter_long_signal() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    payload = interpreter.interpret(asset="BTC", horizon="4h", signals=[_signal(symbol="BTC", direction="long", confidence=0.7)])
+
+    assert isinstance(payload, ForecastPayload)
+    assert payload.action == "long"
+    assert payload.confidence == 0.7
+
+
+def test_tradfi_interpreter_short_signal() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    payload = interpreter.interpret(asset="BTC", horizon="4h", signals=[_signal(symbol="BTC", direction="short", confidence=0.8)])
+
+    assert payload.action == "short"
+    assert payload.confidence == 0.8
+
+
+def test_tradfi_interpreter_low_confidence_abstains() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    payload = interpreter.interpret(asset="BTC", horizon="4h", signals=[_signal(symbol="BTC", direction="long", confidence=0.2)])
+
+    assert payload.action == "no_forecast"
+    assert payload.abstention_reason == AbstentionReason.INSUFFICIENT_DATA
+
+
+def test_tradfi_interpreter_missing_asset_abstains() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    payload = interpreter.interpret(asset="ETH", horizon="4h", signals=[_signal(symbol="BTC", direction="long", confidence=0.7)])
+
+    assert payload.action == "no_forecast"
+    assert payload.abstention_reason == AbstentionReason.INSUFFICIENT_DATA
 
 
 def test_tradfi_basis_producer_publishes_events(monkeypatch, tmp_path) -> None:
@@ -68,6 +117,48 @@ def test_tradfi_basis_producer_publishes_events(monkeypatch, tmp_path) -> None:
     assert ev.payload["symbol"] == "BTC"
     assert ev.payload["basis_annualized"] == 0.06
     assert ev.dedupe_key and "tradfi-basis" in ev.dedupe_key
+
+
+def test_tradfi_dual_write_emits_both_events(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_TRADFI_BASIS_URL", "https://example.test/basis")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "basis_annualized": 4.0,
+                    "funding_annualized": 10.0,
+                    "oi_change_pct": 1.5,
+                    "meltup_score": 2.0,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/basis"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    cfg = Config(universe={"symbols": ["BTC", "ETH"]})
+    ctx = ProducerContext(
+        config=cfg,
+        db=db,
+        client=DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    pr = TradFiBasisProducer(ctx).run()
+
+    signal_events = db.get_events(event_type=EventType.SIGNAL_TRADFI_V1, source="tradfi-basis", limit=10)
+    forecast_events = db.get_events(event_type=EventType.FORECAST_V1, source="tradfi-basis", limit=10)
+
+    assert pr.events_published == 1
+    assert len(signal_events) == 1
+    assert len(forecast_events) == 2
+    assert {event.payload["asset"] for event in forecast_events} == {"BTC", "ETH"}
+    assert any(event.payload["action"] == "long" for event in forecast_events)
+    assert any(event.payload["action"] == "no_forecast" for event in forecast_events)
 
 
 def test_tradfi_basis_producer_handles_401(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

Closes #169. Wires `TradFiBasisProducer` through the FORECAST_V1 pipeline so each cycle dual-writes `SIGNAL_TRADFI_V1` (unchanged) and `FORECAST_V1` (new, via `TradFiBasisInterpreter`).

---

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

- [x] Labels applied ✅

---

## Changes

- Added `TradFiBasisInterpreter` in `engine/producers/tradfi.py` to map normalized tradfi signals into `ForecastPayload` (`long`/`short` or abstain).
- Wired `TradFiBasisProducer.interpreter` to `TradFiBasisInterpreter()`.
- Extended `TradFiBasisProducer.run()` to emit `FORECAST_V1` after existing `SIGNAL_TRADFI_V1` publish, once per configured universe symbol (`horizon="4h"`).
- Added unit tests in `tests/unit/test_producer_tradfi.py` for interpreter long/short/abstain paths and dual-write DB emission.

---

## Tests

- [x] New tests added
- [ ] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `17` passing for targeted forecast/tradfi suite

Additional run: `.venv/bin/python -m pytest tests/ -x -q` currently stops at pre-existing failure `tests/unit/test_b1e55ing.py::test_main_apply_eggs_mode_applies_from_json` (1 failed, 173 passed).

---

## Checklist

- [x] Branch targets `develop`
- [x] `docs/dependencies-docs.md` unchanged (no new file dependencies)
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` not modified
