### PR TITLE
feat(p1): per-asset regime detection

### DIFF
--- a/engine/brain/regime.py
+++ b/engine/brain/regime.py
@@ -128,6 +128,99 @@ class RegimeDetector:
 
         return RegimeResult(state=state, changed=changed, previous=prev)
 
+    def detect_for_asset(self, snapshot: FeatureSnapshot) -> RegimeResult:
+        """Compute regime for a single asset using its own feature snapshot.
+
+        Uses asset-specific technical/tradfi features and falls back to the
+        last known global regime when no usable indicators are present.
+        """
+        now = snapshot.ts
+
+        tech = snapshot.features.get("technical", {})
+        tradfi = snapshot.features.get("tradfi", {})
+        social = snapshot.features.get("social", {})
+
+        rsi = _to_float(tech.get("rsi_14"))
+        ema_20 = _to_float(tech.get("ema_20"))
+        ema_50 = _to_float(tech.get("ema_50"))
+        ema_200 = _to_float(tech.get("ema_200"))
+
+        funding = _to_float(tradfi.get("funding_annualized"))
+        basis = _to_float(tradfi.get("basis_annualized"))
+        fear_greed = _to_float(social.get("fear_greed"))
+
+        evidence: dict[str, float] = {}
+        if rsi is not None:
+            evidence["rsi_14"] = rsi
+        if ema_20 is not None:
+            evidence["ema_20"] = ema_20
+        if ema_50 is not None:
+            evidence["ema_50"] = ema_50
+        if ema_200 is not None:
+            evidence["ema_200"] = ema_200
+        if funding is not None:
+            evidence["funding_annualized"] = funding
+        if basis is not None:
+            evidence["basis_annualized"] = basis
+        if fear_greed is not None:
+            evidence["fear_greed"] = fear_greed
+
+        prev = self._last_regime
+
+        # No usable indicators: carry forward last known global regime, else
+        # default to TRANSITION for deterministic behavior.
+        if not evidence:
+            regime = prev or "TRANSITION"
+            state = RegimeState(regime=regime, ts=now, evidence=evidence)
+            changed = prev is not None and prev != regime
+            return RegimeResult(state=state, changed=changed, previous=prev)
+
+        bull = 0
+        bear = 0
+
+        # Crisis should trigger on extreme stress from any key indicator.
+        crisis = (funding is not None and funding < -0.05) or (rsi is not None and rsi < 20.0)
+
+        # Bullish evidence: positive momentum + healthy basis/funding/EMA trend.
+        if rsi is not None and rsi > 55.0:
+            bull += 1
+        if basis is not None and basis > 3.0:
+            bull += 1
+        if funding is not None and funding > 0.0:
+            bull += 1
+        if ema_20 is not None and ema_50 is not None and ema_20 > ema_50:
+            bull += 1
+        if ema_50 is not None and ema_200 is not None and ema_50 > ema_200:
+            bull += 1
+
+        # Bearish evidence: weak momentum + negative funding/structure.
+        if rsi is not None and rsi < 45.0:
+            bear += 1
+        if funding is not None and funding < 0.0:
+            bear += 1
+        if basis is not None and basis < 2.0:
+            bear += 1
+        if ema_20 is not None and ema_50 is not None and ema_20 < ema_50:
+            bear += 1
+        if ema_50 is not None and ema_200 is not None and ema_50 < ema_200:
+            bear += 1
+        if fear_greed is not None and fear_greed < 25.0:
+            bear += 1
+
+        if crisis:
+            regime = "CRISIS"
+        elif bull >= 2 and bull > bear:
+            regime = "BULL"
+        elif bear >= 2 and bear >= bull:
+            regime = "BEAR"
+        else:
+            regime = "TRANSITION"
+
+        state = RegimeState(regime=regime, ts=now, evidence=evidence)
+        changed = prev is not None and prev != regime
+
+        return RegimeResult(state=state, changed=changed, previous=prev)
+
     def emit_if_changed(self, result: RegimeResult, *, source: str = "brain.regime") -> None:
         if not result.changed:
             return

--- a/engine/brain/synthesis.py
+++ b/engine/brain/synthesis.py
@@ -46,6 +46,7 @@ class SynthesisResult:
     domain_scores: dict[str, float]  # 0..1 per domain (only domains with features)
     weights_used: dict[str, float]  # domain -> weight used this cycle (after quality adjustment)
     weighted_score: float  # 0..1 (domain_scores ⋅ weights_used)
+    regime_tag: str = "unknown"  # per-asset regime (populated by synthesize_with_regime)
 
 
 class FeatureExtractor:
@@ -399,4 +400,36 @@ class VectorSynthesis:
             domain_scores=domain_scores,
             weights_used=weights_used,
             weighted_score=_clamp01(weighted_score),
