### PR TITLE
feat(p1): BRAIN_CYCLE_V1 full-state snapshot — single-event reconstructability

### DIFF
--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -24,6 +24,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
+from time import perf_counter
 
 try:
     from datetime import UTC  # py311+
@@ -89,7 +90,10 @@ class BrainOrchestrator:
             raise RuntimeError(f"Brain cycle blocked by kill switch (level={ks_level})")
 
         cycle_id = str(uuid.uuid4())
-        now = datetime.now(tz=UTC)
+        cycle_started_at = datetime.now(tz=UTC)
+        cycle_started_perf = perf_counter()
+        now = cycle_started_at
+        symbols_upper = [s.upper() for s in symbols]
 
         self.hooks.pre_cycle(PreCycleContext(config=self.config, db=self.db, cycle_id=cycle_id))
 
@@ -118,24 +122,42 @@ class BrainOrchestrator:
         except Exception:
             logging.getLogger("b1e55ed.orchestrator").warning("KS-4 degradation check failed", exc_info=True)
 
-        # Emit a cycle marker (useful for auditing)
-        self.db.append_event(
-            event_type=EventType.BRAIN_CYCLE_V1,
-            payload={"cycle_id": cycle_id, "symbols": [s.upper() for s in symbols]},
-            source="brain.orchestrator",
-            trace_id=cycle_id,
-        )
-
         synth_results: dict[str, SynthesisResult] = {}
+        synthesize_with_regime = getattr(self.synthesis, "synthesize_with_regime", None)
+
         for sym in symbols:
-            synth_results[sym.upper()] = self.synthesis.synthesize(
-                cycle_id=cycle_id,
-                symbol=sym,
-                as_of=now,
-                quality_adjustment=q_mult,
-            )
+            sym_upper = sym.upper()
+            if callable(synthesize_with_regime):
+                try:
+                    synth_results[sym_upper] = synthesize_with_regime(
+                        cycle_id=cycle_id,
+                        symbol=sym,
+                        as_of=now,
+                        quality_adjustment=q_mult,
+                        regime_detector=self.regime,
+                    )
+                except Exception:
+                    logging.getLogger("b1e55ed.orchestrator").warning(
+                        "synthesize_with_regime failed for %s; falling back to synthesize()",
+                        sym_upper,
+                        exc_info=True,
+                    )
+                    synth_results[sym_upper] = self.synthesis.synthesize(
+                        cycle_id=cycle_id,
+                        symbol=sym,
+                        as_of=now,
+                        quality_adjustment=q_mult,
+                    )
+            else:
+                synth_results[sym_upper] = self.synthesis.synthesize(
+                    cycle_id=cycle_id,
+                    symbol=sym,
+                    as_of=now,
+                    quality_adjustment=q_mult,
+                )
+
             # Persist feature snapshot row (reproducibility)
