### PR TITLE
feat(p1): counter-thesis at all PCS levels + regime conviction caps

### DIFF
--- a/engine/brain/conviction.py
+++ b/engine/brain/conviction.py
@@ -41,6 +41,15 @@ def _commitment_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
+# Regime-dependent hard caps on conviction magnitude (0-10 scale).
+_REGIME_CAPS: dict[str, float] = {
+    "BULL": 10.0,
+    "BEAR": 7.0,
+    "TRANSITION": 6.0,
+    "CRISIS": 4.0,
+}
+
+
 # Philip Brier proposed (confidence - outcome)^2 as the scoring rule in 1950.
 # Lower is better. This formula is the hypothesis. That score is the verdict.
 def _confidence_v1(*, pcs: float, cts: float, regime: str | None) -> float:
@@ -62,6 +71,8 @@ class ConvictionResult:
     domain_scores: dict[str, float] = field(default_factory=dict)
     weights_used: dict[str, float] = field(default_factory=dict)
     snapshot: FeatureSnapshot | None = None
+    capped_by_regime: bool = False
+    pre_cap_magnitude: float | None = None
 
 
 # Kahneman's System 2: the slow, deliberate override that checks fast pattern recognition.
@@ -96,9 +107,9 @@ class CounterThesis:
         if regime == "CRISIS":
             penalties.append(30.0)
 
-        # If PCS is high and we have any explicit contradictions, CTS ramps.
+        # If we have any explicit contradictions, CTS ramps.
         base = sum(penalties)
-        if pcs > 75.0 and base > 0:
+        if base > 0:
             base += 10.0
 
         return float(_clamp(base, 0.0, 100.0))
@@ -123,7 +134,7 @@ class ConvictionEngine:
 
         # PCS is 0..100
         pcs = float(_clamp(synthesis.weighted_score * 100.0, 0.0, 100.0))
-        cts = float(self.counter_thesis.compute(synthesis=synthesis, pcs=pcs, regime=regime) if pcs > 75.0 else 0.0)
+        cts = float(self.counter_thesis.compute(synthesis=synthesis, pcs=pcs, regime=regime))
 
         # Final conviction: penalize PCS by up to 50% (cts=100 => -50%)
         final = float(_clamp(pcs * (1.0 - cts / 200.0), 0.0, 100.0))
@@ -138,6 +149,12 @@ class ConvictionEngine:
             direction = "neutral"
 
         magnitude = float(_clamp(abs(final - 50.0) / 5.0, 0.0, 10.0))
