### PR TITLE
feat: review council wiring — workflow + config + labels

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,61 @@
+name: Review Council
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main, develop]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Skip bot PRs and dep-graph PRs
+        if: |
+          github.event.pull_request.user.login == 'github-actions[bot]' ||
+          contains(github.event.pull_request.title, 'auto-update dependency') ||
+          contains(github.event.pull_request.title, 'a b1e55ing')
+        run: |
+          echo "Skipping bot/housekeeping PR"
+          exit 0
+
+      - name: Check if already reviewed
+        id: reviewed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const reviewed = labels.some(l => ['review/pass','review/concern','review/block'].includes(l));
+            core.setOutput('already_reviewed', reviewed ? 'true' : 'false');
+
+      - name: Apply pending label
+        if: steps.reviewed.outputs.already_reviewed == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['review/pending']
+            });
+
+      - name: Send review trigger
+        if: steps.reviewed.outputs.already_reviewed == 'false'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          SHORT_SHA="${HEAD_SHA:0:8}"
+          MSG="[review] PR #${{ github.event.pull_request.number }} on ${{ github.repository }}"
+          MSG="${MSG}"$'\n'"Title: ${{ github.event.pull_request.title }}"
+          MSG="${MSG}"$'\n'"Branch: ${{ github.head_ref }}"
+          MSG="${MSG}"$'\n'"SHA: ${SHORT_SHA}"
+          MSG="${MSG}"$'\n'"Task key: review:${{ github.repository }}:${{ github.event.pull_request.number }}:${SHORT_SHA}"
+          curl -s -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" | python3 -c "import sys,json; r=json.load(sys.stdin); print('Trigger sent' if r.get('ok') else 'Trigger failed: '+str(r))"

--- a/.review-council.yml
+++ b/.review-council.yml
@@ -1,0 +1,54 @@
+# .review-council.yml
+# Review council integration for P-U-C/b1e55ed
+# Extend-only — cannot disable core reviewers (Correctness + Epistemics)
+
+reviewers:
+  conditional:
+    - reviewer: trading-logic
+      when:
+        paths:
+          - "engine/brain/**"
+          - "engine/producers/**"
+          - "engine/core/events.py"
+          - "engine/core/forecast.py"
+        watches:
+          - "engine/brain/conviction.py"
+          - "engine/core/events.py"
+          - "engine/core/database.py"
+    - reviewer: security
+      when:
+        paths:
+          - "**/auth*"
+          - "**/karma*"
+          - "**/credentials*"
+
+hard_human_gate:
+  paths:
+    - "engine/core/events.py"
+    - "engine/brain/conviction.py"
+    - "engine/core/database.py"
+    - "engine/brain/orchestrator.py"
+    - "scripts/b1e55ing.py"
+  label: "review/human-required"
+  block_merge: true
+
+noise_budget:
+  max_findings_per_100_loc: 3
+  max_findings_per_pr: 20
+
+escape_hatch:
+  allowed_humans:
+    - "zozDOTeth"
+    - "b1e55ed-bot"
+
+review_sla_minutes: 10
+
+labels:
+  pending: "review/pending"
+  pass: "review/pass"
+  concern: "review/concern"
+  block: "review/block"
+  human_gate: "review/human-required"
+  override: "review/override"
+
+block_on: "block"


### PR DESCRIPTION
## Summary

Wire review council integration by adding an auto-trigger workflow for PR events and repository-level review council configuration.

Closes #<!-- issue number -->

---

## Type of change

<!-- Check all that apply -->

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [x] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

<!-- Bullet list of what changed. Be specific about files. -->

- Added `.github/workflows/review.yml` to trigger review council on PR open/sync to `main` and `develop`, skip bot/housekeeping PRs, apply `review/pending`, and send Telegram trigger messages.
- Added `.review-council.yml` with conditional reviewer routing, hard human gate paths, noise budget, escape hatch users, SLA, and review label mapping.
- Created review labels in GitHub repo: `review/pending`, `review/pass`, `review/concern`, `review/block`, `review/human-required`, `review/override`.

---

## Tests

- [ ] New tests added (or explain why not needed)
- [ ] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [ ] Test count: `not run (config-only change)` passing

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [ ] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
