### PR TITLE
feat(p3.4): producer self-memory — confidence adjustment from karma history

### DIFF
--- a/engine/core/interpreter.py
+++ b/engine/core/interpreter.py
@@ -22,6 +22,7 @@ from engine.core.forecast import abstain, compute_reasoning_hash
 from engine.core.llm_critic import LLMCritic
 from engine.core.regime import REGIME_CAPS as _REGIME_CAPS
 from engine.core.regime import RegimeMatrix
+from engine.core.self_memory import SelfMemory, SelfMemoryConfig
 from engine.core.utils import clamp
 
 logger = logging.getLogger(__name__)
@@ -393,3 +394,84 @@ class LLMCriticInterpreter(Interpreter):
 
         updated = candidate.model_copy(update={"confidence": new_confidence})
         return self._with_reasoning_hash(updated, critique=result.raw_response, rationale=result.rationale)
+
+
+class SelfMemoryInterpreter(Interpreter):
+    """Wrap an Interpreter and apply producer self-memory confidence deltas.
+
+    Self-memory is a bounded, pre-emit confidence modulation based on the
+    producer's own resolved forecast history.
+
+    Guardrails:
+    - no-op when DB is unavailable
+    - no-op when insufficient resolved samples
+    - confidence delta clamped by SelfMemoryConfig.max_delta
+    - action never changes (confidence only)
+    """
+
+    def __init__(
+        self,
+        inner: Interpreter,
+        db: Any | None = None,
+        config: SelfMemoryConfig | None = None,
+    ) -> None:
+        self.inner = inner
+        self.db = db
+        self._self_memory = SelfMemory(db, config) if db is not None else None
+
+        # Mirror identity at init; producer wiring may update self.* later.
+        self.producer_name = inner.producer_name
+        self.producer_version = inner.producer_version
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        # Keep source identity aligned with BaseProducer.emit_forecast() wiring.
+        self.inner.producer_name = self.producer_name
+        self.inner.producer_version = self.producer_version
+
+        candidate = self.inner.safe_interpret(
+            asset=asset,
+            horizon=horizon,
+            signals=signals,
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs,
+        )
+
+        if candidate.action == "no_forecast" or self._self_memory is None:
+            return candidate
+
+        result = self._self_memory.query(
+            producer_name=self.producer_name,
+            asset=asset,
+            regime=regime_tag,
+        )
+
+        if not result.applied:
+            logger.debug(
+                "self_memory_skipped: producer=%s reason=%s",
+                self.producer_name,
+                result.skip_reason or result.reason,
+            )
+            return candidate
+
+        new_confidence = clamp(float(candidate.confidence) + float(result.confidence_delta), 0.0, 1.0)
+
+        logger.info(
+            "self_memory_applied: producer=%s asset=%s original=%.4f delta=%+.4f new=%.4f long_brier=%s recent_brier=%s",
+            self.producer_name,
+            asset,
+            float(candidate.confidence),
+            float(result.confidence_delta),
+            float(new_confidence),
+            result.long_term_brier,
+            result.recent_brier,
+        )
+
+        return candidate.model_copy(update={"confidence": round(new_confidence, 4)})