-            snap = synth_results[sym.upper()].snapshot
+            snap = synth_results[sym_upper].snapshot
             with self.db.conn:
                 self.db.conn.execute(
                     """
@@ -246,6 +268,74 @@ class BrainOrchestrator:
                     _log.info("watch: %s confidence=%.2f", sym, confidence)
                 elif confidence < 0.45:
                     _log.debug("low conviction: %s confidence=%.2f", sym, confidence)
+
+        domain_scores_payload: dict[str, dict[str, float]] = {}
+        regime_payload: dict[str, str] = {}
+        feature_vectors_payload: dict[str, dict[str, dict[str, float]]] = {}
+
+        for sym in symbols_upper:
+            synth = synth_results.get(sym)
+            if synth is None:
+                domain_scores_payload[sym] = {}
+                regime_payload[sym] = "unknown"
+                feature_vectors_payload[sym] = {}
+                continue
+
+            domain_scores_payload[sym] = {domain: float(score) for domain, score in synth.domain_scores.items()}
+            regime_payload[sym] = str(getattr(synth, "regime_tag", "") or "unknown")
+            feature_vectors_payload[sym] = {
+                domain: {key: float(value) for key, value in feature_map.items()} for domain, feature_map in synth.snapshot.features.items()
+            }
+
+        conviction_payload: dict[str, dict[str, float | str | bool | None]] = {}
+        for sym, conv in convictions.items():
+            conviction_payload[sym] = {
+                "pcs": float(conv.pcs),
+                "magnitude": float(conv.score.magnitude),
+                "direction": str(conv.score.direction),
+                "capped_by_regime": bool(conv.capped_by_regime),
+                "pre_cap_magnitude": float(conv.pre_cap_magnitude) if conv.pre_cap_magnitude is not None else None,
+            }
+
+        cycle_emitted_at = datetime.now(tz=UTC)
+        forecast_ids_payload: dict[str, list[str]] = {sym: [] for sym in symbols_upper}
+        try:
+            forecast_events = self.db.get_events(
+                event_type=EventType.FORECAST_V1,
+                since=cycle_started_at,
+                until=cycle_emitted_at,
+                limit=5000,
+            )
+            for ev in reversed(forecast_events):
+                payload = ev.payload if isinstance(ev.payload, dict) else {}
+                forecast_symbol = str(payload.get("asset") or payload.get("symbol") or "").upper()
+                if forecast_symbol in forecast_ids_payload:
+                    forecast_ids_payload[forecast_symbol].append(ev.id)
+        except Exception:
+            logging.getLogger("b1e55ed.orchestrator").warning(
+                "Failed to collect FORECAST_V1 ids for cycle %s",
+                cycle_id,
+                exc_info=True,
+            )
+
+        cycle_duration_ms = max(0, int((perf_counter() - cycle_started_perf) * 1000))
+
+        self.db.append_event(
+            event_type=EventType.BRAIN_CYCLE_V1,
+            payload={
+                "cycle_id": cycle_id,
+                "symbols": symbols_upper,
+                "domain_scores": domain_scores_payload,
+                "regime": regime_payload,
+                "conviction": conviction_payload,
+                "forecast_ids": forecast_ids_payload,
+                "feature_vectors": feature_vectors_payload,
+                "cycle_duration_ms": cycle_duration_ms,
+                "ts": cycle_emitted_at.isoformat(),
+            },
+            source="brain.orchestrator",
+            trace_id=cycle_id,
+        )
 
         result = CycleResult(
             cycle_id=cycle_id,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -14,6 +14,37 @@ from engine.core.events import EventType
 from engine.security.identity import generate_node_identity
 
 
+def _seed_signals(db: Database, *, now: datetime) -> None:
+    db.append_event(
+        event_type=EventType.SIGNAL_TA_V1,
+        payload={"symbol": "BTC", "rsi_14": 35.0, "trend_strength": 0.7},
+        ts=now,
+    )
+    db.append_event(
+        event_type=EventType.SIGNAL_TRADFI_V1,
+        payload={"symbol": "BTC", "funding_annualized": 10.0, "basis_annualized": 5.0},
+        ts=now,
+    )
+
+
+def _run_cycle_and_get_marker_payload(test_config, temp_dir, monkeypatch) -> tuple[dict, str]:
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+    db = Database(temp_dir / "brain.db")
+
+    now = datetime.now(tz=UTC)
+    _seed_signals(db, now=now)
+
+    orch = BrainOrchestrator(test_config, db, ident)
+    result = orch.run_cycle(["BTC"])
+
+    cycle_events = db.get_events(event_type=EventType.BRAIN_CYCLE_V1, limit=10)
+    marker = next((e for e in cycle_events if e.payload.get("cycle_id") == result.cycle_id), None)
+    assert marker is not None
+
+    return marker.payload, result.cycle_id
+
+
 def test_orchestrator_full_cycle_mock(test_config, temp_dir, monkeypatch):
     monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
     ident = generate_node_identity()
@@ -43,3 +74,39 @@ def test_orchestrator_full_cycle_mock(test_config, temp_dir, monkeypatch):
     # Conviction event emitted
     evs = db.get_events(event_type=EventType.CONVICTION_V1, limit=10)
     assert len(evs) >= 1
+
+
+def test_brain_cycle_v1_payload_has_domain_scores(test_config, temp_dir, monkeypatch):
+    payload, _ = _run_cycle_and_get_marker_payload(test_config, temp_dir, monkeypatch)
+
+    assert "domain_scores" in payload
+    assert isinstance(payload["domain_scores"], dict)
+    assert "BTC" in payload["domain_scores"]
+    assert isinstance(payload["domain_scores"]["BTC"], dict)
+
+
+def test_brain_cycle_v1_payload_has_regime(test_config, temp_dir, monkeypatch):
+    payload, _ = _run_cycle_and_get_marker_payload(test_config, temp_dir, monkeypatch)
+
+    assert "regime" in payload
+    assert isinstance(payload["regime"], dict)
+    assert payload["regime"].get("BTC", "unknown") in {"BULL", "BEAR", "CRISIS", "TRANSITION", "unknown"}
+
+
+def test_brain_cycle_v1_payload_has_conviction(test_config, temp_dir, monkeypatch):
+    payload, _ = _run_cycle_and_get_marker_payload(test_config, temp_dir, monkeypatch)
+
+    assert "conviction" in payload
+    assert isinstance(payload["conviction"], dict)
+    assert "BTC" in payload["conviction"]
+
+    btc_conviction = payload["conviction"]["BTC"]
+    assert {"pcs", "magnitude", "direction", "capped_by_regime", "pre_cap_magnitude"}.issubset(btc_conviction.keys())
+
+
+def test_brain_cycle_v1_payload_has_cycle_duration_ms(test_config, temp_dir, monkeypatch):
+    payload, _ = _run_cycle_and_get_marker_payload(test_config, temp_dir, monkeypatch)
+
+    assert "cycle_duration_ms" in payload
+    assert isinstance(payload["cycle_duration_ms"], int)
+    assert payload["cycle_duration_ms"] >= 0


### PR DESCRIPTION
## Summary

Enrich `BRAIN_CYCLE_V1` emission in the brain orchestrator with a full per-cycle state snapshot (domain scores, per-symbol regime tags, conviction outputs, forecast references, feature vectors, cycle timing, timestamp) so a single event can reconstruct cycle state.

Closes #174

---

## Type of change

<!-- Check all that apply -->

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

<!-- Bullet list of what changed. Be specific about files. -->

- Updated `engine/brain/orchestrator.py` to emit `BRAIN_CYCLE_V1` at end-of-cycle with additive payload fields:
  - `domain_scores` per symbol
  - `regime` per symbol (via `synthesize_with_regime()` when available, fallback to `synthesize()` + `"unknown"`)
  - `conviction` per symbol (`pcs`, `magnitude`, `direction`, `capped_by_regime`, `pre_cap_magnitude`)
  - `forecast_ids` per symbol (best-effort collection of `FORECAST_V1` IDs emitted during cycle window)
  - `feature_vectors` per symbol from `synthesis.snapshot.features`
  - `cycle_duration_ms` from wall-clock elapsed time
  - `ts` ISO timestamp
- Kept all new fields additive with safe defaults (`{}`, `[]`, `"unknown"`) so missing data does not break cycles.
- Added unit tests in `tests/unit/test_orchestrator.py`:
  - `test_brain_cycle_v1_payload_has_domain_scores`
  - `test_brain_cycle_v1_payload_has_regime`
  - `test_brain_cycle_v1_payload_has_conviction`
  - `test_brain_cycle_v1_payload_has_cycle_duration_ms`

---

## Tests

- [x] New tests added (or explain why not needed)
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `759` passing

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [x] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [ ] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
