### PR TITLE
feat(p3.2): regime decision matrix — per-producer regime conditioning

### DIFF
--- a/engine/core/events.py
+++ b/engine/core/events.py
@@ -109,6 +109,7 @@ class AbstentionReason(StrEnum):
     INSUFFICIENT_DATA = "insufficient_data"
     LOW_CONFIDENCE = "low_confidence"
     REGIME_MISMATCH = "regime_mismatch"
+    REGIME_FILTERED = "regime_filtered"
     CONFLICT_UNRESOLVED = "conflict_unresolved"
     THESIS_UNCHANGED = "thesis_unchanged"
 

--- a/engine/core/interpreter.py
+++ b/engine/core/interpreter.py
@@ -21,6 +21,7 @@ from engine.core.events import AbstentionReason, ForecastPayload
 from engine.core.forecast import abstain, compute_reasoning_hash
 from engine.core.llm_critic import LLMCritic
 from engine.core.regime import REGIME_CAPS as _REGIME_CAPS
+from engine.core.regime import RegimeMatrix
 from engine.core.utils import clamp
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,78 @@ class Interpreter(ABC):
     @property
     def source(self) -> str:
         return f"{self.producer_name}@{self.producer_version}"
+
+    # Declare a RegimeMatrix on a subclass to enable regime-conditioned output.
+    # None means "pass interpret() output through unchanged".
+    regime_matrix: RegimeMatrix | None = None
+
+    # Default minimum confidence for non-abstention.
+    # Overridden by RegimeConfig.min_confidence.
+    min_confidence: float = 0.1
+
+    def apply_regime_conditioning(
+        self,
+        forecast: ForecastPayload,
+        regime_tag: str,
+    ) -> ForecastPayload:
+        """Apply regime matrix to a candidate forecast.
+
+        Called automatically by safe_interpret(). Subclasses should NOT call
+        this themselves — it is applied once at the seam.
+
+        Returns the forecast unchanged if:
+        - no regime_matrix is set
+        - forecast.action == "no_forecast"
+        - RegimeConfig has no-op values (multiplier=1.0, abstain=False)
+        """
+        from engine.core.utils import clamp  # local import to avoid circular at module load
+
+        if self.regime_matrix is None or forecast.action == "no_forecast":
+            return forecast
+
+        cfg = self.regime_matrix.get(regime_tag)
+
+        # Hard abstain for this regime
+        if cfg.abstain:
+            return abstain(
+                source=forecast.source,
+                asset=forecast.asset,
+                horizon=forecast.horizon,
+                reason=AbstentionReason.REGIME_FILTERED,
+                regime_tag=regime_tag,
+                visible_signal_refs=forecast.visible_signal_refs,
+            )
+
+        # active_rules=frozenset() means no rules run — implicit abstain
+        if cfg.active_rules is not None and len(cfg.active_rules) == 0:
+            return abstain(
+                source=forecast.source,
+                asset=forecast.asset,
+                horizon=forecast.horizon,
+                reason=AbstentionReason.REGIME_FILTERED,
+                regime_tag=regime_tag,
+                visible_signal_refs=forecast.visible_signal_refs,
+            )
+
+        # Apply confidence multiplier
+        new_confidence = clamp(forecast.confidence * cfg.confidence_multiplier, 0.0, 1.0)
+
+        # Apply min_confidence (regime-specific override, else use class default)
+        effective_min = cfg.min_confidence if cfg.min_confidence is not None else self.min_confidence
+        if new_confidence < effective_min:
+            return abstain(
+                source=forecast.source,
+                asset=forecast.asset,
+                horizon=forecast.horizon,
+                reason=AbstentionReason.LOW_CONFIDENCE,
+                regime_tag=regime_tag,
+                visible_signal_refs=forecast.visible_signal_refs,
+            )
+
+        if new_confidence == forecast.confidence:
+            return forecast  # no change, avoid unnecessary copy
+
+        return forecast.model_copy(update={"confidence": new_confidence})
 
     @abstractmethod
     def interpret(
@@ -81,13 +154,14 @@ class Interpreter(ABC):
     ) -> ForecastPayload:
         """Call interpret() and fall back to abstention on any exception."""
         try:
-            return self.interpret(
+            result = self.interpret(
                 asset=asset,
                 horizon=horizon,
                 signals=signals,
                 regime_tag=regime_tag,
                 visible_signal_refs=visible_signal_refs,
             )
+            return self.apply_regime_conditioning(result, regime_tag)
         except Exception:  # noqa: BLE001
             return abstain(
                 source=self.source,

--- a/engine/core/regime.py
+++ b/engine/core/regime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 # Confidence cap per regime (0-10 scale, converted to 0.0-1.0 at point of use).
 # These are the canonical regime caps. engine.brain.conviction imports from here.
 REGIME_CAPS: dict[str, float] = {
@@ -10,3 +12,54 @@ REGIME_CAPS: dict[str, float] = {
     "TRANSITION": 6.0,
     "CRISIS": 4.0,
 }
+
+
+@dataclass(frozen=True)
+class RegimeConfig:
+    """Behavioural overrides for a single regime.
+
+    All fields are optional — unset means "no change from default".
+    """
+
+    # Scale the rule-engine's candidate confidence before guardrails.
+    # 1.0 = no change. 0.5 = halve confidence. 1.2 = boost 20%.
+    confidence_multiplier: float = 1.0
+
+    # If True, always abstain when this regime is active.
+    # Overrides confidence_multiplier.
+    abstain: bool = False
+
+    # Named rule groups that are active in this regime.
+    # None means "all rules active". frozenset([]) means "no rules run → implicit abstain".
+    # Used by producers that have discrete named rule groups.
+    active_rules: frozenset[str] | None = None
+
+    # Minimum confidence to emit a non-abstention forecast in this regime.
+    # None means "use the interpreter's default min_confidence".
+    min_confidence: float | None = None
+
+
+@dataclass
+class RegimeMatrix:
+    """Per-regime decision matrix for an interpreter.
+
+    Declare once on the interpreter class. The base class applies it
+    automatically after interpret() returns — no if/else inside rules.
+
+    Example:
+        matrix = RegimeMatrix(
+            configs={
+                "BULL": RegimeConfig(confidence_multiplier=1.1),
+                "BEAR": RegimeConfig(confidence_multiplier=0.7, min_confidence=0.5),
+                "CRISIS": RegimeConfig(abstain=True),
+                "TRANSITION": RegimeConfig(confidence_multiplier=0.85),
+            }
+        )
+    """
+
+    configs: dict[str, RegimeConfig] = field(default_factory=dict)
+    default: RegimeConfig = field(default_factory=RegimeConfig)
+
+    def get(self, regime_tag: str) -> RegimeConfig:
+        """Return config for *regime_tag*, falling back to default."""
+        return self.configs.get(regime_tag.upper(), self.default)

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -41,6 +41,7 @@ from engine.core.events import (
 from engine.core.forecast import abstain, compute_reasoning_hash, make_forecast_id
 from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.models import Event
+from engine.core.regime import RegimeConfig, RegimeMatrix
 from engine.core.types import ProducerHealth, ProducerResult
 from engine.producers.base import BaseProducer
 from engine.producers.registry import register
@@ -205,6 +206,19 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
 # Cash-and-carry predates electronic trading. What changed is who is on the other side.
 class TradFiBasisInterpreter(Interpreter):
     """Rule-based interpreter for TradFi basis/carry signals → FORECAST_V1."""
+
+    regime_matrix = RegimeMatrix(
+        configs={
+            # Bull: basis trade works well, slight confidence boost.
+            "BULL": RegimeConfig(confidence_multiplier=1.1),
+            # Bear: basis signals less reliable, require higher conviction.
+            "BEAR": RegimeConfig(confidence_multiplier=0.8, min_confidence=0.45),
+            # Crisis: basis unwinds chaotically — do not trade.
+            "CRISIS": RegimeConfig(abstain=True),
+            # Transition: moderate suppression.
+            "TRANSITION": RegimeConfig(confidence_multiplier=0.9),
+        }
+    )
 
     def interpret(
         self,

--- a/tests/unit/test_regime_matrix.py
+++ b/tests/unit/test_regime_matrix.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from engine.core.events import AbstentionReason, ForecastPayload
+from engine.core.forecast import make_forecast_id
+from engine.core.interpreter import Interpreter
+from engine.core.regime import RegimeConfig, RegimeMatrix
+from engine.producers.tradfi import TradFiBasisInterpreter
+
+
+class _ConfigurableInterpreter(Interpreter):
+    def __init__(self, payload: ForecastPayload, *, regime_matrix: RegimeMatrix | None = None, min_confidence: float = 0.1) -> None:
+        self.payload = payload
+        self.regime_matrix = regime_matrix
+        self.min_confidence = min_confidence
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        return self.payload.model_copy(deep=True)
+
+
+def _mk_forecast(*, action: str = "long", confidence: float = 0.8) -> ForecastPayload:
+    kwargs: dict[str, Any] = {
+        "forecast_id": make_forecast_id(),
+        "asset": "BTC",
+        "horizon": "4h",
+        "action": action,
+        "confidence": confidence,
+        "source": "unit@1.0.0",
+        "regime_tag": "unknown",
+        "visible_signal_refs": ["evt-1"],
+        "used_signal_refs": ["evt-1"],
+    }
+    if action == "no_forecast":
+        kwargs["confidence"] = 0.0
+        kwargs["abstention_reason"] = AbstentionReason.INSUFFICIENT_DATA
+    return ForecastPayload(**kwargs)
+
+
+def test_regime_matrix_get_returns_known_config() -> None:
+    cfg = RegimeConfig(confidence_multiplier=0.7, min_confidence=0.5)
+    matrix = RegimeMatrix(configs={"BEAR": cfg})
+
+    assert matrix.get("bear") == cfg
+
+
+def test_regime_matrix_get_returns_default_for_unknown_regime() -> None:
+    default = RegimeConfig(confidence_multiplier=0.9)
+    matrix = RegimeMatrix(configs={"BULL": RegimeConfig(confidence_multiplier=1.1)}, default=default)
+
+    assert matrix.get("sideways") == default
+
+
+def test_apply_regime_conditioning_abstains_when_configured() -> None:
+    matrix = RegimeMatrix(configs={"CRISIS": RegimeConfig(abstain=True)})
+    interpreter = _ConfigurableInterpreter(_mk_forecast(confidence=0.7), regime_matrix=matrix)
+
+    out = interpreter.apply_regime_conditioning(_mk_forecast(confidence=0.7), "CRISIS")
+
+    assert out.action == "no_forecast"
+    assert out.abstention_reason == AbstentionReason.REGIME_FILTERED
+
+
+def test_apply_regime_conditioning_applies_confidence_multiplier() -> None:
+    matrix = RegimeMatrix(configs={"BEAR": RegimeConfig(confidence_multiplier=0.5)})
+    interpreter = _ConfigurableInterpreter(_mk_forecast(confidence=0.8), regime_matrix=matrix)
+
+    out = interpreter.apply_regime_conditioning(_mk_forecast(confidence=0.8), "BEAR")
+
+    assert out.action == "long"
+    assert out.confidence == pytest.approx(0.4)
+
+
+def test_apply_regime_conditioning_abstains_when_multiplier_drops_below_min_confidence() -> None:
+    matrix = RegimeMatrix(configs={"BEAR": RegimeConfig(confidence_multiplier=0.5)})
+    interpreter = _ConfigurableInterpreter(_mk_forecast(confidence=0.6), regime_matrix=matrix, min_confidence=0.35)
+
+    out = interpreter.apply_regime_conditioning(_mk_forecast(confidence=0.6), "BEAR")
+
+    assert out.action == "no_forecast"
+    assert out.abstention_reason == AbstentionReason.LOW_CONFIDENCE
+
+
+def test_apply_regime_conditioning_abstains_when_active_rules_empty() -> None:
+    matrix = RegimeMatrix(configs={"TRANSITION": RegimeConfig(active_rules=frozenset())})
+    interpreter = _ConfigurableInterpreter(_mk_forecast(confidence=0.7), regime_matrix=matrix)
+
+    out = interpreter.apply_regime_conditioning(_mk_forecast(confidence=0.7), "TRANSITION")
+
+    assert out.action == "no_forecast"
+    assert out.abstention_reason == AbstentionReason.REGIME_FILTERED
+
+
+def test_apply_regime_conditioning_passes_through_no_forecast_unchanged() -> None:
+    matrix = RegimeMatrix(configs={"BULL": RegimeConfig(confidence_multiplier=1.2)})
+    interpreter = _ConfigurableInterpreter(_mk_forecast(action="no_forecast"), regime_matrix=matrix)
+    candidate = _mk_forecast(action="no_forecast")
+
+    out = interpreter.apply_regime_conditioning(candidate, "BULL")
+
+    assert out is candidate
+
+
+def test_apply_regime_conditioning_passes_through_when_no_matrix() -> None:
+    interpreter = _ConfigurableInterpreter(_mk_forecast(confidence=0.8), regime_matrix=None)
+    candidate = _mk_forecast(confidence=0.8)
+
+    out = interpreter.apply_regime_conditioning(candidate, "BEAR")
+
+    assert out is candidate
+
+
+def test_safe_interpret_applies_regime_conditioning() -> None:
+    matrix = RegimeMatrix(configs={"BEAR": RegimeConfig(confidence_multiplier=0.5)})
+    interpreter = _ConfigurableInterpreter(_mk_forecast(confidence=0.8), regime_matrix=matrix)
+
+    out = interpreter.safe_interpret(asset="BTC", horizon="4h", signals=[{"id": "sig-1"}], regime_tag="BEAR")
+
+    assert out.action == "long"
+    assert out.confidence == pytest.approx(0.4)
+
+
+def test_tradfi_basis_interpreter_crisis_regime_abstains() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    assert interpreter.regime_matrix is not None
+
+    out = interpreter.safe_interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[{"symbol": "BTC", "direction": "long", "confidence": 0.7, "signal_reason": "basis healthy"}],
+        regime_tag="CRISIS",
+    )
+
+    assert out.action == "no_forecast"
+    assert out.abstention_reason == AbstentionReason.REGIME_FILTERED
+
+
+def test_tradfi_basis_interpreter_bull_regime_boosts_confidence() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    out = interpreter.safe_interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[{"symbol": "BTC", "direction": "long", "confidence": 0.5, "signal_reason": "basis healthy"}],
+        regime_tag="BULL",
+    )
+
+    assert out.action == "long"
+    assert out.confidence == pytest.approx(0.55)


### PR DESCRIPTION
## Summary

Closes #181

Formalises per-producer regime behaviour into a declarative `RegimeMatrix`. Each producer declares confidence multipliers, abstention conditions, and active rule sets per regime. The base `Interpreter` applies the matrix automatically via `safe_interpret()` — no ad-hoc if/else in rule engines.

## Type of change
- [x] `feat` — new feature

## Labels
Applied: `feat`, `brain`, `producer`, `roadmap`

## Changes

- `engine/core/regime.py` — `RegimeConfig` + `RegimeMatrix` dataclasses
- `engine/core/interpreter.py` — `regime_matrix` attr + `apply_regime_conditioning()` + `safe_interpret()` wiring
- `engine/core/events.py` — `REGIME_FILTERED` abstention reason (if not present)
- `engine/producers/tradfi.py` — reference `RegimeMatrix` on `TradFiBasisInterpreter`
- `tests/unit/test_regime_matrix.py` (new) — full coverage

## Tests

- [x] New tests added
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: 866 passing

## Checklist

- [x] Branch targets `develop`
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` not modified