### PR TITLE
feat(p0b): confidence v1 — PCS/CTS/regime formula

### DIFF
--- a/engine/brain/conviction.py
+++ b/engine/brain/conviction.py
@@ -41,6 +41,16 @@ def _commitment_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
+def _confidence_v1(*, pcs: float, cts: float, regime: str | None) -> float:
+    # P0B.2 confidence v1: PCS/CTS/regime formula.
+    # Calibration tiering exists at forecast-level; calibrated remains False for now.
+    _regime = (regime or "TRANSITION").upper()
+    _regime_factor = {"BULL": 1.0, "BEAR": 0.85, "CHOP": 0.7, "TRANSITION": 0.8}.get(_regime, 0.8)
+    _pcs_component = (pcs - 50.0) / 50.0
+    _cts_penalty = cts / 200.0
+    return float(_clamp(0.5 + (_pcs_component * 0.5 * _regime_factor) - _cts_penalty, 0.1, 0.95))
+
+
 @dataclass(frozen=True, slots=True)
 class ConvictionResult:
     score: ConvictionScore
@@ -146,7 +156,7 @@ class ConvictionEngine:
             cts_score=cts,
             regime=regime,
             domains_used=sorted(list(synthesis.domain_scores.keys())),
-            confidence=float(_clamp((synthesis.snapshot.features and len(synthesis.snapshot.features) or 0) / 6.0, 0.0, 1.0)),
+            confidence=_confidence_v1(pcs=pcs, cts=cts, regime=synthesis.snapshot.regime),
         )
 
         return ConvictionResult(score=score, pcs=pcs, cts=cts, final_conviction=final)

--- a/tests/unit/test_conviction.py
+++ b/tests/unit/test_conviction.py
@@ -8,7 +8,9 @@ except ImportError:  # pragma: no cover
     UTC = UTC  # noqa: N806
 
 
-from engine.brain.conviction import ConvictionEngine
+import pytest
+
+from engine.brain.conviction import ConvictionEngine, _confidence_v1
 from engine.core.database import Database
 from engine.core.types import FeatureSnapshot
 from engine.security.identity import generate_node_identity
@@ -43,3 +45,46 @@ def test_pcs_calculation_and_cts_auto_trigger_at_pcs_gt_75(test_config, temp_dir
     assert res.pcs > 75.0
     assert res.cts > 0.0  # auto-triggered
     assert 0.0 <= res.final_conviction <= 100.0
+
+
+def test_confidence_bull_high_pcs() -> None:
+    confidence = _confidence_v1(pcs=80.0, cts=10.0, regime="BULL")
+    assert confidence == pytest.approx(0.75)
+
+
+def test_confidence_chop_dampens() -> None:
+    bull = _confidence_v1(pcs=80.0, cts=10.0, regime="BULL")
+    chop = _confidence_v1(pcs=80.0, cts=10.0, regime="CHOP")
+
+    assert chop == pytest.approx(0.66)
+    assert chop < bull
+
+
+def test_confidence_high_cts_penalty() -> None:
+    low_cts = _confidence_v1(pcs=80.0, cts=10.0, regime="BULL")
+    high_cts = _confidence_v1(pcs=80.0, cts=80.0, regime="BULL")
+
+    assert high_cts == pytest.approx(0.4)
+    assert high_cts < low_cts
+
+
+def test_confidence_bear_regime() -> None:
+    bull = _confidence_v1(pcs=80.0, cts=10.0, regime="BULL")
+    bear = _confidence_v1(pcs=80.0, cts=10.0, regime="BEAR")
+    chop = _confidence_v1(pcs=80.0, cts=10.0, regime="CHOP")
+
+    assert bear == pytest.approx(0.705)
+    assert chop < bear < bull
+
+
+def test_confidence_clamp_min() -> None:
+    confidence = _confidence_v1(pcs=-1000.0, cts=10000.0, regime="CHOP")
+    assert confidence == 0.1
+
+
+@pytest.mark.parametrize("regime", ["BULL", "BEAR", "CHOP", "TRANSITION", "CRISIS", None])
+def test_confidence_always_clamped_to_contract_bounds(regime: str | None) -> None:
+    for pcs in range(-200, 301, 25):
+        for cts in range(-100, 401, 25):
+            confidence = _confidence_v1(pcs=float(pcs), cts=float(cts), regime=regime)
+            assert 0.1 <= confidence <= 0.95


### PR DESCRIPTION
## Summary

Closes #168. Replaces `len(features)/6.0` data-coverage proxy with a real probability estimate: PCS component, CTS penalty, and regime dampening factor. Ships with `calibrated: False` (correct — no resolved forecasts yet).

## Formula
```
pcs_component = (pcs - 50.0) / 50.0
cts_penalty   = cts / 200.0
regime_factor = {BULL: 1.0, BEAR: 0.85, CHOP: 0.7, TRANSITION: 0.8}[regime]
confidence    = clamp(0.5 + (pcs_component * 0.5 * regime_factor) - cts_penalty, 0.1, 0.95)
```

## Type of Change
- [x] Bug fix

## Testing
- Parametric tests cover all 4 regimes, high/low PCS, high/low CTS, clamp boundaries