### PR TITLE
feat(p3.3): differentiated data inputs by producer

### DIFF
--- a/engine/core/events.py
+++ b/engine/core/events.py
@@ -140,6 +140,11 @@ class TASignalPayload(BaseModel):
     trend_strength: float | None = None
     support_distance: float | None = None
     resistance_distance: float | None = None
+    # P3.3: volatility + breakout enrichment
+    bb_width: float | None = None
+    atr_14: float | None = None
+    volatility_compression: bool = False
+    breakout_failure: bool = False
 
 
 class OnchainSignalPayload(BaseModel):
@@ -148,6 +153,10 @@ class OnchainSignalPayload(BaseModel):
     exchange_flow: float | None = None
     active_addresses_change: float | None = None
     price_momentum_24h: float | None = None
+    # P3.3: directional flow enrichment
+    flow_direction: Literal["inflow", "outflow", "neutral"] | None = None
+    flow_magnitude: float | None = None
+    entity_type: str | None = None
 
 
 class TradFiSignalPayload(BaseModel):
@@ -161,6 +170,11 @@ class TradFiSignalPayload(BaseModel):
     horizon: str = "swing"
     invalidation: float | None = None
     signal_reason: str | None = None
+    # P3.3: smart money + liquidation enrichment
+    smart_money_delta: float | None = None
+    liquidation_cluster_long: float | None = None
+    liquidation_cluster_short: float | None = None
+    liq_asymmetry: float | None = None
 
 
 class SocialSignalPayload(BaseModel):
@@ -177,6 +191,10 @@ class SentimentSignalPayload(BaseModel):
     fear_greed: float | None = None
     fear_greed_change_7d: float | None = None
     ct_sentiment: str | None = None
+    # P3.3: positioning extremes
+    long_short_ratio: float | None = None
+    funding_extreme: bool = False
+    positioning_signal: Literal["extreme_long", "extreme_short", "neutral"] | None = None
 
 
 class EventsSignalPayload(BaseModel):

--- a/engine/producers/onchain.py
+++ b/engine/producers/onchain.py
@@ -74,12 +74,31 @@ class OnchainFlowsProducer(BaseProducer):
             if not sym:
                 continue
 
