### PR TITLE
feat(p4.1): hierarchical weighting — domain priors modulated by reliability, asset_fit, regime_fit, correlation

### DIFF
--- a/engine/brain/hierarchy.py
+++ b/engine/brain/hierarchy.py
@@ -1,0 +1,326 @@
+"""engine.brain.hierarchy
+
+Hierarchical weight computation for P4.1.
+
+Computes per-domain weight multipliers from:
+  - producer_reliability: trailing Brier score (regime-aware)
+  - asset_fit: per-asset per-domain historical performance
+  - regime_fit: domain performance in current regime
+  - correlation_penalty: from P2.3 correlation data
+
+freshness_factor already applied in build_snapshot() — not here.
+
+All multipliers return 1.0 (neutral) when data is insufficient,
+ensuring graceful degradation when tables are empty or P2.x data
+is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Guardrail constants
+MIN_BRIER_SAMPLES = 5  # minimum resolved forecasts before reliability applies
+MIN_ASSET_SAMPLES = 3  # minimum per-asset samples before asset_fit applies
+RELIABILITY_WEIGHT = 0.40  # weight of producer reliability in final multiplier
+ASSET_FIT_WEIGHT = 0.25  # weight of asset fit
+REGIME_FIT_WEIGHT = 0.25  # weight of regime fit
+CORRELATION_WEIGHT = 0.10  # weight of correlation penalty
+MAX_MULTIPLIER = 2.0  # cap: a domain can at most double its prior weight
+MIN_MULTIPLIER = 0.1  # floor: a domain can at most lose 90% of its prior weight
+
+
+@dataclass
+class HierarchyFactors:
+    """Per-domain weight factors computed for one cycle."""
+
+    domain: str
+    producer_reliability: float = 1.0
+    asset_fit: float = 1.0
+    regime_fit: float = 1.0
+    correlation_penalty: float = 0.0
+    final_multiplier: float = 1.0
+    reasons: list[str] = field(default_factory=list)
+
+
+@dataclass
+class HierarchyResult:
+    """Result of a hierarchy computation cycle."""
+
+    multipliers: dict[str, float]
+    factors: dict[str, HierarchyFactors]
+    regime: str = "unknown"
+
+
+class HierarchyEngine:
+    """Computes hierarchical weight multipliers per domain per cycle."""
+
+    def __init__(self, db: Any):
+        self.db = db
+
+    @property
+    def _conn(self) -> Any:
+        return getattr(self.db, "conn", self.db)
+
+    def compute(
+        self,
+        *,
+        symbol: str,
+        regime: str = "unknown",
+        producer_domain_map: dict[str, str],
+    ) -> HierarchyResult:
+        """Compute per-domain multipliers for this cycle."""
+        regime_norm = str(regime or "unknown").upper()
+        domains = {str(d) for d in producer_domain_map.values() if str(d)}
+        factors: dict[str, HierarchyFactors] = {}
+
+        for domain in domains:
+            domain_producers = [p for p, d in producer_domain_map.items() if d == domain]
+            f = HierarchyFactors(domain=domain)
+
+            # 1) producer reliability (trailing Brier, regime-aware)
+            f.producer_reliability = self._producer_reliability(domain_producers, regime=regime_norm)
+            if f.producer_reliability != 1.0:
+                f.reasons.append(f"reliability={f.producer_reliability:.3f}")
+
+            # 2) asset fit
+            f.asset_fit = self._asset_fit(domain_producers, symbol=symbol)
+            if f.asset_fit != 1.0:
+                f.reasons.append(f"asset_fit={f.asset_fit:.3f}")
+
+            # 3) regime fit
+            f.regime_fit = self._regime_fit(domain_producers, regime=regime_norm)
+            if f.regime_fit != 1.0:
+                f.reasons.append(f"regime_fit={f.regime_fit:.3f}")
+
+            # 4) correlation penalty
+            f.correlation_penalty = self._correlation_penalty(
+                domain=domain,
+                producer_domain_map=producer_domain_map,
+                symbol=symbol,
+                regime=regime_norm,
+            )
+            if f.correlation_penalty > 0.05:
+                f.reasons.append(f"corr_penalty={f.correlation_penalty:.3f}")
+
+            # Weighted blend of hierarchy factors.
+            raw = (
+                RELIABILITY_WEIGHT * f.producer_reliability
+                + ASSET_FIT_WEIGHT * f.asset_fit
+                + REGIME_FIT_WEIGHT * f.regime_fit
+                + CORRELATION_WEIGHT * (1.0 - f.correlation_penalty)
+            ) / (RELIABILITY_WEIGHT + ASSET_FIT_WEIGHT + REGIME_FIT_WEIGHT + CORRELATION_WEIGHT)
+
+            f.final_multiplier = _clamp(raw, MIN_MULTIPLIER, MAX_MULTIPLIER)
+            factors[domain] = f
+
+        multipliers = {d: f.final_multiplier for d, f in factors.items()}
+        logger.debug(
+            "hierarchy computed symbol=%s regime=%s multipliers=%s",
+            symbol,
+            regime_norm,
+            multipliers,
+        )
+
+        return HierarchyResult(
+            multipliers=multipliers,
+            factors=factors,
+            regime=regime_norm,
+        )
+
+    def _producer_reliability(self, producers: list[str], regime: str) -> float:
+        """Brier-based reliability score for producer set -> multiplier."""
+        if not producers:
+            return 1.0
+
+        from engine.brain.calibration import brier_summary
+
+        scores: list[float] = []
+        regime_norm = str(regime or "unknown").upper()
+
+        for producer in producers:
+            try:
+                summary = brier_summary(self.db, producer, window_days=30)
+            except Exception:
+                continue
+
+            count = int(summary.get("count") or 0)
+            if count < MIN_BRIER_SAMPLES:
+                continue
+
+            mean_brier = float(summary.get("mean_brier") or 0.25)
+            breakdown_raw = summary.get("regime_breakdown") or {}
+            breakdown = {str(k).upper(): v for k, v in breakdown_raw.items() if isinstance(v, dict)}
+            regime_data = breakdown.get(regime_norm)
+            if regime_data and int(regime_data.get("count") or 0) >= 3:
+                regime_brier = float(regime_data.get("mean_brier") or mean_brier)
+                mean_brier = (0.7 * mean_brier) + (0.3 * regime_brier)
+
+            scores.append(_brier_to_multiplier(mean_brier))
+
+        if not scores:
+            return 1.0
+
+        return _clamp(sum(scores) / len(scores), 0.5, 1.5)
+
+    def _asset_fit(self, producers: list[str], symbol: str) -> float:
+        """Per-asset historical Brier performance for this producer set."""
+        symbol_norm = str(symbol or "").upper()
+        if not producers or not symbol_norm:
+            return 1.0
+
+        try:
+            row = self._query_brier_mean(
+                producers,
+                extra_where="""
+                    AND UPPER(asset) = ?
+                    AND datetime(resolved_at) >= datetime('now', '-60 days')
+                """,
+                extra_params=(symbol_norm,),
+            )
+            if row is None:
+                return 1.0
+            count, mean_brier = row
+            if count < MIN_ASSET_SAMPLES:
+                return 1.0
+            return _clamp(_brier_to_multiplier(mean_brier), 0.5, 1.5)
+        except Exception:
+            return 1.0
+
+    def _regime_fit(self, producers: list[str], regime: str) -> float:
+        """Historical Brier performance in the active regime for this producer set."""
+        regime_norm = str(regime or "unknown").upper()
+        if not producers or regime_norm in {"UNKNOWN", "TRANSITION"}:
+            return 1.0
+
+        try:
+            row = self._query_brier_mean(
+                producers,
+                extra_where="AND UPPER(regime) = ?",
+                extra_params=(regime_norm,),
+            )
+            if row is None:
+                return 1.0
+            count, mean_brier = row
+            if count < MIN_BRIER_SAMPLES:
+                return 1.0
+            return _clamp(_brier_to_multiplier(mean_brier), 0.5, 1.5)
+        except Exception:
+            return 1.0
+
+    def _query_brier_mean(
+        self,
+        producers: list[str],
+        *,
+        extra_where: str = "",
+        extra_params: tuple[Any, ...] = (),
+    ) -> tuple[int, float] | None:
+        if not producers:
+            return None
+
+        placeholders = ",".join("?" for _ in producers)
+        query = f"""
+            SELECT COUNT(*), AVG(brier_score)
+            FROM forecast_calibration
+            WHERE producer_name IN ({placeholders})
+              AND resolved_at IS NOT NULL
+              {extra_where}
+        """
+        params = tuple(producers) + tuple(extra_params)
+        row = self._conn.execute(query, params).fetchone()
+        if row is None:
+            return None
+
+        count = int(row[0] or 0)
+        mean_brier = float(row[1] or 0.25)
+        return count, mean_brier
+
+    def _correlation_penalty(
+        self,
+        *,
+        domain: str,
+        producer_domain_map: dict[str, str],
+        symbol: str,
+        regime: str,
+    ) -> float:
+        """Domain-level penalty derived from producer_correlation pair data."""
+        domain_producers = [p for p, d in producer_domain_map.items() if d == domain]
+        other_producers = [p for p, d in producer_domain_map.items() if d != domain]
+        if not domain_producers or not other_producers:
+            return 0.0
+
+        if not self._table_exists("producer_correlation"):
+            return 0.0
+
+        penalties: list[float] = []
+        for p_a in domain_producers:
+            for p_b in other_producers:
+                corr = self._latest_pair_correlation(
+                    p_a,
+                    p_b,
+                    symbol=symbol,
+                    regime=regime,
+                )
+                if corr is None:
+                    continue
+                penalties.append(abs(corr) * 0.5)
+
+        if not penalties:
+            return 0.0
+
+        return _clamp(max(penalties), 0.0, 0.5)
+
+    def _table_exists(self, table_name: str) -> bool:
+        row = self._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        return row is not None
+
+    def _latest_pair_correlation(self, producer_a: str, producer_b: str, *, symbol: str, regime: str) -> float | None:
+        row = self._conn.execute(
+            """
+            SELECT pearson_r
+            FROM producer_correlation
+            WHERE ((producer_a = ? AND producer_b = ?) OR (producer_a = ? AND producer_b = ?))
+              AND pearson_r IS NOT NULL
+            ORDER BY
+                CASE
+                    WHEN UPPER(asset) = UPPER(?) THEN 0
+                    WHEN UPPER(asset) = 'ALL' THEN 1
+                    ELSE 2
+                END,
+                CASE
+                    WHEN UPPER(regime) = UPPER(?) THEN 0
+                    WHEN UPPER(regime) = 'UNKNOWN' THEN 1
+                    ELSE 2
+                END,
+                datetime(last_updated) DESC
+            LIMIT 1
+            """,
+            (producer_a, producer_b, producer_b, producer_a, str(symbol or ""), str(regime or "unknown")),
+        ).fetchone()
+        if row is None:
+            return None
+        return float(row[0])
+
+
+def _brier_to_multiplier(brier: float) -> float:
+    """Convert Brier score to weight multiplier."""
+    if brier <= 0.10:
+        return 1.5
+    if brier <= 0.20:
+        return 1.3
+    if brier <= 0.25:
+        return 1.0
+    if brier <= 0.30:
+        return 0.85
+    return 0.70
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))

--- a/engine/brain/synthesis.py
+++ b/engine/brain/synthesis.py
@@ -13,7 +13,7 @@ This module ports the *v2* synthesis philosophy from the legacy system:
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 try:
@@ -25,6 +25,7 @@ except ImportError:  # pragma: no cover
 
 from typing import Any, Final
 
+from engine.brain.hierarchy import HierarchyEngine, HierarchyResult
 from engine.core.config import Config
 from engine.core.database import Database
 from engine.core.events import EventType
@@ -67,6 +68,7 @@ class SynthesisResult:
     domain_scores: dict[str, float]  # 0..1 per domain (only domains with features)
     weights_used: dict[str, float]  # domain -> weight used this cycle (after quality adjustment)
     weighted_score: float  # 0..1 (domain_scores ⋅ weights_used)
+    hierarchy_factors: dict[str, float] = field(default_factory=dict)  # domain -> final hierarchy multiplier
     regime_tag: str = "unknown"  # per-asset regime (populated by synthesize_with_regime)
 
 
@@ -362,20 +364,9 @@ class VectorSynthesis:
             if not rows:
                 return {}
 
-            import json as _json
-
-            # Build producer -> domain mapping from recent accepted signals
-            producer_domains: dict[str, str] = {}
-            sig_rows = self.db.conn.execute(
-                "SELECT payload FROM events WHERE type = ? ORDER BY ts DESC LIMIT 500",
-                (str(EventType.SIGNAL_ACCEPTED_V1),),
-            ).fetchall()
-            for sr in sig_rows:
-                p = _json.loads(sr[0]) if isinstance(sr[0], str) else sr[0]
-                pid = str(p.get("producer_id", ""))
-                dom = str(p.get("domain", ""))
-                if pid and dom and pid not in producer_domains:
-                    producer_domains[pid] = dom
+            producer_domains = self._build_producer_domain_map()
+            if not producer_domains:
+                return {}
 
             # Average karma per domain
             domain_scores: dict[str, list[float]] = {}
@@ -393,6 +384,26 @@ class VectorSynthesis:
         except Exception:
             return {}
 
+    def _build_producer_domain_map(self) -> dict[str, str]:
+        """Build producer_name -> domain map from recent SIGNAL_ACCEPTED_V1 events."""
+        import json as _json
+
+        try:
+            rows = self.db.conn.execute(
+                "SELECT payload FROM events WHERE type = ? ORDER BY ts DESC LIMIT 500",
+                (str(EventType.SIGNAL_ACCEPTED_V1),),
+            ).fetchall()
+            mapping: dict[str, str] = {}
+            for row in rows:
+                payload = _json.loads(row[0]) if isinstance(row[0], str) else row[0]
+                producer_id = str(payload.get("producer_id", "")).strip()
+                domain = str(payload.get("domain", "")).strip().lower()
+                if producer_id and domain and producer_id not in mapping:
+                    mapping[producer_id] = domain
+            return mapping
+        except Exception:
+            return {}
+
     def synthesize(
         self,
         *,
@@ -403,6 +414,7 @@ class VectorSynthesis:
         quality_adjustment: dict[str, float] | None = None,
     ) -> SynthesisResult:
         snapshot = self.build_snapshot(cycle_id=cycle_id, symbol=symbol, as_of=as_of)
+        hier_result: HierarchyResult | None = None
 
         base_weights = weights or self.config.weights.model_dump()
         # quality_adjustment: domain -> 0..1 multiplier (already computed by DataQualityMonitor)
@@ -424,6 +436,27 @@ class VectorSynthesis:
             if total_w > 0:
                 weights_used = {k: v / total_w for k, v in weights_used.items()}
 
+        # P4.1: Hierarchical weighting — best-effort modulation of domain priors.
+        try:
+            producer_domain_map = self._build_producer_domain_map()
+            if producer_domain_map:
+                hierarchy = HierarchyEngine(self.db)
+                regime_tag = getattr(snapshot, "regime", None) or "unknown"
+                hier_result = hierarchy.compute(
+                    symbol=symbol,
+                    regime=str(regime_tag),
+                    producer_domain_map=producer_domain_map,
+                )
+                for dom in list(weights_used.keys()):
+                    mult = hier_result.multipliers.get(dom, 1.0)
+                    weights_used[dom] = float(weights_used[dom]) * float(mult)
+                # Re-normalize
+                total_w = sum(weights_used.values())
+                if total_w > 0:
+                    weights_used = {k: v / total_w for k, v in weights_used.items()}
+        except Exception:
+            pass  # hierarchy is best-effort; never break synthesis
+
         domain_scores: dict[str, float] = {}
         for dom, feats in snapshot.features.items():
             s = self.domain_score(dom, feats)
@@ -439,6 +472,7 @@ class VectorSynthesis:
             domain_scores=domain_scores,
             weights_used=weights_used,
             weighted_score=_clamp01(weighted_score),
+            hierarchy_factors=(dict(hier_result.multipliers) if hier_result is not None else {}),
         )
 
     def synthesize_with_regime(
@@ -470,5 +504,6 @@ class VectorSynthesis:
             domain_scores=result.domain_scores,
             weights_used=result.weights_used,
             weighted_score=result.weighted_score,
+            hierarchy_factors=result.hierarchy_factors,
             regime_tag=regime_result.state.regime,
         )

--- a/tests/unit/test_hierarchy.py
+++ b/tests/unit/test_hierarchy.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    from datetime import timezone as _tz  # noqa: PLC0415
+
+    UTC = _tz.utc  # noqa: N806, UP017
+
+from engine.brain.hierarchy import (
+    MAX_MULTIPLIER,
+    MIN_MULTIPLIER,
+    HierarchyEngine,
+    _brier_to_multiplier,
+)
+from engine.brain.synthesis import VectorSynthesis
+from engine.core.database import Database
+from engine.core.events import EventType
+
+
+def _seed_calibration(
+    db: Database,
+    *,
+    producer: str,
+    brier_scores: list[float],
+    asset: str = "BTC",
+    regime: str = "BULL",
+) -> None:
+    now = datetime.now(tz=UTC).isoformat()
+    with db.conn:
+        for idx, brier in enumerate(brier_scores):
+            db.conn.execute(
+                """
+                INSERT INTO forecast_calibration (
+                    forecast_id,
+                    producer_name,
+                    asset,
+                    regime,
+                    horizon,
+                    direction,
+                    confidence,
+                    calibrated,
+                    outcome,
+                    brier_score,
+                    emitted_at,
+                    resolved_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"{producer}-f{idx}",
+                    producer,
+                    asset,
+                    regime,
+                    "4h",
+                    "bullish",
+                    0.7,
+                    0,
+                    1.0,
+                    float(brier),
+                    now,
+                    now,
+                ),
+            )
+
+
+def _seed_signal_accepted(db: Database, *, producer_id: str, domain: str) -> None:
+    db.append_event(
+        event_type=EventType.SIGNAL_ACCEPTED_V1,
+        payload={
+            "trade_id": "t-1",
+            "producer_id": producer_id,
+            "domain": domain,
+            "signal_event_id": f"sig-{producer_id}",
+            "contribution_weight": 1.0,
+            "direction": "bullish",
+            "confidence": 0.7,
+        },
+        ts=datetime.now(tz=UTC),
+    )
+
+
+def test_brier_to_multiplier_thresholds() -> None:
+    assert _brier_to_multiplier(0.05) == 1.5
+    assert _brier_to_multiplier(0.25) == 1.0
+    assert _brier_to_multiplier(0.40) == 0.70
+
+
+def test_compute_empty_db_graceful_degradation(temp_dir) -> None:
+    db = Database(temp_dir / "brain.db")
+    engine = HierarchyEngine(db)
+
+    result = engine.compute(
+        symbol="BTC",
+        regime="BULL",
+        producer_domain_map={"pa": "technical", "pb": "onchain"},
+    )
+
+    assert set(result.multipliers.keys()) == {"technical", "onchain"}
+    assert all(mult == pytest.approx(1.0) for mult in result.multipliers.values())
+
+
+def test_compute_good_brier_data_boosts_multiplier(temp_dir) -> None:
+    db = Database(temp_dir / "brain.db")
+    _seed_calibration(db, producer="tech.alpha", brier_scores=[0.05] * 6, asset="BTC", regime="BULL")
+
+    engine = HierarchyEngine(db)
+    result = engine.compute(
+        symbol="BTC",
+        regime="BULL",
+        producer_domain_map={"tech.alpha": "technical"},
+    )
+
+    assert result.multipliers["technical"] > 1.0
+
+
+def test_compute_poor_brier_data_reduces_multiplier(temp_dir) -> None:
+    db = Database(temp_dir / "brain.db")
+    _seed_calibration(db, producer="tech.beta", brier_scores=[0.40] * 6, asset="BTC", regime="BULL")
+
+    engine = HierarchyEngine(db)
+    result = engine.compute(
+        symbol="BTC",
+        regime="BULL",
+        producer_domain_map={"tech.beta": "technical"},
+    )
+
+    assert result.multipliers["technical"] < 1.0
+
+
+def test_correlation_penalty_no_table_returns_zero() -> None:
+    db = SimpleNamespace(conn=sqlite3.connect(":memory:"))
+    engine = HierarchyEngine(db)
+
+    penalty = engine._correlation_penalty(
+        domain="technical",
+        producer_domain_map={"pa": "technical", "pb": "social"},
+        symbol="BTC",
+        regime="BULL",
+    )
+
+    assert penalty == 0.0
+
+
+def test_correlation_penalty_high_corr_returns_scaled_penalty(temp_dir) -> None:
+    db = Database(temp_dir / "brain.db")
+    with db.conn:
+        db.conn.execute(
+            """
+            INSERT INTO producer_correlation (
+                producer_a,
+                producer_b,
+                asset,
+                regime,
+                pearson_r,
+                sample_count,
+                window_days,
+                last_updated
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+            """,
+            ("pa", "pb", "ALL", "unknown", 0.8, 12, 30),
+        )
+
+    engine = HierarchyEngine(db)
+    penalty = engine._correlation_penalty(
+        domain="technical",
+        producer_domain_map={"pa": "technical", "pb": "social"},
+        symbol="BTC",
+        regime="BULL",
+    )
+
+    assert penalty == pytest.approx(0.4)
+
+
+def test_compute_multiplier_clamped_to_bounds(temp_dir, monkeypatch) -> None:
+    db = Database(temp_dir / "brain.db")
+    engine = HierarchyEngine(db)
+
+    monkeypatch.setattr(engine, "_producer_reliability", lambda *_args, **_kwargs: 99.0)
+    monkeypatch.setattr(engine, "_asset_fit", lambda *_args, **_kwargs: 99.0)
+    monkeypatch.setattr(engine, "_regime_fit", lambda *_args, **_kwargs: 99.0)
+    monkeypatch.setattr(engine, "_correlation_penalty", lambda **_kwargs: -10.0)
+    high = engine.compute(symbol="BTC", regime="BULL", producer_domain_map={"pa": "technical"})
+    assert high.multipliers["technical"] == MAX_MULTIPLIER
+
+    monkeypatch.setattr(engine, "_producer_reliability", lambda *_args, **_kwargs: -99.0)
+    monkeypatch.setattr(engine, "_asset_fit", lambda *_args, **_kwargs: -99.0)
+    monkeypatch.setattr(engine, "_regime_fit", lambda *_args, **_kwargs: -99.0)
+    monkeypatch.setattr(engine, "_correlation_penalty", lambda **_kwargs: 99.0)
+    low = engine.compute(symbol="BTC", regime="BULL", producer_domain_map={"pa": "technical"})
+    assert low.multipliers["technical"] == MIN_MULTIPLIER
+
+
+def test_synthesize_hierarchy_re_normalizes_weights_and_populates_factors(test_config, temp_dir) -> None:
+    db = Database(temp_dir / "brain.db")
+    now = datetime.now(tz=UTC)
+
+    db.append_event(
+        event_type=EventType.SIGNAL_TA_V1,
+        payload={"symbol": "BTC", "rsi_14": 35.0, "trend_strength": 0.8},
+        ts=now,
+    )
+    db.append_event(
+        event_type=EventType.SIGNAL_SOCIAL_V1,
+        payload={"symbol": "BTC", "score": 2.0, "direction": "bullish", "source_count": 5},
+        ts=now,
+    )
+
+    _seed_signal_accepted(db, producer_id="tech.alpha", domain="technical")
+    _seed_signal_accepted(db, producer_id="social.alpha", domain="social")
+
+    _seed_calibration(db, producer="tech.alpha", brier_scores=[0.05] * 6, asset="BTC", regime="BULL")
+    _seed_calibration(db, producer="social.alpha", brier_scores=[0.40] * 6, asset="BTC", regime="BULL")
+
+    result = VectorSynthesis(test_config, db).synthesize(cycle_id="c-h", symbol="BTC", as_of=now)
+
+    assert sum(result.weights_used.values()) == pytest.approx(1.0)
+    assert result.hierarchy_factors
+    assert "technical" in result.hierarchy_factors
+    assert "social" in result.hierarchy_factors
+
+
+def test_synthesis_result_hierarchy_factors_empty_when_hierarchy_skipped(test_config, temp_dir) -> None:
+    db = Database(temp_dir / "brain.db")
+    now = datetime.now(tz=UTC)
+
+    db.append_event(
+        event_type=EventType.SIGNAL_TA_V1,
+        payload={"symbol": "BTC", "rsi_14": 35.0, "trend_strength": 0.8},
+        ts=now,
+    )
+
+    result = VectorSynthesis(test_config, db).synthesize(cycle_id="c-no-h", symbol="BTC", as_of=now)
+    assert result.hierarchy_factors == {}


