### PR TITLE
feat(p1): signal age decay in synthesis

### DIFF
--- a/engine/brain/synthesis.py
+++ b/engine/brain/synthesis.py
@@ -12,6 +12,7 @@ This module ports the *v2* synthesis philosophy from the legacy system:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -36,6 +37,21 @@ def _mean(xs: list[float]) -> float | None:
     if not xs:
         return None
     return float(sum(xs) / len(xs))
+
+
+_DEFAULT_DECAY_LAMBDA = 0.01  # half-life ~70 minutes
+
+
+def _freshness_factor(event_ts: datetime, now: datetime, lambda_: float = _DEFAULT_DECAY_LAMBDA) -> float:
+    """Exponential freshness decay: exp(-λ × age_minutes). Clamped to [0.01, 1.0]."""
+    if event_ts.tzinfo is None:
+        event_ts = event_ts.replace(tzinfo=UTC)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+
+    age_minutes = max(0.0, (now - event_ts).total_seconds() / 60.0)
+    factor = math.exp(-lambda_ * age_minutes)
+    return max(0.01, min(1.0, factor))
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,7 +226,11 @@ class VectorSynthesis:
             vec = self.extractor.extract_domain_features(event_type=et, payload=chosen.payload)
             if not vec:
                 continue
-            feats[dom].update(vec)
+
+            factor = _freshness_factor(chosen.ts, now)
+            decayed_vec = {k: float(v) * factor for k, v in vec.items()}
+
+            feats[dom].update(decayed_vec)
             source_event_ids.append(chosen.id)
 
         # Drop empty domains to keep snapshot compact.

--- a/tests/unit/test_synthesis.py
+++ b/tests/unit/test_synthesis.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import pytest
+
 try:
     from datetime import UTC  # py311+
 except ImportError:  # pragma: no cover
     UTC = UTC  # noqa: N806
 
 
-from engine.brain.synthesis import VectorSynthesis
+from engine.brain.synthesis import VectorSynthesis, _freshness_factor
 from engine.core.database import Database
 from engine.core.events import EventType
 
@@ -94,3 +96,45 @@ def test_synthesis_missing_domain_degrades_gracefully(test_config, temp_dir):
     assert set(res.snapshot.features) == {"technical"}
     assert "technical" in res.domain_scores
     assert res.weighted_score == res.domain_scores["technical"]
+
+
+def test_freshness_factor_at_zero_age():
+    now = datetime.now(tz=UTC)
+    assert _freshness_factor(now, now) == 1.0
+
+
+def test_freshness_factor_at_70_min():
+    now = datetime.now(tz=UTC)
+    event_ts = now - timedelta(minutes=70)
+    assert _freshness_factor(event_ts, now) == pytest.approx(0.5, abs=0.01)
+
+
+def test_freshness_factor_at_large_age():
+    now = datetime.now(tz=UTC)
+    event_ts = now - timedelta(minutes=1000)
+    assert _freshness_factor(event_ts, now) == 0.01
+
+
+def test_synthesis_applies_decay_to_stale_events(test_config, temp_dir):
+    now = datetime.now(tz=UTC)
+
+    fresh_db = Database(temp_dir / "fresh.db")
+    stale_db = Database(temp_dir / "stale.db")
+
+    payload = {"symbol": "BTC", "direction": "neutral", "conviction": 10.0, "rationale": ""}
+
+    fresh_db.append_event(
+        event_type=EventType.SIGNAL_CURATOR_V1,
+        payload=payload,
+        ts=now,
+    )
+    stale_db.append_event(
+        event_type=EventType.SIGNAL_CURATOR_V1,
+        payload=payload,
+        ts=now - timedelta(hours=3),
+    )
+
+    fresh_res = VectorSynthesis(test_config, fresh_db).synthesize(cycle_id="fresh", symbol="BTC", as_of=now)
+    stale_res = VectorSynthesis(test_config, stale_db).synthesize(cycle_id="stale", symbol="BTC", as_of=now)
+
+    assert stale_res.domain_scores["curator"] < fresh_res.domain_scores["curator"]


### PR DESCRIPTION
## Summary

Closes #170. Adds `exp(-λ × age_minutes)` freshness factor to synthesis. A tradfi signal from 4h ago and an onchain signal from 30 seconds ago are no longer weighted equally. Default λ=0.01 (half-life ~70 min).

## Type of Change
- [x] New feature

## Testing
- Half-life property test
- Stale vs fresh event comparison