### PR TITLE
feat(p3.5): adversarial prosecutor pass — LLM counter-case gate before emit

### DIFF
--- a/engine/core/interpreter.py
+++ b/engine/core/interpreter.py
@@ -20,6 +20,7 @@ from typing import Any
 from engine.core.events import AbstentionReason, ForecastPayload
 from engine.core.forecast import abstain, compute_reasoning_hash
 from engine.core.llm_critic import LLMCritic
+from engine.core.prosecutor import ProsecutionResult, Prosecutor
 from engine.core.regime import REGIME_CAPS as _REGIME_CAPS
 from engine.core.regime import RegimeMatrix
 from engine.core.self_memory import SelfMemory, SelfMemoryConfig
@@ -475,3 +476,105 @@ class SelfMemoryInterpreter(Interpreter):
         )
 
         return candidate.model_copy(update={"confidence": round(new_confidence, 4)})
+
+
+class ProsecutorInterpreter(Interpreter):
+    """Wrap an Interpreter and run an adversarial prosecutor pass post-emit.
+
+    The prosecutor constructs the strongest counter-case against a candidate.
+    - suppress=True (and not shadow): abstain
+    - confidence_boost>0 (and not shadow): apply bounded confidence boost
+    - shadow=True (default): log only, never mutates candidate
+
+    Position in stack: last gate before emission.
+    """
+
+    def __init__(
+        self,
+        inner: Interpreter,
+        prosecutor: Prosecutor | None = None,
+        shadow: bool = True,
+        regime_caps: dict[str, float] | None = None,
+    ) -> None:
+        self.inner = inner
+        self.prosecutor = prosecutor
+        self.shadow = shadow
+        self._regime_caps: dict[str, float] = regime_caps if regime_caps is not None else _REGIME_CAPS
+
+        # Mirror identity at init; producer wiring may update self.* later.
+        self.producer_name = inner.producer_name
+        self.producer_version = inner.producer_version
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        # Keep source identity aligned with BaseProducer.emit_forecast() wiring.
+        self.inner.producer_name = self.producer_name
+        self.inner.producer_version = self.producer_version
+
+        candidate = self.inner.safe_interpret(
+            asset=asset,
+            horizon=horizon,
+            signals=signals,
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs,
+        )
+
+        # Pass through abstentions or when prosecutor is unconfigured.
+        if candidate.action == "no_forecast" or self.prosecutor is None:
+            return candidate
+
+        result: ProsecutionResult = self.prosecutor.prosecute(
+            candidate=candidate,
+            signals=signals,
+            regime_tag=regime_tag,
+        )
+
+        if result.error:
+            logger.warning("prosecutor_failed: %s", result.error)
+            return candidate
+
+        effective_shadow = self.shadow or self.prosecutor.config.shadow
+
+        logger.info(
+            "prosecutor_result: producer=%s asset=%s action=%s confidence=%.4f "
+            "bear_strength=%.4f bull_strength=%.4f suppress=%s confidence_boost=%.4f shadow=%s rationale=%s",
+            self.producer_name,
+            asset,
+            candidate.action,
+            float(candidate.confidence),
+            float(result.bear_strength),
+            float(result.bull_strength),
+            result.suppress,
+            float(result.confidence_boost),
+            effective_shadow,
+            result.rationale,
+        )
+
+        if effective_shadow:
+            return candidate
+
+        if result.suppress:
+            return abstain(
+                source=candidate.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.LOW_CONFIDENCE,
+                regime_tag=regime_tag,
+                visible_signal_refs=candidate.visible_signal_refs,
+            )
+
+        if result.confidence_boost > 0:
+            new_confidence = clamp(float(candidate.confidence) + float(result.confidence_boost), 0.0, 1.0)
+            regime_cap = clamp(float(self._regime_caps.get(regime_tag.upper(), 10.0)) / 10.0, 0.0, 1.0)
+            new_confidence = min(new_confidence, regime_cap)
+            if new_confidence != candidate.confidence:
+                return candidate.model_copy(update={"confidence": round(new_confidence, 4)})
+
+        return candidate