+            exchange_flow = row.get("exchange_flow")
+            flow_direction: str | None = None
+            flow_magnitude: float | None = None
+            if exchange_flow is not None:
+                try:
+                    ef = float(exchange_flow)
+                except (TypeError, ValueError):
+                    ef = 0.0
+                if ef > 1_000_000:
+                    flow_direction = "inflow"
+                elif ef < -1_000_000:
+                    flow_direction = "outflow"
+                else:
+                    flow_direction = "neutral"
+                flow_magnitude = round(min(abs(ef) / 50_000_000, 1.0), 3)
+
             payload_obj = OnchainSignalPayload(
                 symbol=sym,
                 whale_netflow=row.get("whale_netflow"),
-                exchange_flow=row.get("exchange_flow"),
+                exchange_flow=exchange_flow,
                 active_addresses_change=row.get("active_addresses_change"),
                 price_momentum_24h=row.get("price_momentum_24h"),
+                flow_direction=flow_direction,
+                flow_magnitude=flow_magnitude,
+                entity_type=row.get("entity_type"),
             )
             payload = payload_obj.model_dump(mode="json")
             out.append(

--- a/engine/producers/sentiment.py
+++ b/engine/producers/sentiment.py
@@ -77,11 +77,51 @@ class MarketSentimentProducer(BaseProducer):
             if not sym:
                 continue
 
+            fear_greed = row.get("fear_greed")
+            long_short_ratio = row.get("long_short_ratio")
+            funding_annualized = row.get("funding_annualized")
+
+            funding_extreme = False
+            positioning_signal: str | None = None
+
+            if funding_annualized is not None:
+                try:
+                    fa = float(funding_annualized)
+                    funding_extreme = fa > 30.0 or fa < -10.0
+                except (TypeError, ValueError):
+                    funding_extreme = False
+
+            if long_short_ratio is not None:
+                try:
+                    lsr = float(long_short_ratio)
+                except (TypeError, ValueError):
+                    lsr = 1.0
+                if lsr > 2.0:
+                    positioning_signal = "extreme_long"
+                elif lsr < 0.5:
+                    positioning_signal = "extreme_short"
+                else:
+                    positioning_signal = "neutral"
+            elif fear_greed is not None:
+                try:
+                    fg = float(fear_greed)
+                except (TypeError, ValueError):
+                    fg = 50.0
+                if fg >= 80:
+                    positioning_signal = "extreme_long"
+                elif fg <= 20:
+                    positioning_signal = "extreme_short"
+                else:
+                    positioning_signal = "neutral"
+
             payload_obj = SentimentSignalPayload(
                 symbol=sym,
-                fear_greed=row.get("fear_greed"),
+                fear_greed=fear_greed,
                 fear_greed_change_7d=row.get("fear_greed_change_7d"),
                 ct_sentiment=row.get("ct_sentiment"),
+                long_short_ratio=long_short_ratio,
+                funding_extreme=funding_extreme,
+                positioning_signal=positioning_signal,
             )
             payload = payload_obj.model_dump(mode="json")
             out.append(

--- a/engine/producers/ta.py
+++ b/engine/producers/ta.py
@@ -30,8 +30,17 @@ from typing import Any
 
 import httpx
 
-from engine.core.events import EventType, TASignalPayload
+from engine.core.events import (
+    AbstentionReason,
+    EventType,
+    ForecastLifecycleState,
+    ForecastPayload,
+    TASignalPayload,
+)
+from engine.core.forecast import abstain, compute_reasoning_hash, make_forecast_id
+from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.models import Event
+from engine.core.regime import RegimeConfig, RegimeMatrix
 from engine.core.types import ProducerHealth, ProducerResult
 from engine.producers.base import BaseProducer
 from engine.producers.registry import register
@@ -43,10 +52,122 @@ def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
     return f"{EventType.SIGNAL_TA_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
 
 
+class TechnicalInterpreter(Interpreter):
+    """Rule-based interpreter for TA signals → FORECAST_V1.
+
+    P3.3: Uses volatility compression and breakout failure as key differentiators.
+    """
+
+    regime_matrix = RegimeMatrix(
+        configs={
+            "BULL": RegimeConfig(confidence_multiplier=1.1),
+            "BEAR": RegimeConfig(confidence_multiplier=0.8, min_confidence=0.4),
+            "CRISIS": RegimeConfig(abstain=True),
+            "TRANSITION": RegimeConfig(confidence_multiplier=0.9),
+        }
+    )
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        refs = visible_signal_refs or []
+        asset_sigs = [s for s in signals if str(s.get("symbol", "")).upper() == asset.upper()]
+        if not asset_sigs:
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.INSUFFICIENT_DATA,
+                regime_tag=regime_tag,
+                visible_signal_refs=refs,
+            )
+
+        sig = asset_sigs[0]
+        trend = sig.get("trend")
+
+        try:
+            strength = float(sig.get("trend_strength") or 0.0)
+        except (TypeError, ValueError):
+            strength = 0.0
+
+        rsi = sig.get("rsi_14")
+        volatility_compression = bool(sig.get("volatility_compression", False))
+        breakout_failure = bool(sig.get("breakout_failure", False))
+
+        if trend not in ("bullish", "bearish") or strength < 0.3:
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.INSUFFICIENT_DATA,
+                regime_tag=regime_tag,
+                visible_signal_refs=refs,
+            )
+
+        action = "long" if trend == "bullish" else "short"
+        confidence = min(0.35 + strength * 0.5, 0.85)
+
+        if rsi is not None:
+            try:
+                rsi_val = float(rsi)
+            except (TypeError, ValueError):
+                rsi_val = None
+            if rsi_val is not None and ((action == "long" and rsi_val > 70) or (action == "short" and rsi_val < 30)):
+                confidence *= 0.85
+
+        if volatility_compression:
+            confidence *= 1.15
+        if breakout_failure:
+            confidence *= 0.5
+
+        confidence = min(confidence, 0.90)
+
+        if confidence < 0.3:
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.LOW_CONFIDENCE,
+                regime_tag=regime_tag,
+                visible_signal_refs=refs,
+            )
+
+        return ForecastPayload(
+            forecast_id=make_forecast_id(),
+            asset=asset,
+            horizon=horizon,
+            action=action,
+            confidence=round(confidence, 3),
+            source=self.source,
+            regime_tag=regime_tag,
+            lifecycle_state=ForecastLifecycleState.NEW,
+            reasoning_hash=compute_reasoning_hash(
+                {
+                    "action": action,
+                    "confidence": confidence,
+                    "trend": trend,
+                    "volatility_compression": volatility_compression,
+                    "breakout_failure": breakout_failure,
+                },
+                "",
+                str(sig.get("trend", "")),
+            ),
+            visible_signal_refs=refs,
+            used_signal_refs=refs,
+        )
+
+
 @register("technical-analysis", domain="technical")
 class TechnicalAnalysisProducer(BaseProducer):
     schedule = "*/15 * * * *"
     mcp_source_url: str | None = None  # override with MCP server URL when available
