### PR TITLE
feat(p2): isotonic calibration — per-producer confidence calibration

### DIFF
--- a/engine/brain/isotonic.py
+++ b/engine/brain/isotonic.py
@@ -1,0 +1,265 @@
+"""
+Isotonic calibration for per-producer forecast confidence.
+
+Fits isotonic regression on resolved forecast_calibration rows:
+  input  x = raw confidence (0.5–1.0)
+  target y = outcome (1.0 = hit, 0.0 = miss)
+
+Calibrated confidence is a monotone-increasing adjustment so that
+"0.7 confidence" actually means a ~70% historical win rate.
+
+Shadow mode: calibrated values are written to forecast_calibration.calibrated=1
+but the raw confidence is NOT overwritten. Callers must opt in via
+get_calibrated_confidence().
+"""
+
+from __future__ import annotations
+
+import importlib
+from bisect import bisect_right
+from typing import Any
+
+_SklearnIsotonicRegression: Any | None
+try:
+    _sklearn_isotonic = importlib.import_module("sklearn.isotonic")
+    _SklearnIsotonicRegression = _sklearn_isotonic.IsotonicRegression
+except ModuleNotFoundError:  # pragma: no cover - fallback exercised only when sklearn is absent
+    _SklearnIsotonicRegression = None
+
+
+def _connection(db: Any) -> Any:
+    """Accept either a Database object (has .conn) or a raw sqlite3 connection."""
+    return getattr(db, "conn", db)
+
+
+def _clamp_confidence(value: float) -> float:
+    return max(0.5, min(1.0, float(value)))
+
+
+def _fit_isotonic_fallback(confidences: list[float], outcomes: list[float]) -> tuple[list[float], list[float]]:
+    """Minimal weighted PAV isotonic fit used only when sklearn is unavailable."""
+    ordered = sorted(zip(confidences, outcomes, strict=False), key=lambda item: item[0])
+    if not ordered:
+        return [], []
+
+    x_unique: list[float] = []
+    y_sum: list[float] = []
+    weights: list[float] = []
+
+    for x_val, y_val in ordered:
+        x_float = float(x_val)
+        y_float = float(y_val)
+        if x_unique and x_float == x_unique[-1]:
+            y_sum[-1] += y_float
+            weights[-1] += 1.0
+        else:
+            x_unique.append(x_float)
+            y_sum.append(y_float)
+            weights.append(1.0)
+
+    y_avg = [s / w for s, w in zip(y_sum, weights, strict=False)]
+
+    block_starts: list[int] = []
+    block_ends: list[int] = []
+    block_sumw: list[float] = []
+    block_sumy: list[float] = []
+
+    for i, (y_val, w_val) in enumerate(zip(y_avg, weights, strict=False)):
+        block_starts.append(i)
+        block_ends.append(i)
+        block_sumw.append(float(w_val))
+        block_sumy.append(float(y_val) * float(w_val))
+
+        while len(block_sumw) >= 2:
+            prev_mean = block_sumy[-2] / block_sumw[-2]
+            curr_mean = block_sumy[-1] / block_sumw[-1]
+            if prev_mean <= curr_mean:
+                break
+
+            block_ends[-2] = block_ends[-1]
+            block_sumw[-2] += block_sumw[-1]
+            block_sumy[-2] += block_sumy[-1]
+
+            block_starts.pop()
+            block_ends.pop()
+            block_sumw.pop()
+            block_sumy.pop()
+
+    fitted = [0.0] * len(x_unique)
+    for start, end, sum_w, sum_y in zip(block_starts, block_ends, block_sumw, block_sumy, strict=False):
+        level = sum_y / sum_w
+        for idx in range(start, end + 1):
+            fitted[idx] = level
+
+    return x_unique, fitted
+
+
+def fit_calibrator(
+    db: Any,
+    producer_name: str,
+    asset: str = "ALL",
+    regime: str = "unknown",
+    min_samples: int = 20,
+) -> dict[str, list[float]] | None:
+    """
+    Fit an isotonic calibrator for one producer/asset/regime slice.
+
+    Returns:
+        {"x": [knot_x...], "y": [knot_y...]} or None when there is
+        insufficient resolved data.
+    """
+    conn = _connection(db)
+    rows = conn.execute(
+        """
+        SELECT confidence, outcome
+        FROM forecast_calibration
+        WHERE outcome IS NOT NULL
+          AND producer_name = ?
+          AND (? = 'ALL' OR asset = ?)
+          AND (? = 'unknown' OR regime = ?)
+        ORDER BY confidence ASC, id ASC
+        """,
+        (producer_name, asset, asset, regime, regime),
+    ).fetchall()
+
+    if len(rows) < min_samples:
+        return None
+
+    confidences = [float(row[0]) for row in rows]
+    outcomes = [float(row[1]) for row in rows]
+
+    x_knots: list[float]
+    y_knots: list[float]
+    if _SklearnIsotonicRegression is not None:
+        model = _SklearnIsotonicRegression(out_of_bounds="clip")
+        model.fit(confidences, outcomes)
+        x_knots = [float(value) for value in model.X_thresholds_]
+        y_knots = [float(value) for value in model.y_thresholds_]
+    else:  # pragma: no cover - local/dev fallback
+        x_knots, y_knots = _fit_isotonic_fallback(confidences, outcomes)
+
+    if not x_knots or not y_knots or len(x_knots) != len(y_knots):
+        return None
+
+    return {"x": x_knots, "y": y_knots}
+
+
+def get_calibrated_confidence(
+    raw_confidence: float,
+    calibrator_dict: dict[str, list[float]] | None,
+) -> float:
+    """
+    Apply isotonic knots to a raw confidence value.
+
+    Shadow-safe fallback: if no calibrator is available, return raw confidence.
+    """
+    raw = float(raw_confidence)
+    if calibrator_dict is None:
+        return raw
+
+    x_knots_raw = calibrator_dict.get("x", [])
+    y_knots_raw = calibrator_dict.get("y", [])
+    if not x_knots_raw or not y_knots_raw:
+        return _clamp_confidence(raw)
+
+    x_knots = [float(x) for x in x_knots_raw]
+    y_knots = [float(y) for y in y_knots_raw]
+    if len(x_knots) != len(y_knots):
+        return _clamp_confidence(raw)
+
+    # Defensive normalization if caller provided unsorted knots.
+    ordered_pairs = sorted(zip(x_knots, y_knots, strict=False), key=lambda item: item[0])
+    xs = [pair[0] for pair in ordered_pairs]
+    ys = [pair[1] for pair in ordered_pairs]
+
+    if raw <= xs[0]:
+        return _clamp_confidence(ys[0])
+    if raw >= xs[-1]:
+        return _clamp_confidence(ys[-1])
+
+    idx = bisect_right(xs, raw)
+    left_x = xs[idx - 1]
+    right_x = xs[idx]
+    left_y = ys[idx - 1]
+    right_y = ys[idx]
+
+    if right_x == left_x:
+        calibrated = right_y
+    else:
+        weight = (raw - left_x) / (right_x - left_x)
+        calibrated = left_y + (right_y - left_y) * weight
+
+    return _clamp_confidence(calibrated)
+
+
+def mark_calibrated(db: Any, forecast_ids: list[str]) -> int:
+    """Mark forecast_calibration rows as calibrated. Returns rows updated."""
+    ids = [str(forecast_id) for forecast_id in forecast_ids if forecast_id]
+    if not ids:
+        return 0
+
+    conn = _connection(db)
+    placeholders = ",".join(["?"] * len(ids))
+
+    with conn:
+        cursor = conn.execute(
+            f"""
+            UPDATE forecast_calibration
+            SET calibrated = 1
+            WHERE forecast_id IN ({placeholders})
+              AND calibrated <> 1
+            """,
+            ids,
+        )
+
+    return int(cursor.rowcount or 0)
+
+
+def get_calibration_summary(db: Any, producer_name: str) -> dict[str, dict[str, Any]]:
+    """
+    Return calibration status by regime for one producer.
+
+    Shape:
+        {
+            "regime": {
+                "n_resolved": int,
+                "n_calibrated": int,
+                "x_knots": list[float],
+                "y_knots": list[float],
+            }
+        }
+    """
+    conn = _connection(db)
+    rows = conn.execute(
+        """
+        SELECT
+            regime,
+            COUNT(*) AS n_resolved,
+            SUM(CASE WHEN calibrated = 1 THEN 1 ELSE 0 END) AS n_calibrated
+        FROM forecast_calibration
+        WHERE producer_name = ?
+          AND outcome IS NOT NULL
+        GROUP BY regime
+        ORDER BY regime ASC
+        """,
+        (producer_name,),
+    ).fetchall()
+
+    summary: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        regime = str(row[0])
+        calibrator = fit_calibrator(
+            db=db,
+            producer_name=producer_name,
+            asset="ALL",
+            regime=regime,
+            min_samples=20,
+        )
+        summary[regime] = {
+            "n_resolved": int(row[1] or 0),
+            "n_calibrated": int(row[2] or 0),
+            "x_knots": calibrator["x"] if calibrator else [],
+            "y_knots": calibrator["y"] if calibrator else [],
+        }
+
+    return summary