--- a/engine/core/prosecutor.py
+++ b/engine/core/prosecutor.py
@@ -1,0 +1,253 @@
+"""engine.core.prosecutor
+
+Adversarial LLM pass — prosecutor, not curator.
+
+The prosecutor's job: find the strongest bear case against the current
+forecast. If the bear case is stronger than the bull case, suppress.
+If the bear case is weak, the conviction increases.
+
+Catches correlated inputs: when all signals agree because they're
+measuring the same thing from different angles.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from engine.core.events import ForecastPayload
+from engine.core.utils import clamp
+
+_PROSECUTOR_SYSTEM_PROMPT = (
+    "You are a skeptical prosecutor reviewing a trading forecast.\n"
+    "Your job: construct the STRONGEST possible case AGAINST this forecast.\n"
+    "Find correlated inputs, missing risks, or reasons the thesis fails.\n"
+    "Be concise. Respond ONLY in JSON with keys:\n"
+    "  bear_strength (0.0-1.0): strength of the bear/counter case\n"
+    "  bull_strength (0.0-1.0): strength of the bull/thesis case from the data\n"
+    "  suppress (bool): true if bear_strength > bull_strength by more than 0.15\n"
+    "  confidence_boost (float, 0.0-0.15): bonus if bear case is weak (bear_strength < 0.25)\n"
+    "  rationale (str): one-sentence reason\n"
+    "If uncertain, set suppress=false and confidence_boost=0."
+)
+
+
+def _as_bool(raw: str | None, default: bool) -> bool:
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _as_float(raw: str | None, default: float) -> float:
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True, slots=True)
+class ProsecutorConfig:
+    enabled: bool = False
+    url: str = "https://api.openai.com/v1"
+    key: str | None = None
+    model: str = "gpt-4o-mini"
+    timeout_s: float = 8.0
+    # shadow=True: log result but never suppress/boost.
+    shadow: bool = True
+
+    @classmethod
+    def from_env(cls) -> ProsecutorConfig:
+        return cls(
+            enabled=_as_bool(os.getenv("B1E55ED_PROSECUTOR_ENABLED"), False),
+            url=os.getenv("B1E55ED_PROSECUTOR_URL", "https://api.openai.com/v1"),
+            key=os.getenv("B1E55ED_PROSECUTOR_KEY") or os.getenv("OPENAI_API_KEY"),
+            model=os.getenv("B1E55ED_PROSECUTOR_MODEL", "gpt-4o-mini"),
+            timeout_s=_as_float(os.getenv("B1E55ED_PROSECUTOR_TIMEOUT_S"), 8.0),
+            shadow=_as_bool(os.getenv("B1E55ED_PROSECUTOR_SHADOW"), True),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProsecutionResult:
+    bear_strength: float
+    bull_strength: float
+    suppress: bool
+    confidence_boost: float
+    rationale: str
+    raw_response: str
+    error: str | None = None
+
+
+class Prosecutor:
+    """Adversarial LLM pass — finds the strongest counter-case against a forecast."""
+
+    def __init__(self, config: ProsecutorConfig) -> None:
+        self.config = config
+
+    @staticmethod
+    def _summarize_signals(signals: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Keep only the most relevant fields for LLM context."""
+        top = signals[:5]
+        summarized: list[dict[str, Any]] = []
+        for signal in top:
+            keep = {k: v for k, v in signal.items() if v is not None and k not in ("reasoning_hash", "forecast_id")}
+            summarized.append(keep)
+        return summarized
+
+    @staticmethod
+    def _extract_content(response_json: dict[str, Any]) -> str:
+        choices = response_json.get("choices")
+        if not isinstance(choices, list) or not choices:
+            raise ValueError("missing choices in prosecutor LLM response")
+
+        first = choices[0]
+        if not isinstance(first, dict):
+            raise ValueError("invalid first choice in prosecutor LLM response")
+
+        message = first.get("message")
+        if not isinstance(message, dict):
+            raise ValueError("missing message in prosecutor LLM response")
+
+        content = message.get("content", "")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for chunk in content:
+                if isinstance(chunk, str):
+                    parts.append(chunk)
+                    continue
+                if isinstance(chunk, dict) and isinstance(chunk.get("text"), str):
+                    parts.append(str(chunk["text"]))
+            return "".join(parts)
+
+        raise ValueError("unsupported prosecutor message content shape")
+
+    @staticmethod
+    def _parse_json(raw_text: str) -> dict[str, Any]:
+        cleaned = raw_text.strip()
+        if cleaned.startswith("```"):
+            cleaned = re.sub(r"^```(?:json)?", "", cleaned, count=1).strip()
+            if cleaned.endswith("```"):
+                cleaned = cleaned[:-3].strip()
+
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError:
+            start = cleaned.find("{")
+            end = cleaned.rfind("}")
+            if start < 0 or end <= start:
+                raise
+            parsed = json.loads(cleaned[start : end + 1])
+
+        if not isinstance(parsed, dict):
+            raise ValueError("prosecutor response JSON must be an object")
+        return parsed
+
+    def prosecute(
+        self,
+        *,
+        candidate: ForecastPayload,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+    ) -> ProsecutionResult:
+        """Run the adversarial pass. Never raises; returns an error result on failure."""
+        cfg = self.config
+        if not cfg.enabled:
+            return ProsecutionResult(
+                bear_strength=0.0,
+                bull_strength=1.0,
+                suppress=False,
+                confidence_boost=0.0,
+                rationale="prosecutor_disabled",
+                raw_response="",
+            )
+
+        prompt = (
+            f"Forecast: action={candidate.action}, confidence={candidate.confidence:.2f}, "
+            f"asset={candidate.asset}, horizon={candidate.horizon}, regime={regime_tag}\n"
+            f"Signals: {json.dumps(self._summarize_signals(signals), separators=(',', ':'))}\n"
+            "What is the strongest case AGAINST this forecast?"
+        )
+
+        try:
+            if not cfg.key:
+                raise ValueError("prosecutor API key missing")
+
+            payload = {
+                "model": cfg.model,
+                "messages": [
+                    {"role": "system", "content": _PROSECUTOR_SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+                "max_tokens": 200,
+                "temperature": 0.1,
+            }
+            headers = {
+                "Authorization": f"Bearer {cfg.key}",
+                "Content-Type": "application/json",
+            }
+
+            with httpx.Client(base_url=cfg.url.rstrip("/"), timeout=cfg.timeout_s) as client:
+                response = client.post("/chat/completions", json=payload, headers=headers)
+                response.raise_for_status()
+                response_json = response.json()
+
+            raw_response = self._extract_content(response_json)
+        except Exception as exc:  # noqa: BLE001
+            return ProsecutionResult(
+                bear_strength=0.0,
+                bull_strength=1.0,
+                suppress=False,
+                confidence_boost=0.0,
+                rationale="prosecutor_error",
+                raw_response="",
+                error=str(exc),
+            )
+
+        return self._parse(raw_response)
+
+    @staticmethod
+    def _parse(raw: str) -> ProsecutionResult:
+        """Parse JSON from LLM response. Fails gracefully."""
+        try:
+            data = Prosecutor._parse_json(raw)
+            bear = clamp(float(data.get("bear_strength", 0.0)), 0.0, 1.0)
+            bull = clamp(float(data.get("bull_strength", 1.0)), 0.0, 1.0)
+
+            suppress_raw = data.get("suppress", False)
+            if isinstance(suppress_raw, bool):
+                suppress = suppress_raw
+            elif isinstance(suppress_raw, (int, float)):
+                suppress = bool(suppress_raw)
+            else:
+                suppress = _as_bool(str(suppress_raw) if suppress_raw is not None else None, False)
+
+            confidence_boost = clamp(float(data.get("confidence_boost", 0.0)), 0.0, 0.15)
+            rationale = str(data.get("rationale", "")).strip()
+
+            return ProsecutionResult(
+                bear_strength=bear,
+                bull_strength=bull,
+                suppress=suppress,
+                confidence_boost=confidence_boost,
+                rationale=rationale,
+                raw_response=raw,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ProsecutionResult(
+                bear_strength=0.0,
+                bull_strength=1.0,
+                suppress=False,
+                confidence_boost=0.0,
+                rationale="parse_error",
+                raw_response=raw,
+                error=str(exc),
+            )

--- a/tests/unit/test_prosecutor.py
+++ b/tests/unit/test_prosecutor.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from engine.core.events import AbstentionReason, ForecastLifecycleState, ForecastPayload
+from engine.core.forecast import make_forecast_id
+from engine.core.interpreter import Interpreter, ProsecutorInterpreter, SelfMemoryInterpreter
+from engine.core.prosecutor import ProsecutionResult, Prosecutor, ProsecutorConfig
+from engine.producers.tradfi import TradFiBasisInterpreter
+
+
+class _StaticInterpreter(Interpreter):
+    producer_name = "unit-producer"
+    producer_version = "1.0.0"
+
+    def __init__(self, payload: ForecastPayload) -> None:
+        self.payload = payload
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        return self.payload.model_copy(deep=True)
+
+
+class _FakeProsecutor:
+    def __init__(self, result: ProsecutionResult, *, enabled: bool = True, shadow: bool = False) -> None:
+        self.result = result
+        self.called = False
+        self.config = ProsecutorConfig(enabled=enabled, shadow=shadow)
+
+    def prosecute(
+        self,
+        *,
+        candidate: ForecastPayload,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+    ) -> ProsecutionResult:
+        self.called = True
+        return self.result
+
+
+def _mk_payload(*, action: str = "long", confidence: float = 0.6) -> ForecastPayload:
+    kwargs: dict[str, Any] = {
+        "forecast_id": make_forecast_id(),
+        "asset": "BTC",
+        "horizon": "4h",
+        "action": action,
+        "confidence": confidence,
+        "source": "unit-producer@1.0.0",
+        "regime_tag": "unknown",
+        "lifecycle_state": ForecastLifecycleState.NEW,
+        "visible_signal_refs": ["evt-1"],
+        "used_signal_refs": ["evt-1"],
+    }
+    if action == "no_forecast":
+        kwargs["confidence"] = 0.0
+        kwargs["abstention_reason"] = AbstentionReason.INSUFFICIENT_DATA
+    return ForecastPayload(**kwargs)
+
+
+def test_prosecutor_parse_valid_json() -> None:
+    raw = '{"bear_strength":0.72,"bull_strength":0.41,"suppress":true,"confidence_boost":0.05,"rationale":"bear case dominates"}'
+
+    result = Prosecutor._parse(raw)
+
+    assert result.error is None
+    assert result.bear_strength == pytest.approx(0.72)
+    assert result.bull_strength == pytest.approx(0.41)
+    assert result.suppress is True
+    assert result.confidence_boost == pytest.approx(0.05)
+    assert result.rationale == "bear case dominates"
+
+
+def test_prosecutor_parse_markdown_fenced_json() -> None:
+    raw = """```json
+    {
+      "bear_strength": 0.10,
+      "bull_strength": 0.80,
+      "suppress": false,
+      "confidence_boost": 0.10,
+      "rationale": "counter-case is weak"
+    }
+    ```"""
+
+    result = Prosecutor._parse(raw)
+
+    assert result.error is None
+    assert result.suppress is False
+    assert result.confidence_boost == pytest.approx(0.10)
+    assert result.rationale == "counter-case is weak"
+
+
+def test_prosecutor_parse_garbage_returns_safe_fallback() -> None:
+    result = Prosecutor._parse("definitely not json")
+
+    assert result.error is not None
+    assert result.rationale == "parse_error"
+    assert result.suppress is False
+    assert result.confidence_boost == pytest.approx(0.0)
+
+
+def test_prosecutor_prosecute_disabled_returns_noop() -> None:
+    prosecutor = Prosecutor(ProsecutorConfig(enabled=False))
+
+    result = prosecutor.prosecute(candidate=_mk_payload(), signals=[{"name": "x"}], regime_tag="BULL")
+
+    assert result.suppress is False
+    assert result.confidence_boost == pytest.approx(0.0)
+    assert result.rationale == "prosecutor_disabled"
+
+
+def test_prosecutor_prosecute_httpx_error_returns_safe_result() -> None:
+    prosecutor = Prosecutor(ProsecutorConfig(enabled=True, key="test-key"))
+
+    with patch("engine.core.prosecutor.httpx.Client", side_effect=httpx.TimeoutException("boom")):
+        result = prosecutor.prosecute(candidate=_mk_payload(), signals=[{"name": "x"}], regime_tag="BULL")
+
+    assert result.suppress is False
+    assert result.confidence_boost == pytest.approx(0.0)
+    assert result.rationale == "prosecutor_error"
+    assert result.error is not None
+
+
+def test_prosecutor_config_from_env_reads_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B1E55ED_PROSECUTOR_ENABLED", "true")
+    monkeypatch.setenv("B1E55ED_PROSECUTOR_URL", "https://llm.example/v1")
+    monkeypatch.setenv("B1E55ED_PROSECUTOR_MODEL", "test-model")
+    monkeypatch.setenv("B1E55ED_PROSECUTOR_TIMEOUT_S", "3.25")
+    monkeypatch.setenv("B1E55ED_PROSECUTOR_SHADOW", "false")
+    monkeypatch.delenv("B1E55ED_PROSECUTOR_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "fallback-key")
+
+    cfg = ProsecutorConfig.from_env()
+
+    assert cfg.enabled is True
+    assert cfg.url == "https://llm.example/v1"
+    assert cfg.key == "fallback-key"
+    assert cfg.model == "test-model"
+    assert cfg.timeout_s == pytest.approx(3.25)
+    assert cfg.shadow is False
+
+
+def test_prosecutor_interpreter_without_prosecutor_passes_through() -> None:
+    candidate = _mk_payload(action="long", confidence=0.61)
+    wrapped = ProsecutorInterpreter(inner=_StaticInterpreter(candidate), prosecutor=None, shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == candidate.action
+    assert out.confidence == pytest.approx(candidate.confidence)
+
+
+def test_prosecutor_interpreter_shadow_mode_does_not_suppress() -> None:
+    candidate = _mk_payload(action="long", confidence=0.62)
+    fake = _FakeProsecutor(
+        ProsecutionResult(
+            bear_strength=0.85,
+            bull_strength=0.35,
+            suppress=True,
+            confidence_boost=0.0,
+            rationale="strong bear case",
+            raw_response="{}",
+        ),
+        enabled=True,
+        shadow=False,
+    )
+    wrapped = ProsecutorInterpreter(inner=_StaticInterpreter(candidate), prosecutor=fake, shadow=True)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert fake.called is True
+    assert out.action == candidate.action
+    assert out.confidence == pytest.approx(candidate.confidence)
+
+
+def test_prosecutor_interpreter_live_mode_suppresses_to_abstention() -> None:
+    candidate = _mk_payload(action="long", confidence=0.62)
+    fake = _FakeProsecutor(
+        ProsecutionResult(
+            bear_strength=0.80,
+            bull_strength=0.40,
+            suppress=True,
+            confidence_boost=0.0,
+            rationale="counter-thesis stronger",
+            raw_response="{}",
+        ),
+        enabled=True,
+        shadow=False,
+    )
+    wrapped = ProsecutorInterpreter(inner=_StaticInterpreter(candidate), prosecutor=fake, shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "no_forecast"
+    assert out.abstention_reason == AbstentionReason.LOW_CONFIDENCE
+
+
+def test_prosecutor_interpreter_live_mode_applies_confidence_boost() -> None:
+    candidate = _mk_payload(action="long", confidence=0.60)
+    fake = _FakeProsecutor(
+        ProsecutionResult(
+            bear_strength=0.20,
+            bull_strength=0.70,
+            suppress=False,
+            confidence_boost=0.10,
+            rationale="weak bear case",
+            raw_response="{}",
+        ),
+        enabled=True,
+        shadow=False,
+    )
+    wrapped = ProsecutorInterpreter(inner=_StaticInterpreter(candidate), prosecutor=fake, shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "long"
+    assert out.confidence == pytest.approx(0.70)
+
+
+def test_prosecutor_interpreter_live_mode_boost_respects_regime_cap() -> None:
+    candidate = _mk_payload(action="long", confidence=0.68)
+    fake = _FakeProsecutor(
+        ProsecutionResult(
+            bear_strength=0.15,
+            bull_strength=0.80,
+            suppress=False,
+            confidence_boost=0.10,
+            rationale="weak bear case",
+            raw_response="{}",
+        ),
+        enabled=True,
+        shadow=False,
+    )
+    wrapped = ProsecutorInterpreter(inner=_StaticInterpreter(candidate), prosecutor=fake, shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BEAR")
+
+    assert out.action == "long"
+    assert out.confidence == pytest.approx(0.70)
+
+
+def test_prosecutor_interpreter_no_forecast_passes_through_without_prosecution() -> None:
+    candidate = _mk_payload(action="no_forecast")
+    fake = _FakeProsecutor(
+        ProsecutionResult(
+            bear_strength=1.0,
+            bull_strength=0.0,
+            suppress=True,
+            confidence_boost=0.0,
+            rationale="irrelevant",
+            raw_response="{}",
+        ),
+        enabled=True,
+        shadow=False,
+    )
+    wrapped = ProsecutorInterpreter(inner=_StaticInterpreter(candidate), prosecutor=fake, shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "no_forecast"
+    assert fake.called is False
+
+
+def test_full_stack_prosecutor_over_self_memory_over_tradfi_composes() -> None:
+    stack = ProsecutorInterpreter(
+        inner=SelfMemoryInterpreter(inner=TradFiBasisInterpreter(), db=None),
+        prosecutor=None,
+        shadow=False,
+    )
+    stack.producer_name = "tradfi-basis"
+    stack.producer_version = "1.0.0"
+
+    out = stack.interpret(
+        asset="BTC",
+        horizon="4h",
+        signals=[
+            {
+                "symbol": "BTC",
+                "direction": "long",
+                "confidence": 0.75,
+                "signal_reason": "carry edge",
+                "liq_asymmetry": 0.50,
+            }
+        ],
+        regime_tag="BULL",
+        visible_signal_refs=["evt-1"],
+    )
+
+    assert out.action == "long"
+    assert out.source == "tradfi-basis@1.0.0"
+    assert out.confidence > 0.75
+    assert out.visible_signal_refs == ["evt-1"]


### PR DESCRIPTION
## Summary

Closes #184

Final gate in the P3 interpreter stack. Adversarial LLM pass with inverted objective: find the strongest counter-case against the forecast. Bear case > bull case → suppress to no_forecast. Bear case weak → bounded confidence boost. Default: shadow mode (observe only).

Stack after P3.5: Rule engine → RegimeMatrix → SelfMemory → LLMCritic → Prosecutor → emit

## Type of change
- [x] `feat` — new feature

## Labels
Applied: `feat`, `brain`, `roadmap`

## Changes

- `engine/core/prosecutor.py` (new) — `Prosecutor`, `ProsecutorConfig`, `ProsecutionResult`, `_parse()`
- `engine/core/interpreter.py` — `ProsecutorInterpreter` wrapper
- `tests/unit/test_prosecutor.py` (new) — 13 tests, full coverage

## Tests

- [x] New tests added (13)
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: 904 passing
- [x] Smoke tests pass: `uv run python tests/smoke.py`
- [x] Ruff clean: `ruff check engine/core/prosecutor.py engine/core/interpreter.py`

## Checklist

- [x] Branch targets `develop`
- [x] shadow=True by default — no live suppression without explicit opt-in
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` not modified
- [x] No new dependencies added