### PR TITLE
feat(p0b): per-producer attribution in conviction_log

### DIFF
--- a/engine/brain/conviction.py
+++ b/engine/brain/conviction.py
@@ -14,7 +14,7 @@ but expressed in the v3 event + types contract.
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 try:
@@ -47,6 +47,8 @@ class ConvictionResult:
     pcs: float
     cts: float
     final_conviction: float
+    domain_scores: dict[str, float] = field(default_factory=dict)
+    weights_used: dict[str, float] = field(default_factory=dict)
 
 
 class CounterThesis:
@@ -149,9 +151,25 @@ class ConvictionEngine:
             confidence=float(_clamp((synthesis.snapshot.features and len(synthesis.snapshot.features) or 0) / 6.0, 0.0, 1.0)),
         )
 
-        return ConvictionResult(score=score, pcs=pcs, cts=cts, final_conviction=final)
+        return ConvictionResult(
+            score=score,
+            pcs=pcs,
+            cts=cts,
+            final_conviction=final,
+            domain_scores=dict(synthesis.domain_scores),
+            weights_used=dict(synthesis.weights_used),
+        )
 
-    def emit(self, result: ConvictionResult, *, cycle_id: str, source: str = "brain.conviction") -> None:
+    def emit(
+        self,
+        result: ConvictionResult,
+        *,
+        cycle_id: str,
+        source: str = "brain.conviction",
+        producer_name: str = "",
+        event_id: str = "",
+        contribution_weight: float = 1.0,
+    ) -> None:
         p = {
             "symbol": result.score.symbol,
             "direction": result.score.direction,
@@ -165,7 +183,11 @@ class ConvictionEngine:
         }
         self.db.append_event(event_type=EventType.CONVICTION_V1, payload=p, source=source, trace_id=cycle_id)
 
-        # Also persist to conviction_scores table for learning.
+        producer = producer_name or ""
+        signal_event_id = event_id or ""
+        contribution = float(contribution_weight)
+
+        # Also persist to conviction_scores + conviction_log tables for learning.
         with self.db.conn:
             self.db.conn.execute(
                 """
@@ -190,3 +212,35 @@ class ConvictionEngine:
                     result.score.confidence,
                 ),
             )
+
+            for domain, domain_score in result.domain_scores.items():
+                domain_weight = float(result.weights_used.get(domain, 0.0))
+                weighted_contribution = float(domain_score) * domain_weight * contribution
+                self.db.conn.execute(
+                    """
+                    INSERT INTO conviction_log (
+                        cycle_id,
+                        symbol,
+                        domain,
+                        domain_score,
+                        domain_weight,
+                        weighted_contribution,
+                        producer_name,
+                        event_id,
+                        contribution_weight,
+                        ts
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        cycle_id,
+                        result.score.symbol,
+                        domain,
+                        float(domain_score),
+                        domain_weight,
+                        weighted_contribution,
+                        producer,
+                        signal_event_id,
+                        contribution,
+                        result.score.ts.isoformat(),
+                    ),
+                )