+
+        regime_key = regime.upper() if regime else "TRANSITION"
+        cap = _REGIME_CAPS.get(regime_key, _REGIME_CAPS["TRANSITION"])
+        capped_by_regime = magnitude > cap
+        pre_cap_magnitude = magnitude if capped_by_regime else None
+        magnitude = min(magnitude, cap)
 
         payload_wo_commit = {
             "symbol": synthesis.snapshot.symbol,
@@ -174,6 +191,8 @@ class ConvictionEngine:
             domain_scores=dict(synthesis.domain_scores),
             weights_used=dict(synthesis.weights_used),
             snapshot=synthesis.snapshot,
+            capped_by_regime=capped_by_regime,
+            pre_cap_magnitude=pre_cap_magnitude,
         )
 
     def emit(

--- a/tests/unit/test_conviction.py
+++ b/tests/unit/test_conviction.py
@@ -16,6 +16,35 @@ from engine.core.types import FeatureSnapshot
 from engine.security.identity import generate_node_identity
 
 
+def _build_engine(test_config, temp_dir, monkeypatch) -> ConvictionEngine:
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+    db = Database(temp_dir / "brain.db")
+    return ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+
+def _build_synthesis(*, weighted_score: float, features: dict[str, dict[str, float]]):
+    snap = FeatureSnapshot(
+        cycle_id="c",
+        symbol="BTC",
+        ts=datetime.now(tz=UTC),
+        features=features,
+        source_event_ids=[],
+        regime=None,
+        version="v2",
+    )
+
+    class _Synth:
+        pass
+
+    synth = _Synth()
+    synth.snapshot = snap
+    synth.domain_scores = {domain: 1.0 for domain in features}
+    synth.weights_used = {domain: (1.0 / len(features) if features else 0.0) for domain in features}
+    synth.weighted_score = weighted_score
+    return synth
+
+
 def test_pcs_calculation_and_cts_auto_trigger_at_pcs_gt_75(test_config, temp_dir, monkeypatch):
     # Identity requires password env; set for test.
     monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
@@ -45,6 +74,87 @@ def test_pcs_calculation_and_cts_auto_trigger_at_pcs_gt_75(test_config, temp_dir
     assert res.pcs > 75.0
     assert res.cts > 0.0  # auto-triggered
     assert 0.0 <= res.final_conviction <= 100.0
+
+
+def test_counter_thesis_fires_below_pcs_75(test_config, temp_dir, monkeypatch) -> None:
+    eng = _build_engine(test_config, temp_dir, monkeypatch)
+    synth = _build_synthesis(
+        weighted_score=0.60,
+        features={"technical": {"rsi_14": 75.0}},
+    )
+
+    res = eng.compute(synthesis=synth, regime="BULL", as_of=datetime.now(tz=UTC))
+
+    assert res.pcs < 75.0
+    assert res.cts > 0.0
+
+
+def test_counter_thesis_fires_above_pcs_75(test_config, temp_dir, monkeypatch) -> None:
+    eng = _build_engine(test_config, temp_dir, monkeypatch)
+    synth = _build_synthesis(
+        weighted_score=0.80,
+        features={"technical": {"rsi_14": 75.0}},
+    )
+
+    res = eng.compute(synthesis=synth, regime="BULL", as_of=datetime.now(tz=UTC))
+
+    assert res.pcs > 75.0
+    assert res.cts > 0.0
+
+
+def test_regime_cap_bear(test_config, temp_dir, monkeypatch) -> None:
+    eng = _build_engine(test_config, temp_dir, monkeypatch)
+    synth = _build_synthesis(
+        weighted_score=1.0,
+        features={"technical": {"rsi_14": 50.0}},
+    )
+
+    res = eng.compute(synthesis=synth, regime="BEAR", as_of=datetime.now(tz=UTC))
+
+    assert res.score.magnitude == pytest.approx(7.0)
+    assert res.capped_by_regime is True
+    assert res.pre_cap_magnitude == pytest.approx(10.0)
+
+
+def test_regime_cap_crisis(test_config, temp_dir, monkeypatch) -> None:
+    eng = _build_engine(test_config, temp_dir, monkeypatch)
+    synth = _build_synthesis(
+        weighted_score=1.0,
+        features={"technical": {"rsi_14": 50.0}},
+    )
+
+    res = eng.compute(synthesis=synth, regime="CRISIS", as_of=datetime.now(tz=UTC))
+
+    assert res.score.magnitude == pytest.approx(4.0)
+    assert res.capped_by_regime is True
+
+
+def test_regime_cap_bull_no_cap(test_config, temp_dir, monkeypatch) -> None:
+    eng = _build_engine(test_config, temp_dir, monkeypatch)
+    synth = _build_synthesis(
+        weighted_score=1.0,
+        features={"technical": {"rsi_14": 50.0}},
+    )
+
+    res = eng.compute(synthesis=synth, regime="BULL", as_of=datetime.now(tz=UTC))
+
+    assert res.score.magnitude == pytest.approx(10.0)
+    assert res.capped_by_regime is False
+    assert res.pre_cap_magnitude is None
+
+
+def test_capped_by_regime_flag_set(test_config, temp_dir, monkeypatch) -> None:
+    eng = _build_engine(test_config, temp_dir, monkeypatch)
+    synth = _build_synthesis(
+        weighted_score=0.95,
+        features={"technical": {"rsi_14": 50.0}},
+    )
+
+    res = eng.compute(synthesis=synth, regime="TRANSITION", as_of=datetime.now(tz=UTC))
+
+    assert res.capped_by_regime is True
+    assert res.pre_cap_magnitude is not None
+    assert res.pre_cap_magnitude > res.score.magnitude
 
 
 def test_confidence_bull_high_pcs() -> None:


### PR DESCRIPTION
## Summary

Counter-thesis now fires at all PCS levels, and conviction magnitude is hard-capped by regime to enforce prior risk limits.

Closes #172

---

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

- Removed the PCS>75 gate in `CounterThesis.compute()` so explicit contradictions produce CTS at all PCS levels.
- Removed the PCS>75 gate in `ConvictionEngine.compute()` so CTS is always computed.
- Added module-level `_REGIME_CAPS` and applied regime hard caps to conviction `magnitude` (`BULL=10`, `BEAR=7`, `TRANSITION=6`, `CRISIS=4`).
- Added `capped_by_regime` and `pre_cap_magnitude` fields to `ConvictionResult` for post-hoc learning/auditability.
- Added unit tests for CTS behavior below/above PCS 75 and regime cap behavior/flags.

---

## Tests

- [x] New tests added (or explain why not needed)
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `743` passing

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [x] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