+        )
+
+    def synthesize_with_regime(
+        self,
+        *,
+        cycle_id: str,
+        symbol: str,
+        quality_adjustment: dict[str, float] | None,
+        regime_detector: Any,
+        as_of: datetime | None = None,
+        weights: dict[str, float] | None = None,
+    ) -> SynthesisResult:
+        """Run synthesis and attach a per-asset regime tag.
+
+        Existing callers can continue using ``synthesize()``; this method is an
+        additive convenience for pipelines that need symbol-local regime tags.
+        """
+        result = self.synthesize(
+            cycle_id=cycle_id,
+            symbol=symbol,
+            as_of=as_of,
+            weights=weights,
+            quality_adjustment=quality_adjustment,
+        )
+        regime_result = regime_detector.detect_for_asset(result.snapshot)
+
+        return SynthesisResult(
+            snapshot=result.snapshot,
+            domain_scores=result.domain_scores,
+            weights_used=result.weights_used,
+            weighted_score=result.weighted_score,
+            regime_tag=regime_result.state.regime,
         )

--- a/tests/unit/test_per_asset_regime.py
+++ b/tests/unit/test_per_asset_regime.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    UTC = UTC  # noqa: N806
+
+
+from engine.brain.regime import RegimeDetector
+from engine.brain.synthesis import SynthesisResult, VectorSynthesis
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.core.types import FeatureSnapshot
+
+
+def _snapshot(symbol: str, features: dict[str, dict[str, float]]) -> FeatureSnapshot:
+    return FeatureSnapshot(
+        cycle_id="cycle-1",
+        symbol=symbol,
+        ts=datetime.now(tz=UTC),
+        features=features,
+        source_event_ids=[],
+        regime=None,
+        version="v2",
+    )
+
+
+def test_detect_for_asset_bull(temp_dir):
+    db = Database(temp_dir / "brain.db")
+    detector = RegimeDetector(db)
+
+    snap = _snapshot(
+        "ETH",
+        {
+            "technical": {"rsi_14": 62.0, "ema_20": 2550.0, "ema_50": 2480.0},
+            "tradfi": {"funding_annualized": 0.02, "basis_annualized": 4.2},
+        },
+    )
+
+    result = detector.detect_for_asset(snap)
+    assert result.state.regime == "BULL"
+
+
+def test_detect_for_asset_bear(temp_dir):
+    db = Database(temp_dir / "brain.db")
+    detector = RegimeDetector(db)
+
+    snap = _snapshot(
+        "SOL",
+        {
+            "technical": {"rsi_14": 40.0, "ema_20": 130.0, "ema_50": 140.0},
+            "tradfi": {"funding_annualized": -0.01, "basis_annualized": 1.8},
+        },
+    )
+
+    result = detector.detect_for_asset(snap)
+    assert result.state.regime in {"BEAR", "TRANSITION"}
+
+
+def test_detect_for_asset_no_features(temp_dir):
+    db = Database(temp_dir / "brain.db")
+    detector = RegimeDetector(db)
+
+    # Seed last known global regime to exercise fallback behavior.
+    global_bull = _snapshot(
+        "BTC",
+        {
+            "technical": {"rsi_14": 56.0},
+            "tradfi": {"funding_annualized": 10.0, "basis_annualized": 5.0},
+            "social": {"fear_greed": 50.0},
+        },
+    )
+    detector.detect(as_of=global_bull.ts, btc_snapshot=global_bull)
+
+    empty = _snapshot("ETH", {})
+    result = detector.detect_for_asset(empty)
+
+    assert result.state.regime == "BULL"
+    assert result.previous == "BULL"
+
+
+def test_synthesis_result_has_regime_tag():
+    result = SynthesisResult(
+        snapshot=_snapshot("BTC", {}),
+        domain_scores={},
+        weights_used={},
+        weighted_score=0.0,
+    )
+
+    assert result.regime_tag == "unknown"
+
+
+def test_synthesize_with_regime_returns_regime_tag(test_config, temp_dir):
+    db = Database(temp_dir / "brain.db")
+    now = datetime.now(tz=UTC)
+
+    db.append_event(
+        event_type=EventType.SIGNAL_TA_V1,
+        payload={"symbol": "ETH", "rsi_14": 63.0, "ema_20": 2550.0, "ema_50": 2480.0},
+        ts=now,
+    )
+    db.append_event(
+        event_type=EventType.SIGNAL_TRADFI_V1,
+        payload={"symbol": "ETH", "funding_annualized": 0.02, "basis_annualized": 4.1},
+        ts=now,
+    )
+
+    synth = VectorSynthesis(test_config, db)
+    detector = RegimeDetector(db)
+
+    result = synth.synthesize_with_regime(
+        cycle_id="cycle-with-regime",
+        symbol="ETH",
+        as_of=now,
+        quality_adjustment=None,
+        regime_detector=detector,
+    )
+
+    assert result.regime_tag != "unknown"
+    assert result.regime_tag == "BULL"


### PR DESCRIPTION
## Summary

Closes #171. BTC regime no longer forces ETH/SOL. Adds `detect_for_asset()` to `RegimeDetector` and `regime_tag` field to `SynthesisResult`. All changes additive — existing callers unaffected.

## Type of Change
- [x] New feature

## Testing
- Per-asset detection: bull/bear/no-features fallback
- SynthesisResult carries regime_tag