--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -606,6 +606,7 @@ class Database:
         self._ensure_table_exists("scoring_params")
         # P2.2 — producer calibration curves
         self._ensure_table_exists("producer_calibration")
+        # P2.5 — isotonic calibration uses forecast_calibration (P2.1); no new table
         self._migrate_karma_intents_unique_trade_id()
 
     def _ensure_table_exists(self, table: str) -> None:

--- a/tests/test_isotonic.py
+++ b/tests/test_isotonic.py
@@ -1,0 +1,233 @@
+"""Tests for P2.5 — isotonic confidence calibration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.brain.isotonic import (
+    fit_calibrator,
+    get_calibrated_confidence,
+    get_calibration_summary,
+    mark_calibrated,
+)
+from engine.core.database import Database
+
+
+def _seed(
+    db: Database,
+    forecast_id: str,
+    producer_name: str,
+    confidence: float,
+    outcome: float,
+    asset: str = "BTC",
+    regime: str = "unknown",
+) -> None:
+    db.conn.execute(
+        """
+        INSERT INTO forecast_calibration
+            (forecast_id, producer_name, asset, regime, horizon, direction,
+             confidence, outcome, brier_score, emitted_at, resolved_at)
+        VALUES (?, ?, ?, ?, '24h', 'bullish', ?, ?,
+                (? - ?) * (? - ?),
+                datetime('now','-2 days'), datetime('now','-1 day'))
+        """,
+        (
+            forecast_id,
+            producer_name,
+            asset,
+            regime,
+            confidence,
+            outcome,
+            confidence,
+            outcome,
+            confidence,
+            outcome,
+        ),
+    )
+    db.conn.commit()
+
+
+@pytest.fixture()
+def idb(temp_dir: Path) -> Database:
+    db = Database(temp_dir / "brain.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_fit_calibrator_returns_none_when_fewer_than_min_samples(idb: Database) -> None:
+    for i in range(19):
+        _seed(
+            idb,
+            forecast_id=f"few-{i}",
+            producer_name="p-few",
+            confidence=0.5 + (i * 0.02),
+            outcome=float(i % 2),
+            regime="unknown",
+        )
+
+    calibrator = fit_calibrator(idb, producer_name="p-few", regime="unknown", min_samples=20)
+    assert calibrator is None
+
+
+def test_fit_calibrator_returns_knot_dict_when_enough_samples(idb: Database) -> None:
+    for i in range(20):
+        confidence = 0.5 + (i * 0.02)
+        outcome = 1.0 if confidence >= 0.7 else 0.0
+        _seed(idb, f"enough-{i}", "p-enough", confidence, outcome, regime="trend")
+
+    calibrator = fit_calibrator(idb, producer_name="p-enough", regime="trend", min_samples=20)
+
+    assert calibrator is not None
+    assert set(calibrator.keys()) == {"x", "y"}
+    assert len(calibrator["x"]) > 0
+    assert len(calibrator["x"]) == len(calibrator["y"])
+    assert calibrator["x"] == sorted(calibrator["x"])
+
+
+def test_get_calibrated_confidence_is_monotone_for_sorted_inputs(idb: Database) -> None:
+    for i in range(30):
+        confidence = 0.5 + (i * 0.015)
+        outcome = float((i * 7) % 5 in {0, 1})
+        _seed(idb, f"mono-{i}", "p-mono", confidence, outcome, regime="chop")
+
+    calibrator = fit_calibrator(idb, producer_name="p-mono", regime="chop", min_samples=20)
+    assert calibrator is not None
+
+    raw_values = [0.5 + (i * 0.01) for i in range(51)]
+    calibrated_values = [get_calibrated_confidence(raw, calibrator) for raw in raw_values]
+
+    for prev, curr in zip(calibrated_values, calibrated_values[1:], strict=False):
+        assert curr >= prev
+
+
+def test_get_calibrated_confidence_returns_raw_when_calibrator_is_none() -> None:
+    raw = 0.73
+    assert get_calibrated_confidence(raw, None) == pytest.approx(raw)
+
+
+def test_get_calibrated_confidence_clamps_to_lower_bound() -> None:
+    calibrator = {"x": [0.5, 1.0], "y": [0.0, 0.2]}
+    assert get_calibrated_confidence(0.8, calibrator) == pytest.approx(0.5)
+
+
+def test_get_calibrated_confidence_clamps_to_upper_bound() -> None:
+    calibrator = {"x": [0.5, 1.0], "y": [1.2, 1.5]}
+    assert get_calibrated_confidence(0.8, calibrator) == pytest.approx(1.0)
+
+
+def test_mark_calibrated_updates_only_requested_rows(idb: Database) -> None:
+    _seed(idb, "mark-1", "p-mark", 0.65, 1.0)
+    _seed(idb, "mark-2", "p-mark", 0.70, 0.0)
+    _seed(idb, "mark-3", "p-mark", 0.75, 1.0)
+
+    updated = mark_calibrated(idb, ["mark-1", "mark-3"])
+    assert updated == 2
+
+    rows = idb.conn.execute("SELECT forecast_id, calibrated FROM forecast_calibration WHERE producer_name = 'p-mark' ORDER BY forecast_id").fetchall()
+    by_id = {str(row[0]): int(row[1]) for row in rows}
+
+    assert by_id["mark-1"] == 1
+    assert by_id["mark-2"] == 0
+    assert by_id["mark-3"] == 1
+
+
+def test_mark_calibrated_returns_zero_for_empty_input(idb: Database) -> None:
+    assert mark_calibrated(idb, []) == 0
+
+
+def test_get_calibration_summary_returns_expected_structure(idb: Database) -> None:
+    bull_ids: list[str] = []
+    bear_ids: list[str] = []
+
+    for i in range(20):
+        forecast_id = f"sum-bull-{i}"
+        bull_ids.append(forecast_id)
+        confidence = 0.5 + (i * 0.02)
+        outcome = 1.0 if i % 3 != 0 else 0.0
+        _seed(idb, forecast_id, "p-summary", confidence, outcome, regime="bull")
+
+    for i in range(5):
+        forecast_id = f"sum-bear-{i}"
+        bear_ids.append(forecast_id)
+        confidence = 0.55 + (i * 0.03)
+        outcome = float(i % 2)
+        _seed(idb, forecast_id, "p-summary", confidence, outcome, regime="bear")
+
+    for i in range(10):
+        _seed(idb, f"other-{i}", "p-other", 0.6 + (i * 0.01), float(i % 2), regime="bull")
+
+    mark_calibrated(idb, bull_ids[:3] + bear_ids[:2])
+
+    summary = get_calibration_summary(idb, producer_name="p-summary")
+
+    assert set(summary.keys()) == {"bear", "bull"}
+    assert set(summary["bull"].keys()) == {"n_resolved", "n_calibrated", "x_knots", "y_knots"}
+    assert summary["bull"]["n_resolved"] == 20
+    assert summary["bull"]["n_calibrated"] == 3
+    assert len(summary["bull"]["x_knots"]) > 0
+    assert len(summary["bull"]["x_knots"]) == len(summary["bull"]["y_knots"])
+
+    assert summary["bear"]["n_resolved"] == 5
+    assert summary["bear"]["n_calibrated"] == 2
+    assert summary["bear"]["x_knots"] == []
+    assert summary["bear"]["y_knots"] == []
+
+
+def test_edge_case_all_wins_returns_full_confidence(idb: Database) -> None:
+    for i in range(20):
+        _seed(idb, f"win-{i}", "p-win", 0.5 + (i * 0.02), 1.0, regime="allwins")
+
+    calibrator = fit_calibrator(idb, producer_name="p-win", regime="allwins", min_samples=20)
+    assert calibrator is not None
+    assert all(y == pytest.approx(1.0) for y in calibrator["y"])
+    assert get_calibrated_confidence(0.62, calibrator) == pytest.approx(1.0)
+
+
+def test_edge_case_all_losses_returns_floor_after_clamp(idb: Database) -> None:
+    for i in range(20):
+        _seed(idb, f"loss-{i}", "p-loss", 0.5 + (i * 0.02), 0.0, regime="allloss")
+
+    calibrator = fit_calibrator(idb, producer_name="p-loss", regime="allloss", min_samples=20)
+    assert calibrator is not None
+    assert all(y == pytest.approx(0.0) for y in calibrator["y"])
+    assert get_calibrated_confidence(0.88, calibrator) == pytest.approx(0.5)
+
+
+def test_fit_calibrator_mixed_producers_are_isolated(idb: Database) -> None:
+    for i in range(25):
+        confidence = 0.5 + (i * 0.015)
+        _seed(idb, f"a-{i}", "p-a", confidence, 1.0, regime="mix")
+        _seed(idb, f"b-{i}", "p-b", confidence, 0.0, regime="mix")
+
+    cal_a = fit_calibrator(idb, producer_name="p-a", regime="mix", min_samples=20)
+    cal_b = fit_calibrator(idb, producer_name="p-b", regime="mix", min_samples=20)
+
+    assert cal_a is not None
+    assert cal_b is not None
+
+    pred_a = get_calibrated_confidence(0.8, cal_a)
+    pred_b = get_calibrated_confidence(0.8, cal_b)
+
+    assert pred_a > pred_b
+    assert pred_a == pytest.approx(1.0)
+    assert pred_b == pytest.approx(0.5)
+
+
+def test_fit_calibrator_respects_asset_filter(idb: Database) -> None:
+    for i in range(20):
+        confidence = 0.5 + (i * 0.02)
+        _seed(idb, f"btc-{i}", "p-asset", confidence, 1.0, asset="BTC", regime="r1")
+        _seed(idb, f"eth-{i}", "p-asset", confidence, 0.0, asset="ETH", regime="r1")
+
+    btc = fit_calibrator(idb, producer_name="p-asset", asset="BTC", regime="r1", min_samples=20)
+    eth = fit_calibrator(idb, producer_name="p-asset", asset="ETH", regime="r1", min_samples=20)
+
+    assert btc is not None
+    assert eth is not None
+
+    assert get_calibrated_confidence(0.75, btc) == pytest.approx(1.0)
+    assert get_calibrated_confidence(0.75, eth) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

Isotonic regression calibration for per-producer forecast confidence (P2.5). Fits sklearn IsotonicRegression on resolved forecast_calibration rows. Calibrated values written to forecast_calibration.calibrated=1 but raw confidence is preserved — callers opt in via get_calibrated_confidence().

Closes #179

---

## Type of change

- [x] `feat` — new feature

---

## Labels

- [x] Labels applied ✅

---

## Tests

- [x] New tests added
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`