### PR TITLE
feat(p1): feature_key/feature_value in conviction_log

### DIFF
--- a/engine/brain/conviction.py
+++ b/engine/brain/conviction.py
@@ -28,7 +28,7 @@ from engine.brain.synthesis import SynthesisResult
 from engine.core.config import Config
 from engine.core.database import Database
 from engine.core.events import EventType, canonical_json
-from engine.core.types import ConvictionScore
+from engine.core.types import ConvictionScore, FeatureSnapshot
 
 
 def _clamp(x: float, lo: float, hi: float) -> float:
@@ -61,6 +61,7 @@ class ConvictionResult:
     final_conviction: float
     domain_scores: dict[str, float] = field(default_factory=dict)
     weights_used: dict[str, float] = field(default_factory=dict)
+    snapshot: FeatureSnapshot | None = None
 
 
 # Kahneman's System 2: the slow, deliberate override that checks fast pattern recognition.
@@ -172,6 +173,7 @@ class ConvictionEngine:
             final_conviction=final,
             domain_scores=dict(synthesis.domain_scores),
             weights_used=dict(synthesis.weights_used),
+            snapshot=synthesis.snapshot,
         )
 
     def emit(
@@ -230,6 +232,15 @@ class ConvictionEngine:
             for domain, domain_score in result.domain_scores.items():
                 domain_weight = float(result.weights_used.get(domain, 0.0))
                 weighted_contribution = float(domain_score) * domain_weight * contribution
+
+                feature_key: str | None = None
+                feature_value: float | None = None
+                if result.snapshot is not None:
+                    domain_features = result.snapshot.features.get(domain, {})
+                    if domain_features:
+                        feature_key, feature_value = max(domain_features.items(), key=lambda kv: abs(kv[1]))
+                        feature_value = float(feature_value)
+
                 self.db.conn.execute(
                     """
                     INSERT INTO conviction_log (
@@ -242,8 +253,10 @@ class ConvictionEngine:
                         producer_name,
                         event_id,
                         contribution_weight,
+                        feature_key,
+                        feature_value,
                         ts
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         cycle_id,
@@ -255,6 +268,8 @@ class ConvictionEngine:
                         producer,
                         signal_event_id,
                         contribution,
+                        feature_key,
+                        feature_value,
                         result.score.ts.isoformat(),
                     ),
                 )

--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -240,6 +240,8 @@ CREATE TABLE IF NOT EXISTS conviction_log (
     producer_name TEXT NOT NULL DEFAULT '',
     event_id TEXT NOT NULL DEFAULT '',
     contribution_weight REAL NOT NULL DEFAULT 1.0,
+    feature_key TEXT,
+    feature_value REAL,
     ts TEXT NOT NULL
 );
 
@@ -519,6 +521,8 @@ class Database:
         self._ensure_column("conviction_log", "producer_name", "TEXT NOT NULL DEFAULT ''")
         self._ensure_column("conviction_log", "event_id", "TEXT NOT NULL DEFAULT ''")
         self._ensure_column("conviction_log", "contribution_weight", "REAL NOT NULL DEFAULT 1.0")
+        self._ensure_column("conviction_log", "feature_key", "TEXT")
+        self._ensure_column("conviction_log", "feature_value", "REAL")
         self._migrate_karma_intents_unique_trade_id()
 
     def _ensure_column(self, table: str, column: str, column_type: str) -> None:

--- a/tests/unit/test_conviction_attribution.py
+++ b/tests/unit/test_conviction_attribution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime
 from types import SimpleNamespace
 
@@ -129,3 +130,93 @@ def test_emit_defaults_keep_backward_compatibility(test_config, temp_dir, monkey
     assert all(str(r["producer_name"]) == "" for r in rows)
     assert all(str(r["event_id"]) == "" for r in rows)
     assert all(float(r["contribution_weight"]) == pytest.approx(1.0) for r in rows)
+
+
+def test_feature_key_populated_in_conviction_log(test_config, temp_dir, monkeypatch):
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    result = _build_result(engine=eng, cycle_id="cycle-features")
+    eng.emit(result, cycle_id="cycle-features")
+
+    rows = db.conn.execute(
+        """
+        SELECT domain, feature_key, feature_value
+        FROM conviction_log
+        WHERE cycle_id = ?
+        ORDER BY domain
+        """,
+        ("cycle-features",),
+    ).fetchall()
+
+    assert len(rows) == 2
+    observed = {str(r["domain"]): (r["feature_key"], float(r["feature_value"]) if r["feature_value"] is not None else None) for r in rows}
+    assert observed["technical"] == ("rsi_14", pytest.approx(55.0))
+    assert observed["tradfi"] == ("funding_annualized", pytest.approx(20.0))
+
+
+def test_feature_key_null_when_no_snapshot(test_config, temp_dir, monkeypatch):
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    result = replace(_build_result(engine=eng, cycle_id="cycle-null-features"), snapshot=None)
+    eng.emit(result, cycle_id="cycle-null-features")
+
+    rows = db.conn.execute(
+        """
+        SELECT feature_key, feature_value
+        FROM conviction_log
+        WHERE cycle_id = ?
+        """,
+        ("cycle-null-features",),
+    ).fetchall()
+
+    assert len(rows) == 2
+    assert all(r["feature_key"] is None for r in rows)
+    assert all(r["feature_value"] is None for r in rows)
+
+
+def test_primary_feature_is_max_absolute_value(test_config, temp_dir, monkeypatch):
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    base = _build_result(engine=eng, cycle_id="cycle-primary-feature")
+    custom_snapshot = FeatureSnapshot(
+        cycle_id="cycle-primary-feature",
+        symbol="BTC",
+        ts=datetime.now(tz=UTC),
+        features={"tradfi": {"rsi": 0.3, "macd": 0.8, "ema": -0.9}},
+        source_event_ids=["evt-1"],
+        regime="BULL",
+        version="v2",
+    )
+    result = replace(
+        base,
+        domain_scores={"tradfi": base.domain_scores["tradfi"]},
+        weights_used={"tradfi": base.weights_used["tradfi"]},
+        snapshot=custom_snapshot,
+    )
+
+    eng.emit(result, cycle_id="cycle-primary-feature")
+
+    row = db.conn.execute(
+        """
+        SELECT feature_key, feature_value
+        FROM conviction_log
+        WHERE cycle_id = ? AND domain = 'tradfi'
+        """,
+        ("cycle-primary-feature",),
+    ).fetchone()
+
+    assert row is not None
+    assert str(row["feature_key"]) == "ema"
+    assert float(row["feature_value"]) == pytest.approx(-0.9)


### PR DESCRIPTION
## Summary

Adds `feature_key` and `feature_value` introspection columns to `conviction_log` and records the primary per-domain feature (max absolute value) at conviction emission time so attribution can answer which specific signal drove a call.

Closes #173

---

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [x] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

- Added nullable `feature_key` (`TEXT`) and `feature_value` (`REAL`) to `conviction_log` schema in `engine/core/database.py`.
- Added SQLite additive migration guards via `_ensure_column(...)` for `conviction_log.feature_key` and `conviction_log.feature_value`.
- Extended `ConvictionResult` with `snapshot: FeatureSnapshot | None` in `engine/brain/conviction.py`.
- Passed `snapshot=synthesis.snapshot` when building `ConvictionResult` in `ConvictionEngine.compute()`.
- Extended `ConvictionEngine.emit()` to compute the primary domain feature as `max(abs(value))` and persist `feature_key/feature_value` in each `conviction_log` row.
- Added tests in `tests/unit/test_conviction_attribution.py` for populated feature attribution, NULL-safe behavior with no snapshot, and max-absolute feature selection.

---

## Tests

- [x] New tests added (or explain why not needed)
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `740` passing

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [x] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