--- a/engine/core/self_memory.py
+++ b/engine/core/self_memory.py
@@ -1,0 +1,170 @@
+"""engine.core.self_memory
+
+Producer self-memory confidence adjustment based on resolved forecast history.
+
+This module provides a small, bounded confidence modulation layer that can be
+applied before emitting a forecast. It does not change action (long/short/flat)
+and is guarded against unstable feedback loops.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from engine.core.utils import clamp
+
+# Guardrail defaults
+MIN_RESOLVED = 5
+MAX_DELTA = 0.30
+STREAK_WINDOW_DAYS = 3
+LONG_WINDOW_DAYS = 90
+STREAK_WEIGHT = 0.35
+
+GOOD_BRIER_THRESHOLD = 0.20
+POOR_BRIER_THRESHOLD = 0.33
+
+
+@dataclass(slots=True)
+class SelfMemoryResult:
+    """Outcome of a self-memory query."""
+
+    confidence_delta: float
+    applied: bool
+    reason: str
+    long_term_brier: float | None
+    recent_brier: float | None
+    resolved_count: int
+    skip_reason: str | None = None
+
+
+@dataclass(slots=True)
+class SelfMemoryConfig:
+    """Configuration for self-memory behavior."""
+
+    enabled: bool = True
+    min_resolved: int = MIN_RESOLVED
+    max_delta: float = MAX_DELTA
+    streak_window_days: int = STREAK_WINDOW_DAYS
+    long_window_days: int = LONG_WINDOW_DAYS
+    streak_weight: float = STREAK_WEIGHT
+
+
+class SelfMemory:
+    """Compute confidence deltas from producer calibration history.
+
+    - long-term Brier is the anchor
+    - recent Brier adds bounded recency
+    - optional regime performance contributes a small adjustment
+    - final delta is clamped to configured max_delta
+    """
+
+    def __init__(self, db: Any, config: SelfMemoryConfig | None = None) -> None:
+        self.db = db
+        self.config = config or SelfMemoryConfig()
+
+    def query(self, producer_name: str, asset: str, regime: str = "unknown") -> SelfMemoryResult:
+        """Return a bounded confidence delta for *producer_name*.
+
+        Args:
+            producer_name: Producer ID used in calibration rows.
+            asset: Included for call-site parity/future extension.
+            regime: Current regime tag for optional regime-conditioned scoring.
+        """
+        _ = asset  # reserved for future asset-specific calibration windows
+        cfg = self.config
+
+        if not cfg.enabled:
+            return SelfMemoryResult(
+                confidence_delta=0.0,
+                applied=False,
+                reason="disabled",
+                long_term_brier=None,
+                recent_brier=None,
+                resolved_count=0,
+                skip_reason="self-memory disabled in config",
+            )
+
+        from engine.brain.calibration import brier_summary
+
+        long_summary = brier_summary(self.db, producer_name, window_days=cfg.long_window_days)
+        resolved = int(long_summary.get("count", 0) or 0)
+        if resolved < cfg.min_resolved:
+            return SelfMemoryResult(
+                confidence_delta=0.0,
+                applied=False,
+                reason="insufficient_data",
+                long_term_brier=None,
+                recent_brier=None,
+                resolved_count=resolved,
+                skip_reason=f"only {resolved} resolved forecasts (need {cfg.min_resolved})",
+            )
+
+        long_raw = long_summary.get("mean_brier")
+        long_brier = float(long_raw) if long_raw is not None else 0.25
+
+        recent_summary = brier_summary(self.db, producer_name, window_days=cfg.streak_window_days)
+        recent_count = int(recent_summary.get("count", 0) or 0)
+        recent_brier: float | None
+        if recent_count >= 2 and recent_summary.get("mean_brier") is not None:
+            recent_brier = float(recent_summary["mean_brier"])
+        else:
+            recent_brier = None
+
+        long_delta = _brier_to_delta(long_brier)
+        recent_delta = _brier_to_delta(recent_brier) if recent_brier is not None else long_delta
+
+        streak_weight = clamp(float(cfg.streak_weight), 0.0, 1.0)
+        blended = (1.0 - streak_weight) * long_delta + streak_weight * recent_delta
+
+        regime_stats = _regime_stats(long_summary.get("regime_breakdown"), regime)
+        if regime_stats is not None:
+            regime_brier = regime_stats.get("mean_brier")
+            regime_count = int(regime_stats.get("count", 0) or 0)
+            if regime_brier is not None and regime_count >= 3:
+                regime_delta = _brier_to_delta(float(regime_brier))
+                blended = (blended * 0.8) + (regime_delta * 0.2)
+
+        final_delta = clamp(blended, -float(cfg.max_delta), float(cfg.max_delta))
+
+        reason_parts = [f"long_brier={long_brier:.3f}"]
+        if recent_brier is not None:
+            reason_parts.append(f"recent_brier={recent_brier:.3f}")
+        reason_parts.append(f"delta={final_delta:+.3f}")
+
+        return SelfMemoryResult(
+            confidence_delta=round(final_delta, 4),
+            applied=True,
+            reason=", ".join(reason_parts),
+            long_term_brier=round(long_brier, 4),
+            recent_brier=round(recent_brier, 4) if recent_brier is not None else None,
+            resolved_count=resolved,
+        )
+
+
+def _regime_stats(regime_breakdown: Any, regime: str) -> dict[str, Any] | None:
+    if not isinstance(regime_breakdown, dict):
+        return None
+
+    target = str(regime).upper()
+    if target in regime_breakdown and isinstance(regime_breakdown[target], dict):
+        return regime_breakdown[target]
+
+    for key, value in regime_breakdown.items():
+        if str(key).upper() == target and isinstance(value, dict):
+            return value
+
+    return None
+
+
+def _brier_to_delta(brier: float) -> float:
+    """Map Brier score to signed confidence delta."""
+    if brier <= 0.10:
+        return 0.15
+    if brier <= GOOD_BRIER_THRESHOLD:
+        return 0.08
+    if brier <= 0.25:
+        return 0.0
+    if brier <= POOR_BRIER_THRESHOLD:
+        return -0.10
+    return -0.20

--- a/tests/unit/test_self_memory.py
+++ b/tests/unit/test_self_memory.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from engine.core.events import AbstentionReason, ForecastLifecycleState, ForecastPayload
+from engine.core.forecast import make_forecast_id
+from engine.core.interpreter import Interpreter, NullInterpreter, SelfMemoryInterpreter
+from engine.core.self_memory import MAX_DELTA, SelfMemory, SelfMemoryConfig, _brier_to_delta
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    from datetime import timezone as _tz  # noqa: PLC0415
+
+    UTC = _tz.utc  # noqa: N806, UP017
+
+
+@pytest.fixture()
+def memory_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE forecast_calibration (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            forecast_id TEXT NOT NULL UNIQUE,
+            producer_name TEXT NOT NULL,
+            asset TEXT NOT NULL,
+            regime TEXT NOT NULL DEFAULT 'unknown',
+            horizon TEXT NOT NULL,
+            direction TEXT NOT NULL,
+            confidence REAL NOT NULL,
+            calibrated INTEGER NOT NULL DEFAULT 0,
+            outcome REAL,
+            brier_score REAL,
+            price_at_emit REAL,
+            price_at_resolve REAL,
+            emitted_at TEXT NOT NULL,
+            resolved_at TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _ts(days_ago: int, offset_minutes: int) -> str:
+    return (datetime.now(tz=UTC) - timedelta(days=days_ago, minutes=offset_minutes)).isoformat()
+
+
+def _seed_resolved(
+    conn: sqlite3.Connection,
+    *,
+    prefix: str,
+    producer: str,
+    regime: str,
+    brier: float,
+    count: int,
+    days_ago: int,
+    confidence: float = 0.6,
+) -> None:
+    for i in range(count):
+        conn.execute(
+            """
+            INSERT INTO forecast_calibration
+                (forecast_id, producer_name, asset, regime, horizon, direction,
+                 confidence, outcome, brier_score, emitted_at, resolved_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"{prefix}-{i}",
+                producer,
+                "BTC",
+                regime,
+                "4h",
+                "bullish",
+                confidence,
+                1.0,
+                brier,
+                _ts(days_ago + 1, i),
+                _ts(days_ago, i),
+            ),
+        )
+    conn.commit()
+
+
+class _StaticInterpreter(Interpreter):
+    producer_name = "unit-producer"
+    producer_version = "1.0.0"
+
+    def __init__(self, payload: ForecastPayload) -> None:
+        self.payload = payload
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        return self.payload.model_copy(deep=True)
+
+
+def _mk_payload(*, action: str = "long", confidence: float = 0.6) -> ForecastPayload:
+    kwargs: dict[str, Any] = {
+        "forecast_id": make_forecast_id(),
+        "asset": "BTC",
+        "horizon": "4h",
+        "action": action,
+        "confidence": confidence,
+        "source": "unit-producer@1.0.0",
+        "regime_tag": "unknown",
+        "lifecycle_state": ForecastLifecycleState.NEW,
+        "visible_signal_refs": ["evt-1"],
+        "used_signal_refs": ["evt-1"],
+    }
+    if action == "no_forecast":
+        kwargs["confidence"] = 0.0
+        kwargs["abstention_reason"] = AbstentionReason.INSUFFICIENT_DATA
+    return ForecastPayload(**kwargs)
+
+
+def test_brier_to_delta_excellent() -> None:
+    assert _brier_to_delta(0.05) == pytest.approx(0.15)
+
+
+def test_brier_to_delta_random_baseline() -> None:
+    assert _brier_to_delta(0.25) == pytest.approx(0.0)
+
+
+def test_brier_to_delta_poor() -> None:
+    assert _brier_to_delta(0.40) == pytest.approx(-0.20)
+
+
+def test_self_memory_query_empty_db_returns_not_applied(memory_db: sqlite3.Connection) -> None:
+    result = SelfMemory(memory_db).query(producer_name="unit-producer", asset="BTC", regime="BULL")
+
+    assert result.applied is False
+    assert result.resolved_count == 0
+    assert result.confidence_delta == pytest.approx(0.0)
+
+
+def test_self_memory_query_good_history_returns_positive_delta(memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="good",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.15,
+        count=10,
+        days_ago=1,
+    )
+
+    result = SelfMemory(memory_db).query(producer_name="unit-producer", asset="BTC", regime="BULL")
+
+    assert result.applied is True
+    assert result.resolved_count == 10
+    assert result.confidence_delta > 0.0
+
+
+def test_self_memory_query_poor_history_returns_negative_delta(memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="poor",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.35,
+        count=10,
+        days_ago=1,
+    )
+
+    result = SelfMemory(memory_db).query(producer_name="unit-producer", asset="BTC", regime="BULL")
+
+    assert result.applied is True
+    assert result.resolved_count == 10
+    assert result.confidence_delta < 0.0
+
+
+def test_self_memory_query_recent_poor_streak_overrides_long_term(memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="long-good",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.15,
+        count=8,
+        days_ago=30,
+    )
+    _seed_resolved(
+        memory_db,
+        prefix="recent-poor",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.40,
+        count=2,
+        days_ago=1,
+    )
+
+    result = SelfMemory(memory_db).query(producer_name="unit-producer", asset="BTC", regime="UNKNOWN")
+
+    assert result.applied is True
+    assert result.resolved_count == 10
+    assert result.confidence_delta < 0.0
+
+
+def test_self_memory_query_caps_positive_delta_at_max(monkeypatch: pytest.MonkeyPatch, memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="cap-pos",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.15,
+        count=10,
+        days_ago=1,
+    )
+    monkeypatch.setattr("engine.core.self_memory._brier_to_delta", lambda _brier: 2.0)
+
+    result = SelfMemory(memory_db, config=SelfMemoryConfig(max_delta=MAX_DELTA)).query(
+        producer_name="unit-producer",
+        asset="BTC",
+        regime="BULL",
+    )
+
+    assert result.applied is True
+    assert result.confidence_delta == pytest.approx(MAX_DELTA)
+
+
+def test_self_memory_query_caps_negative_delta_at_max(monkeypatch: pytest.MonkeyPatch, memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="cap-neg",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.15,
+        count=10,
+        days_ago=1,
+    )
+    monkeypatch.setattr("engine.core.self_memory._brier_to_delta", lambda _brier: -2.0)
+
+    result = SelfMemory(memory_db, config=SelfMemoryConfig(max_delta=MAX_DELTA)).query(
+        producer_name="unit-producer",
+        asset="BTC",
+        regime="BULL",
+    )
+
+    assert result.applied is True
+    assert result.confidence_delta == pytest.approx(-MAX_DELTA)
+
+
+def test_self_memory_interpreter_with_no_db_passes_through_unchanged() -> None:
+    candidate = _mk_payload(action="long", confidence=0.61)
+    wrapped = SelfMemoryInterpreter(inner=_StaticInterpreter(candidate), db=None)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == candidate.action
+    assert out.confidence == pytest.approx(candidate.confidence)
+
+
+def test_self_memory_interpreter_wrapping_null_interpreter_preserves_abstention(memory_db: sqlite3.Connection) -> None:
+    wrapped = SelfMemoryInterpreter(inner=NullInterpreter(), db=memory_db)
+    wrapped.producer_name = "unit-producer"
+    wrapped.producer_version = "1.0.0"
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "no_forecast"
+    assert out.abstention_reason == AbstentionReason.INSUFFICIENT_DATA
+
+
+def test_self_memory_interpreter_boosts_confidence_for_good_track_record(memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="interp-good",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.15,
+        count=10,
+        days_ago=1,
+    )
+    candidate = _mk_payload(action="long", confidence=0.50)
+    wrapped = SelfMemoryInterpreter(inner=_StaticInterpreter(candidate), db=memory_db)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "long"
+    assert out.confidence > candidate.confidence
+
+
+def test_self_memory_interpreter_suppresses_confidence_for_poor_track_record(memory_db: sqlite3.Connection) -> None:
+    _seed_resolved(
+        memory_db,
+        prefix="interp-poor",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.35,
+        count=10,
+        days_ago=1,
+    )
+    candidate = _mk_payload(action="long", confidence=0.65)
+    wrapped = SelfMemoryInterpreter(inner=_StaticInterpreter(candidate), db=memory_db)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "long"
+    assert out.confidence < candidate.confidence
+
+
+def test_self_memory_interpreter_regime_specific_worse_performance_adds_suppression(memory_db: sqlite3.Connection) -> None:
+    # Overall mean ~= 0.24 (neutral), BULL regime good, BEAR regime poor.
+    _seed_resolved(
+        memory_db,
+        prefix="mix-bull",
+        producer="unit-producer",
+        regime="BULL",
+        brier=0.15,
+        count=7,
+        days_ago=10,
+    )
+    _seed_resolved(
+        memory_db,
+        prefix="mix-bear",
+        producer="unit-producer",
+        regime="BEAR",
+        brier=0.45,
+        count=3,
+        days_ago=10,
+    )
+
+    candidate = _mk_payload(action="long", confidence=0.70)
+    wrapped = SelfMemoryInterpreter(inner=_StaticInterpreter(candidate), db=memory_db)
+
+    out_bull = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+    out_bear = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BEAR")
+
+    assert out_bear.action == "long"
+    assert out_bull.action == "long"
+    assert out_bear.confidence < out_bull.confidence
+    assert out_bear.confidence < candidate.confidence


### PR DESCRIPTION
## Summary

Closes #183

Producers query their own resolved forecast history before emitting. Recent + long-term Brier score history adjusts confidence within guardrails: bounded ±30%, action immutable, insufficient data → no-op.

## Type of change
- [x] `feat` — new feature

## Labels
Applied: `feat`, `brain`, `roadmap`

## Changes

- `engine/core/self_memory.py` (new) — `SelfMemory`, `SelfMemoryResult`, `SelfMemoryConfig`, `_brier_to_delta()`
- `engine/core/interpreter.py` — `SelfMemoryInterpreter` wrapper
- `tests/unit/test_self_memory.py` (new) — full coverage (14 tests)

## Tests

- [x] New tests added
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: 891 passing

## Checklist

- [x] Branch targets `develop`
- [x] Action never changes — confidence only
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` not modified