--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -237,11 +237,27 @@ CREATE TABLE IF NOT EXISTS conviction_log (
     domain_score REAL NOT NULL,
     domain_weight REAL NOT NULL,
     weighted_contribution REAL NOT NULL,
+    producer_name TEXT NOT NULL DEFAULT '',
+    event_id TEXT NOT NULL DEFAULT '',
+    contribution_weight REAL NOT NULL DEFAULT 1.0,
     ts TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_conviction_log_cycle ON conviction_log(cycle_id);
 CREATE INDEX IF NOT EXISTS idx_conviction_log_symbol ON conviction_log(symbol);
+
+CREATE TABLE IF NOT EXISTS forecast_attribution (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    forecast_id TEXT NOT NULL,
+    conviction_id TEXT NOT NULL,
+    position_id TEXT,
+    contribution_weight REAL NOT NULL,
+    disposition TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_forecast_attribution_forecast ON forecast_attribution(forecast_id);
+CREATE INDEX IF NOT EXISTS idx_forecast_attribution_conviction ON forecast_attribution(conviction_id);
 
 -- ============================================================
 -- Producer Health
@@ -500,6 +516,9 @@ class Database:
         self._ensure_column("events", "contributor_id", "TEXT")
         self._ensure_column("events", "hash_version", "INT DEFAULT 1")
         self._ensure_column("karma_intents", "contributor_id", "TEXT")
+        self._ensure_column("conviction_log", "producer_name", "TEXT NOT NULL DEFAULT ''")
+        self._ensure_column("conviction_log", "event_id", "TEXT NOT NULL DEFAULT ''")
+        self._ensure_column("conviction_log", "contribution_weight", "REAL NOT NULL DEFAULT 1.0")
         self._migrate_karma_intents_unique_trade_id()
 
     def _ensure_column(self, table: str, column: str, column_type: str) -> None:

--- a/tests/unit/test_conviction_attribution.py
+++ b/tests/unit/test_conviction_attribution.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    UTC = UTC  # noqa: N806
+
+
+import pytest
+
+from engine.brain.conviction import ConvictionEngine
+from engine.core.database import Database
+from engine.core.types import FeatureSnapshot
+from engine.security.identity import generate_node_identity
+
+
+def _build_result(*, engine: ConvictionEngine, cycle_id: str, symbol: str = "BTC"):
+    snapshot = FeatureSnapshot(
+        cycle_id=cycle_id,
+        symbol=symbol,
+        ts=datetime.now(tz=UTC),
+        features={
+            "tradfi": {"funding_annualized": 20.0, "basis_annualized": 4.0},
+            "technical": {"rsi_14": 55.0},
+        },
+        source_event_ids=["evt-1"],
+        regime="BULL",
+        version="v2",
+    )
+
+    synthesis = SimpleNamespace(
+        snapshot=snapshot,
+        domain_scores={"tradfi": 0.8, "technical": 0.6},
+        weights_used={"tradfi": 0.6, "technical": 0.4},
+        weighted_score=0.72,
+    )
+
+    return engine.compute(synthesis=synthesis, regime="BULL", as_of=datetime.now(tz=UTC))
+
+
+def test_emit_persists_producer_attribution_fields(test_config, temp_dir, monkeypatch):
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    result = _build_result(engine=eng, cycle_id="cycle-attr")
+    eng.emit(
+        result,
+        cycle_id="cycle-attr",
+        producer_name="producer.social",
+        event_id="signal-social-123",
+        contribution_weight=0.6,
+    )
+
+    rows = db.conn.execute(
+        """
+        SELECT producer_name, event_id, contribution_weight
+        FROM conviction_log
+        WHERE cycle_id = ?
+        """,
+        ("cycle-attr",),
+    ).fetchall()
+
+    assert len(rows) == 2
+    assert all(str(r["producer_name"]) == "producer.social" for r in rows)
+    assert all(str(r["event_id"]) == "signal-social-123" for r in rows)
+    assert all(float(r["contribution_weight"]) == pytest.approx(0.6) for r in rows)
+
+
+def test_forecast_attribution_table_exists_and_accepts_row(temp_dir):
+    db = Database(temp_dir / "brain.db")
+
+    with db.conn:
+        db.conn.execute(
+            """
+            INSERT INTO forecast_attribution (
+                forecast_id,
+                conviction_id,
+                position_id,
+                contribution_weight,
+                disposition
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            ("forecast-1", "conviction-1", None, 0.75, "included"),
+        )
+
+    row = db.conn.execute(
+        """
+        SELECT forecast_id, conviction_id, position_id, contribution_weight, disposition
+        FROM forecast_attribution
+        WHERE forecast_id = ?
+        """,
+        ("forecast-1",),
+    ).fetchone()
+
+    assert row is not None
+    assert str(row["forecast_id"]) == "forecast-1"
+    assert str(row["conviction_id"]) == "conviction-1"
+    assert row["position_id"] is None
+    assert float(row["contribution_weight"]) == pytest.approx(0.75)
+    assert str(row["disposition"]) == "included"
+
+
+def test_emit_defaults_keep_backward_compatibility(test_config, temp_dir, monkeypatch):
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    result = _build_result(engine=eng, cycle_id="cycle-default")
+    eng.emit(result, cycle_id="cycle-default")
+
+    rows = db.conn.execute(
+        """
+        SELECT producer_name, event_id, contribution_weight
+        FROM conviction_log
+        WHERE cycle_id = ?
+        """,
+        ("cycle-default",),
+    ).fetchall()
+
+    assert len(rows) == 2
+    assert all(str(r["producer_name"]) == "" for r in rows)
+    assert all(str(r["event_id"]) == "" for r in rows)
+    assert all(float(r["contribution_weight"]) == pytest.approx(1.0) for r in rows)


### PR DESCRIPTION
## Summary

Adds per-producer attribution fields to `conviction_log` and introduces `forecast_attribution` to connect forecast → conviction (→ position) attribution records.

Closes #167

---

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

- Added `producer_name`, `event_id`, and `contribution_weight` (with safe defaults) to `conviction_log` schema.
- Added new `forecast_attribution` table and indexes on `forecast_id` and `conviction_id`.
- Added additive SQLite migration guards in `Database._init_schema()` via `_ensure_column(...)` for existing DBs.
- Extended `ConvictionEngine.emit(...)` with optional `producer_name`, `event_id`, and `contribution_weight` params (backward compatible defaults).
- Added conviction log writes in `emit(...)` for per-domain attribution rows including producer/event metadata.
- Added `tests/unit/test_conviction_attribution.py` covering producer attribution insert, forecast table insert, and default backward compatibility.

---

## Tests

- [x] New tests added (or explain why not needed)
- [ ] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `173` passing (`1` failing: `tests/unit/test_b1e55ing.py::test_main_apply_eggs_mode_applies_from_json`)

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [ ] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