### PR DESCRIPTION
## Summary

Closes #185

Replaces flat domain weights with a full hierarchy. Domain weights become priors modulated each cycle by:
- **Producer reliability** (trailing Brier score, regime-aware — from `brier_summary()`)
- **Asset fit** (per-asset per-domain historical Brier performance)
- **Regime fit** (domain performance in current regime)
- **Correlation penalty** (from P2.3 `producer_correlation` data)

Graceful degradation: all factors return 1.0 (neutral) when data is insufficient. Hierarchy is best-effort — wrapped in try/except, never breaks synthesis.

---

## Type of change

- [x] `feat` — new feature

---

## Labels

- [x] Labels applied ✅

---

## Changes

- `engine/brain/hierarchy.py` **(new)** — `HierarchyEngine`, `HierarchyFactors`, `HierarchyResult`, `_brier_to_multiplier()`, `_clamp()`
- `engine/brain/synthesis.py` — wire `HierarchyEngine` into `synthesize()`, add `hierarchy_factors` field to `SynthesisResult`, extract `_build_producer_domain_map()` shared helper
- `tests/unit/test_hierarchy.py` **(new)** — 9 tests covering unit + integration

---

## Tests

- [x] New tests added
- [x] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: 913 passed, 33 warnings

---

## Checklist

- [x] Branch targets the correct base (`develop`)
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified**
- [x] Hierarchy is best-effort (wrapped in try/except)
- [x] All multipliers default to 1.0 when data insufficient