+    interpreter: Interpreter | NullInterpreter | None = TechnicalInterpreter()
 
     def _endpoint(self) -> str | None:
         return os.getenv("B1E55ED_TA_URL") or os.getenv("TA_URL")
@@ -74,6 +195,21 @@ class TechnicalAnalysisProducer(BaseProducer):
             if not sym:
                 continue
 
+            bb_upper = row.get("bb_upper")
+            bb_lower = row.get("bb_lower")
+            bb_mid = row.get("bb_mid") or row.get("ema_20")
+
+            bb_width: float | None = None
+            volatility_compression = False
+            if bb_upper is not None and bb_lower is not None and bb_mid is not None:
+                try:
+                    bb_mid_val = float(bb_mid)
+                    if bb_mid_val > 0:
+                        bb_width = round((float(bb_upper) - float(bb_lower)) / bb_mid_val, 4)
+                        volatility_compression = bb_width < 0.04
+                except (TypeError, ValueError):
+                    bb_width = None
+
             payload_obj = TASignalPayload(
                 symbol=sym,
                 rsi_14=row.get("rsi_14"),
@@ -86,6 +222,10 @@ class TechnicalAnalysisProducer(BaseProducer):
                 trend_strength=row.get("trend_strength"),
                 support_distance=row.get("support_distance"),
                 resistance_distance=row.get("resistance_distance"),
+                bb_width=bb_width,
+                atr_14=row.get("atr_14"),
+                volatility_compression=volatility_compression,
+                breakout_failure=bool(row.get("breakout_failure", False)),
             )
             payload = payload_obj.model_dump(mode="json")
             out.append(

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -197,6 +197,152 @@ async def _fetch_binance(client: httpx.AsyncClient, universe: list[str]) -> list
     return results
 
 
+async def _fetch_hl_liquidations(client: httpx.AsyncClient, symbols: list[str]) -> dict[str, dict[str, float]]:
+    """Fetch Hyperliquid liquidation-cluster proxy data.
+
+    Returns:
+        dict[symbol -> {liquidation_cluster_long, liquidation_cluster_short, liq_asymmetry}]
+
+    Fails silently and returns {} on any error.
+    """
+
+    try:
+        resp = await client.post(
+            "https://api.hyperliquid.xyz/info",
+            json={"type": "metaAndAssetCtxs"},
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not isinstance(data, list) or len(data) < 2:
+            return {}
+
+        meta = data[0] if isinstance(data[0], dict) else {}
+        asset_ctxs = data[1] if isinstance(data[1], list) else []
+        universe = meta.get("universe", []) if isinstance(meta, dict) else []
+
+        symbol_set = {s.upper() for s in symbols}
+        result: dict[str, dict[str, float]] = {}
+
+        for idx, asset_info in enumerate(universe):
+            if not isinstance(asset_info, dict):
+                continue
+            name = str(asset_info.get("name", "")).upper()
+            if name not in symbol_set or idx >= len(asset_ctxs):
+                continue
+
+            ctx = asset_ctxs[idx] if isinstance(asset_ctxs[idx], dict) else {}
+            mark_px = float(ctx.get("markPx", 0) or 0)
+            oi = float(ctx.get("openInterest", 0) or 0)
+            funding = float(ctx.get("funding", 0) or 0)
+
+            # Heuristic split: positive funding implies longer crowding.
+            crowding_bias = max(-0.4, min(0.4, funding * 100))
+            long_frac = max(0.1, min(0.9, 0.5 + crowding_bias))
+            short_frac = 1.0 - long_frac
+
+            long_cluster = oi * mark_px * long_frac * 0.15
+            short_cluster = oi * mark_px * short_frac * 0.15
+            total = long_cluster + short_cluster
+            liq_asymmetry = long_cluster / total if total > 0 else 0.5
+
+            result[name] = {
+                "liquidation_cluster_long": round(long_cluster, 0),
+                "liquidation_cluster_short": round(short_cluster, 0),
+                "liq_asymmetry": round(liq_asymmetry, 3),
+            }
+
+        return result
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+async def _fetch_nansen_smart_money(
+    client: httpx.AsyncClient,
+    symbols: list[str],
+    *,
+    api_key: str | None,
+) -> dict[str, float]:
+    """Best-effort smart-money netflow fetch.
+
+    Env-gated by NANSEN_API_KEY. Returns {} on any error.
+    """
+
+    if not api_key:
+        return {}
+
+    try:
+        resp = await client.post(
+            "https://api.nansen.ai/api/v1/smart-money/netflow",
+            headers={
+                "apiKey": api_key,
+                "User-Agent": "b1e55ed-tradfi-producer/1.0",
+            },
+            json={"symbols": symbols},
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        rows: Any
+        if isinstance(data, dict):
+            rows = data.get("data", data.get("results", []))
+        else:
+            rows = data
+
+        if not isinstance(rows, list):
+            return {}
+
+        result: dict[str, float] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            sym = str(row.get("symbol") or row.get("asset") or "").upper().strip()
+            if not sym:
+                continue
+
+            val = row.get("netflow_usd")
+            if val is None:
+                val = row.get("netflow")
+            if val is None:
+                val = row.get("smart_money_delta")
+            if val is None:
+                continue
+
+            try:
+                result[sym] = float(val)
+            except (TypeError, ValueError):
+                continue
+
+        return result
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+async def _collect_direct(universe: list[str]) -> list[dict[str, Any]]:
+    """Collect TradFi basis rows and enrich with optional differentiated inputs."""
+
+    async with httpx.AsyncClient() as client:
+        base_rows = await _fetch_binance(client, universe)
+        liq_by_symbol = await _fetch_hl_liquidations(client, universe)
+        smart_money = await _fetch_nansen_smart_money(
+            client,
+            universe,
+            api_key=os.getenv("NANSEN_API_KEY"),
+        )
+
+    for row in base_rows:
+        sym = str(row.get("symbol", "")).upper().strip()
+        if not sym:
+            continue
+
+        row.update(liq_by_symbol.get(sym, {}))
+        row["smart_money_delta"] = smart_money.get(sym)
+
+    return base_rows
+
+
 def _dedupe_key(*, producer: str, symbol: str, ts: datetime) -> str:
     """Symbol + timestamp (+ producer) dedupe key."""
     return f"{EventType.SIGNAL_TRADFI_V1}:{producer}:{symbol}:{int(ts.timestamp())}"
@@ -251,6 +397,21 @@ class TradFiBasisInterpreter(Interpreter):
             action = "short"
         else:
             action = "flat"
+
+        # P3.3: differentiated confidence adjustments
+        liq_asym = float(sig.get("liq_asymmetry") or 0.5)
+        smart_delta: float | None
+        try:
+            smart_delta = float(sig.get("smart_money_delta")) if sig.get("smart_money_delta") is not None else None
+        except (TypeError, ValueError):
+            smart_delta = None
+
+        if action == "long" and liq_asym > 0.65:
+            raw_confidence *= 0.85
+        if action == "long" and smart_delta is not None and smart_delta > 0:
+            raw_confidence = min(raw_confidence * 1.1, 0.95)
+        if action == "long" and smart_delta is not None and smart_delta < -1_000_000:
+            raw_confidence *= 0.75
 
         if raw_confidence < 0.3 or action == "flat":
             return abstain(
@@ -315,7 +476,7 @@ class TradFiBasisProducer(BaseProducer):
             return []
 
         try:
-            return asyncio.run(_fetch_binance(httpx.AsyncClient(), universe))
+            return asyncio.run(_collect_direct(universe))
         except Exception:
             self.ctx.logger.exception("tradfi_binance_fetch_failed")
             return []
@@ -344,6 +505,10 @@ class TradFiBasisProducer(BaseProducer):
                 direction=direction,
                 confidence=confidence,
                 signal_reason=reason,
+                smart_money_delta=row.get("smart_money_delta"),
+                liquidation_cluster_long=row.get("liquidation_cluster_long"),
+                liquidation_cluster_short=row.get("liquidation_cluster_short"),
+                liq_asymmetry=row.get("liq_asymmetry"),
             )
             payload = payload_obj.model_dump(mode="json")
             out.append(

--- a/tests/unit/test_p3_3_differentiated_inputs.py
+++ b/tests/unit/test_p3_3_differentiated_inputs.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+import pytest
+
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import (
+    AbstentionReason,
+    OnchainSignalPayload,
+    SentimentSignalPayload,
+    TASignalPayload,
+    TradFiSignalPayload,
+)
+from engine.core.metrics import MetricsRegistry
+from engine.producers.base import ProducerContext
+from engine.producers.onchain import OnchainFlowsProducer
+from engine.producers.sentiment import MarketSentimentProducer
+from engine.producers.ta import TechnicalInterpreter
+from engine.producers.tradfi import TradFiBasisInterpreter, _fetch_hl_liquidations
+
+
+class DummyClient:
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:  # noqa: ARG002
+        raise AssertionError("network request should not be called in normalize tests")
+
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:  # noqa: ARG002
+        raise AssertionError("request_json should not be called in normalize tests")
+
+
+def _ctx(tmp_path, name: str) -> ProducerContext:
+    return ProducerContext(
+        config=Config(),
+        db=Database(tmp_path / f"{name}.db"),
+        client=DummyClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+
+def test_ta_payload_accepts_new_fields() -> None:
+    payload = TASignalPayload(
+        symbol="BTC",
+        rsi_14=52.0,
+        trend="bullish",
+        bb_width=0.031,
+        atr_14=1200.5,
+        volatility_compression=True,
+        breakout_failure=False,
+    )
+    assert payload.symbol == "BTC"
+    assert payload.bb_width == 0.031
+    assert payload.volatility_compression is True
+
+
+def test_onchain_payload_accepts_new_flow_fields() -> None:
+    payload = OnchainSignalPayload(
+        symbol="ETH",
+        exchange_flow=-2_000_000,
+        flow_direction="outflow",
+        flow_magnitude=0.4,
+        entity_type="whale",
+    )
+    assert payload.flow_direction == "outflow"
+    assert payload.flow_magnitude == 0.4
+    assert payload.entity_type == "whale"
+
+
+def test_tradfi_payload_accepts_new_liquidation_fields() -> None:
+    payload = TradFiSignalPayload(
+        symbol="BTC",
+        direction="long",
+        confidence=0.7,
+        smart_money_delta=1_500_000,
+        liquidation_cluster_long=20_000_000,
+        liquidation_cluster_short=12_000_000,
+        liq_asymmetry=0.625,
+    )
+    assert payload.smart_money_delta == 1_500_000
+    assert payload.liquidation_cluster_long == 20_000_000
+    assert payload.liq_asymmetry == 0.625
+
+
+def test_sentiment_payload_accepts_new_positioning_fields() -> None:
+    payload = SentimentSignalPayload(
+        symbol="SOL",
+        fear_greed=78.0,
+        long_short_ratio=2.3,
+        funding_extreme=True,
+        positioning_signal="extreme_long",
+    )
+    assert payload.long_short_ratio == 2.3
+    assert payload.funding_extreme is True
+    assert payload.positioning_signal == "extreme_long"
+
+
+def _ta_signal(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "symbol": "BTC",
+        "trend": "bullish",
+        "trend_strength": 0.6,
+        "rsi_14": 55.0,
+        "volatility_compression": False,
+        "breakout_failure": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_technical_interpreter_volatility_compression_boosts_confidence() -> None:
+    interpreter = TechnicalInterpreter()
+
+    baseline = interpreter.interpret(asset="BTC", horizon="4h", signals=[_ta_signal()])
+    boosted = interpreter.interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[_ta_signal(volatility_compression=True)],
+    )
+
+    assert baseline.action == "long"
+    assert boosted.action == "long"
+    assert boosted.confidence > baseline.confidence
+
+
+def test_technical_interpreter_breakout_failure_suppresses_confidence() -> None:
+    interpreter = TechnicalInterpreter()
+
+    baseline = interpreter.interpret(asset="BTC", horizon="4h", signals=[_ta_signal()])
+    suppressed = interpreter.interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[_ta_signal(breakout_failure=True)],
+    )
+
+    assert suppressed.action == "long"
+    assert suppressed.confidence < baseline.confidence
+
+
+def test_technical_interpreter_weak_trend_abstains() -> None:
+    interpreter = TechnicalInterpreter()
+
+    payload = interpreter.interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[_ta_signal(trend_strength=0.2)],
+    )
+
+    assert payload.action == "no_forecast"
+    assert payload.abstention_reason == AbstentionReason.INSUFFICIENT_DATA
+
+
+def test_tradfi_interpreter_suppresses_long_when_liq_asymmetry_high() -> None:
+    interpreter = TradFiBasisInterpreter()
+
+    payload = interpreter.interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[
+            {
+                "symbol": "BTC",
+                "direction": "long",
+                "confidence": 0.8,
+                "signal_reason": "setup",
+                "liq_asymmetry": 0.7,
+            }
+        ],
+    )
+
+    assert payload.action == "long"
+    assert payload.confidence == pytest.approx(0.68, rel=1e-3)
+
+
+def test_fetch_hl_liquidations_failure_returns_empty_dict() -> None:
+    class FailingClient:
+        async def post(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG002
+            raise httpx.TimeoutException("boom")
+
+    result = asyncio.run(_fetch_hl_liquidations(FailingClient(), ["BTC"]))
+    assert result == {}
+
+
+def test_onchain_normalize_sets_outflow_direction(tmp_path) -> None:
+    producer = OnchainFlowsProducer(_ctx(tmp_path, "onchain"))
+
+    events = producer.normalize(
+        [
+            {
+                "symbol": "BTC",
+                "exchange_flow": -2_500_000,
+            }
+        ]
+    )
+
+    assert len(events) == 1
+    payload = events[0].payload
+    assert payload["flow_direction"] == "outflow"
+    assert payload["flow_magnitude"] == pytest.approx(0.05, rel=1e-3)
+
+
+def test_sentiment_normalize_sets_extreme_long_from_fear_greed(tmp_path) -> None:
+    producer = MarketSentimentProducer(_ctx(tmp_path, "sentiment"))
+
+    events = producer.normalize([{"symbol": "BTC", "fear_greed": 85}])
+
+    assert len(events) == 1
+    payload = events[0].payload
+    assert payload["positioning_signal"] == "extreme_long"


### PR DESCRIPTION
## Summary

Closes #182

Enriches 4 producer signal schemas with differentiated inputs that let interpreters distinguish identical-looking metrics with different contexts.

## Type of change
- [x] `feat` — new feature

## Labels
Applied: `feat`, `producer`, `roadmap`

## Changes

- `engine/core/events.py` — new optional fields on TASignalPayload, OnchainSignalPayload, TradFiSignalPayload, SentimentSignalPayload
- `engine/producers/tradfi.py` — HL liquidation cluster fetch + liq_asymmetry interpreter logic
- `engine/producers/ta.py` — BB width/compression compute + TechnicalInterpreter with compression/failure signals
- `engine/producers/onchain.py` — directional flow classification (inflow/outflow/neutral) + magnitude
- `engine/producers/sentiment.py` — positioning extremes from F&G + L/S ratio + funding extreme flag
- `tests/unit/test_p3_3_differentiated_inputs.py` (new)

## Tests

- [x] New tests added
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: 877 passing

## Checklist

- [x] Branch targets `develop`
- [x] All new payload fields are optional (None default)
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` not modified
