### PR TITLE
feat(p4.2): multi-horizon forecasts per producer

### DIFF
--- a/engine/core/horizons.py
+++ b/engine/core/horizons.py
@@ -1,0 +1,77 @@
+"""engine.core.horizons
+
+Multi-horizon forecast configuration.
+
+Defines the standard horizons and per-horizon confidence adjustments.
+Each producer can declare which horizons it supports and how confidence
+scales across them.
+
+Design principle: short horizons are noisier → lower confidence cap.
+Long horizons are less actionable but higher conviction when signals agree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from engine.core.utils import clamp
+
+# Standard horizon labels
+HORIZONS = ["1h", "4h", "24h", "3d", "7d"]
+
+# Short labels for deduplication keys
+HORIZON_SHORT = {
+    "1h": "1h",
+    "4h": "4h",
+    "24h": "24h",
+    "3d": "3d",
+    "7d": "7d",
+}
+
+
+@dataclass(frozen=True)
+class HorizonConfig:
+    """Configuration for one horizon."""
+
+    label: str
+    confidence_scale: float
+    confidence_cap: float
+    enabled: bool = True
+
+
+# Default horizon configs per domain type
+# Short horizons = noisier = lower cap
+# Long horizons = higher conviction = higher cap (if signal agrees)
+TECHNICAL_HORIZONS: list[HorizonConfig] = [
+    HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85),
+    HorizonConfig("24h", confidence_scale=0.90, confidence_cap=0.80),
+]
+
+TRADFI_HORIZONS: list[HorizonConfig] = [
+    HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85),
+    HorizonConfig("24h", confidence_scale=1.05, confidence_cap=0.88),
+    HorizonConfig("3d", confidence_scale=0.95, confidence_cap=0.82),
+]
+
+ONCHAIN_HORIZONS: list[HorizonConfig] = [
+    HorizonConfig("4h", confidence_scale=0.90, confidence_cap=0.80),
+    HorizonConfig("24h", confidence_scale=1.0, confidence_cap=0.85),
+    HorizonConfig("3d", confidence_scale=1.10, confidence_cap=0.88),
+]
+
+SENTIMENT_HORIZONS: list[HorizonConfig] = [
+    HorizonConfig("4h", confidence_scale=0.85, confidence_cap=0.75),
+    HorizonConfig("24h", confidence_scale=1.0, confidence_cap=0.82),
+]
+
+# Fallback for any producer not specifying
+DEFAULT_HORIZONS: list[HorizonConfig] = [
+    HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85),
+]
+
+
+def apply_horizon_config(base_confidence: float, cfg: HorizonConfig) -> float:
+    """Apply horizon-specific scaling and cap to a base confidence."""
+
+    scaled = base_confidence * cfg.confidence_scale
+    return clamp(scaled, 0.0, cfg.confidence_cap)

--- a/engine/producers/base.py
+++ b/engine/producers/base.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
 
     UTC = _tz.utc  # noqa: N806, UP017
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from engine.core.client import DataClient
 from engine.core.config import Config
@@ -37,6 +37,9 @@ from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.metrics import MetricsRegistry
 from engine.core.models import Event, compute_event_hash
 from engine.core.types import CANONICAL_DOMAINS, ProducerHealth, ProducerResult
+
+if TYPE_CHECKING:
+    from engine.core.horizons import HorizonConfig
 
 
 @dataclass(frozen=True, slots=True)
@@ -196,39 +199,22 @@ class BaseProducer(ABC):
 
         return published
 
-    def emit_forecast(
-        self,
-        *,
-        asset: str,
-        horizon: str,
-        signals: list[dict] | None = None,
-        regime_tag: str = "unknown",
-        visible_signal_refs: list[str] | None = None,
-    ) -> ForecastPayload | None:
-        """Emit a FORECAST_V1 event via this producer's interpreter.
+    def _wire_interpreter_source(self) -> None:
+        """Ensure interpreter source is wired to this producer name."""
 
-        Returns None if no interpreter is configured.
-        Returns a ForecastPayload (including abstentions) if one is.
-
-        The event is published to the DB automatically.
-        """
-
-        if self.interpreter is None:
-            return None
-
-        # Ensure source is wired up
-        if hasattr(self.interpreter, "producer_name"):
+        if self.interpreter is not None and hasattr(self.interpreter, "producer_name"):
             self.interpreter.producer_name = self.name
 
-        forecast = self.interpreter.safe_interpret(
-            asset=asset,
-            horizon=horizon,
-            signals=signals or [],
-            regime_tag=regime_tag,
-            visible_signal_refs=visible_signal_refs,
-        )
+    def _store_forecast(
+        self,
+        *,
+        forecast: ForecastPayload,
+        asset: str,
+        horizon: str,
+        regime_tag: str,
+    ) -> None:
+        """Persist a FORECAST_V1 event and register calibration metadata."""
 
-        # Publish FORECAST_V1 to DB
         self.ctx.db.append_event(
             event_type=EventType.FORECAST_V1,
             payload=forecast.model_dump(),
@@ -259,7 +245,97 @@ class BaseProducer(ABC):
         except Exception as e:  # noqa: BLE001
             self.ctx.logger.warning("calibration.register_forecast failed: %s", e)
 
+    def emit_forecast(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict] | None = None,
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload | None:
+        """Emit a FORECAST_V1 event via this producer's interpreter.
+
+        Returns None if no interpreter is configured.
+        Returns a ForecastPayload (including abstentions) if one is.
+
+        The event is published to the DB automatically.
+        """
+
+        if self.interpreter is None:
+            return None
+
+        self._wire_interpreter_source()
+
+        forecast = self.interpreter.safe_interpret(
+            asset=asset,
+            horizon=horizon,
+            signals=signals or [],
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs,
+        )
+
+        self._store_forecast(
+            forecast=forecast,
+            asset=asset,
+            horizon=horizon,
+            regime_tag=regime_tag,
+        )
+
         return forecast
+
+    def emit_forecasts_multi_horizon(
+        self,
+        *,
+        asset: str,
+        signals: list[dict],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+        horizon_configs: list[HorizonConfig] | None = None,
+    ) -> int:
+        """Emit forecasts for multiple horizons from one set of signals.
+
+        Returns total forecasts published. Abstentions are skipped for this path.
+        """
+
+        if self.interpreter is None:
+            return 0
+
+        from engine.core.horizons import DEFAULT_HORIZONS, apply_horizon_config
+
+        configs = horizon_configs or DEFAULT_HORIZONS
+        total = 0
+
+        for cfg in configs:
+            if not cfg.enabled:
+                continue
+
+            self._wire_interpreter_source()
+            candidate = self.interpreter.safe_interpret(
+                asset=asset,
+                horizon=cfg.label,
+                signals=signals,
+                regime_tag=regime_tag,
+                visible_signal_refs=visible_signal_refs,
+            )
+
+            if candidate.action == "no_forecast":
+                continue
+
+            scaled_confidence = apply_horizon_config(candidate.confidence, cfg)
+            if scaled_confidence < 0.1:
+                continue
+
+            scaled = candidate.model_copy(update={"confidence": round(scaled_confidence, 4)})
+            self._store_forecast(
+                forecast=scaled,
+                asset=asset,
+                horizon=cfg.label,
+                regime_tag=regime_tag,
+            )
+            total += 1
+
+        return total
 
     def run(self) -> ProducerResult:
         start = time.perf_counter()

--- a/engine/producers/onchain.py
+++ b/engine/producers/onchain.py
@@ -31,6 +31,7 @@ from typing import Any
 import httpx
 
 from engine.core.events import EventType, OnchainSignalPayload
+from engine.core.horizons import ONCHAIN_HORIZONS
 from engine.core.models import Event
 from engine.core.types import ProducerHealth, ProducerResult
 from engine.producers.base import BaseProducer
@@ -126,6 +127,17 @@ class OnchainFlowsProducer(BaseProducer):
                 health = ProducerHealth.DEGRADED
             events = self.normalize(raw)
             published = self.publish(events)
+
+            symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+            signal_payloads = [e.payload for e in events]
+            for symbol in symbols:
+                self.emit_forecasts_multi_horizon(
+                    asset=symbol,
+                    signals=signal_payloads,
+                    regime_tag="unknown",
+                    visible_signal_refs=[],
+                    horizon_configs=ONCHAIN_HORIZONS,
+                )
         except httpx.HTTPStatusError as e:
             code = getattr(e.response, "status_code", None)
             health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR

--- a/engine/producers/sentiment.py
+++ b/engine/producers/sentiment.py
@@ -32,6 +32,7 @@ from typing import Any
 import httpx
 
 from engine.core.events import EventType, SentimentSignalPayload
+from engine.core.horizons import SENTIMENT_HORIZONS
 from engine.core.models import Event
 from engine.core.types import ProducerHealth, ProducerResult
 from engine.producers.base import BaseProducer
@@ -151,6 +152,17 @@ class MarketSentimentProducer(BaseProducer):
                 health = ProducerHealth.DEGRADED
             events = self.normalize(raw)
             published = self.publish(events)
+
+            symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+            signal_payloads = [e.payload for e in events]
+            for symbol in symbols:
+                self.emit_forecasts_multi_horizon(
+                    asset=symbol,
+                    signals=signal_payloads,
+                    regime_tag="unknown",
+                    visible_signal_refs=[],
+                    horizon_configs=SENTIMENT_HORIZONS,
+                )
         except httpx.HTTPStatusError as e:
             code = getattr(e.response, "status_code", None)
             health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR

--- a/engine/producers/ta.py
+++ b/engine/producers/ta.py
@@ -38,6 +38,7 @@ from engine.core.events import (
     TASignalPayload,
 )
 from engine.core.forecast import abstain, compute_reasoning_hash, make_forecast_id
+from engine.core.horizons import TECHNICAL_HORIZONS
 from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.models import Event
 from engine.core.regime import RegimeConfig, RegimeMatrix
@@ -255,6 +256,17 @@ class TechnicalAnalysisProducer(BaseProducer):
                 health = ProducerHealth.DEGRADED
             events = self.normalize(raw)
             published = self.publish(events)
+
+            symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+            signal_payloads = [e.payload for e in events]
+            for symbol in symbols:
+                self.emit_forecasts_multi_horizon(
+                    asset=symbol,
+                    signals=signal_payloads,
+                    regime_tag="unknown",
+                    visible_signal_refs=[],
+                    horizon_configs=TECHNICAL_HORIZONS,
+                )
         except httpx.HTTPStatusError as e:
             code = getattr(e.response, "status_code", None)
             health = ProducerHealth.DEGRADED if code in (401, 403) else ProducerHealth.ERROR

--- a/engine/producers/tradfi.py
+++ b/engine/producers/tradfi.py
@@ -39,6 +39,7 @@ from engine.core.events import (
     TradFiSignalPayload,
 )
 from engine.core.forecast import abstain, compute_reasoning_hash, make_forecast_id
+from engine.core.horizons import TRADFI_HORIZONS
 from engine.core.interpreter import Interpreter, NullInterpreter
 from engine.core.models import Event
 from engine.core.regime import RegimeConfig, RegimeMatrix
@@ -540,13 +541,14 @@ class TradFiBasisProducer(BaseProducer):
             published = self.publish(normalized_events)
 
             symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+            signal_payloads = [e.payload for e in normalized_events]
             for symbol in symbols:
-                self.emit_forecast(
+                self.emit_forecasts_multi_horizon(
                     asset=symbol,
-                    horizon="4h",
-                    signals=[e.payload for e in normalized_events],
+                    signals=signal_payloads,
                     regime_tag="unknown",
                     visible_signal_refs=[],
+                    horizon_configs=TRADFI_HORIZONS,
                 )
         except httpx.HTTPStatusError as e:
             code = getattr(e.response, "status_code", None)

--- a/tests/unit/test_multi_horizon.py
+++ b/tests/unit/test_multi_horizon.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import pytest
+
+from engine.core.client import DataClient
+from engine.core.config import Config
+from engine.core.database import Database
+from engine.core.events import AbstentionReason, EventType, ForecastLifecycleState, ForecastPayload
+from engine.core.forecast import abstain, make_forecast_id
+from engine.core.horizons import DEFAULT_HORIZONS, HorizonConfig, apply_horizon_config
+from engine.core.interpreter import Interpreter
+from engine.core.metrics import MetricsRegistry
+from engine.producers.base import BaseProducer, ProducerContext
+from engine.producers.tradfi import TradFiBasisProducer
+
+
+class _DummyClient:
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return self._response
+
+    async def request_json(self, method: str, url: str, **kwargs: Any) -> Any:
+        resp = await self.request(method, url, **kwargs)
+        return resp.json()
+
+
+class _FixedInterpreter(Interpreter):
+    def __init__(self, *, action: str = "long", confidence: float = 0.7) -> None:
+        self._action = action
+        self._confidence = confidence
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        refs = visible_signal_refs or []
+        if self._action == "no_forecast":
+            return abstain(
+                source=self.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.INSUFFICIENT_DATA,
+                regime_tag=regime_tag,
+                visible_signal_refs=refs,
+            )
+
+        return ForecastPayload(
+            forecast_id=make_forecast_id(),
+            asset=asset,
+            horizon=horizon,
+            action=self._action,
+            confidence=self._confidence,
+            source=self.source,
+            regime_tag=regime_tag,
+            lifecycle_state=ForecastLifecycleState.NEW,
+            visible_signal_refs=refs,
+            used_signal_refs=refs,
+        )
+
+
+class _TestProducer(BaseProducer):
+    name = "multi-horizon-test"
+    domain = "events"
+    schedule = "continuous"
+
+    def collect(self) -> list[dict]:
+        return []
+
+    def normalize(self, raw: list[dict]):  # type: ignore[no-untyped-def]
+        return []
+
+
+def _make_ctx(tmp_path) -> ProducerContext:
+    db = Database(tmp_path / "events.db")
+    return ProducerContext(
+        config=Config(),
+        db=db,
+        client=DataClient(),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+
+def test_apply_horizon_config_under_cap() -> None:
+    cfg = HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85)
+    assert apply_horizon_config(0.80, cfg) == pytest.approx(0.80)
+
+
+def test_apply_horizon_config_capped() -> None:
+    cfg = HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85)
+    assert apply_horizon_config(0.90, cfg) == pytest.approx(0.85)
+
+
+def test_apply_horizon_config_scaled_and_capped() -> None:
+    cfg = HorizonConfig("3d", confidence_scale=1.10, confidence_cap=0.88)
+    assert apply_horizon_config(0.80, cfg) == pytest.approx(0.88)
+
+
+def test_emit_forecasts_multi_horizon_publishes_for_each_enabled_horizon(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = _FixedInterpreter(action="long", confidence=0.7)
+
+    configs = [
+        HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85),
+        HorizonConfig("24h", confidence_scale=1.0, confidence_cap=0.85),
+        HorizonConfig("3d", confidence_scale=1.0, confidence_cap=0.85),
+    ]
+
+    published = producer.emit_forecasts_multi_horizon(
+        asset="BTC",
+        signals=[{"symbol": "BTC"}],
+        regime_tag="unknown",
+        visible_signal_refs=["evt-1"],
+        horizon_configs=configs,
+    )
+
+    events = producer.ctx.db.get_events(event_type=EventType.FORECAST_V1, source=producer.name, limit=10)
+
+    assert published == 3
+    assert len(events) == 3
+    assert {event.payload["horizon"] for event in events} == {"4h", "24h", "3d"}
+
+
+def test_emit_forecasts_multi_horizon_skips_no_forecast(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = _FixedInterpreter(action="no_forecast", confidence=0.7)
+
+    published = producer.emit_forecasts_multi_horizon(
+        asset="BTC",
+        signals=[{"symbol": "BTC"}],
+        horizon_configs=[HorizonConfig("4h", confidence_scale=1.0, confidence_cap=0.85)],
+    )
+
+    events = producer.ctx.db.get_events(event_type=EventType.FORECAST_V1, source=producer.name, limit=10)
+
+    assert published == 0
+    assert events == []
+
+
+def test_emit_forecasts_multi_horizon_skips_low_scaled_confidence(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = _FixedInterpreter(action="long", confidence=0.12)
+
+    published = producer.emit_forecasts_multi_horizon(
+        asset="BTC",
+        signals=[{"symbol": "BTC"}],
+        horizon_configs=[HorizonConfig("4h", confidence_scale=0.5, confidence_cap=0.85)],
+    )
+
+    events = producer.ctx.db.get_events(event_type=EventType.FORECAST_V1, source=producer.name, limit=10)
+
+    assert published == 0
+    assert events == []
+
+
+def test_emit_forecasts_multi_horizon_uses_default_configs(tmp_path) -> None:
+    producer = _TestProducer(_make_ctx(tmp_path))
+    producer.interpreter = _FixedInterpreter(action="long", confidence=0.7)
+
+    published = producer.emit_forecasts_multi_horizon(
+        asset="BTC",
+        signals=[{"symbol": "BTC"}],
+    )
+
+    events = producer.ctx.db.get_events(event_type=EventType.FORECAST_V1, source=producer.name, limit=10)
+
+    assert published == 1
+    assert len(events) == 1
+    assert events[0].payload["horizon"] == DEFAULT_HORIZONS[0].label
+
+
+def test_tradfi_run_emits_three_horizons_per_symbol(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("B1E55ED_TRADFI_BASIS_URL", "https://example.test/basis")
+
+    resp = httpx.Response(
+        200,
+        json={
+            "data": [
+                {
+                    "symbol": "BTC",
+                    "basis_annualized": 4.0,
+                    "funding_annualized": 10.0,
+                    "oi_change_pct": 1.5,
+                    "meltup_score": 2.0,
+                }
+            ]
+        },
+        request=httpx.Request("POST", "https://example.test/basis"),
+    )
+
+    db = Database(tmp_path / "events.db")
+    cfg = Config(universe={"symbols": ["BTC"]})
+    ctx = ProducerContext(
+        config=cfg,
+        db=db,
+        client=_DummyClient(response=resp),
+        metrics=MetricsRegistry(),
+        logger=logging.getLogger("test"),
+    )
+
+    TradFiBasisProducer(ctx).run()
+
+    forecast_events = db.get_events(event_type=EventType.FORECAST_V1, source="tradfi-basis", limit=10)
+
+    assert len(forecast_events) == 3
+    assert {event.payload["horizon"] for event in forecast_events} == {"4h", "24h", "3d"}
+
+    confidence_by_horizon = {event.payload["horizon"]: event.payload["confidence"] for event in forecast_events}
+    assert confidence_by_horizon["4h"] == pytest.approx(0.55)
+    assert confidence_by_horizon["24h"] == pytest.approx(0.5775)
+    assert confidence_by_horizon["3d"] == pytest.approx(0.5225)

--- a/tests/unit/test_producer_tradfi.py
+++ b/tests/unit/test_producer_tradfi.py
@@ -155,10 +155,10 @@ def test_tradfi_dual_write_emits_both_events(monkeypatch, tmp_path) -> None:
 
     assert pr.events_published == 1
     assert len(signal_events) == 1
-    assert len(forecast_events) == 2
-    assert {event.payload["asset"] for event in forecast_events} == {"BTC", "ETH"}
-    assert any(event.payload["action"] == "long" for event in forecast_events)
-    assert any(event.payload["action"] == "no_forecast" for event in forecast_events)
+    assert len(forecast_events) == 3
+    assert {event.payload["asset"] for event in forecast_events} == {"BTC"}
+    assert {event.payload["horizon"] for event in forecast_events} == {"4h", "24h", "3d"}
+    assert all(event.payload["action"] == "long" for event in forecast_events)
 
 
 def test_tradfi_basis_producer_handles_401(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

Closes #186

Producers now emit FORECAST_V1 at multiple horizons from the same data. "smart-onchain bullish 4h at 0.55 AND bullish 3d at 0.78" — stronger conviction on longer TF signals real accumulation.

## Type of change
- [x] `feat` — new feature

## Changes

- `engine/core/horizons.py` (new) — horizon configs, per-domain constants, apply_horizon_config()
- `engine/producers/base.py` — emit_forecasts_multi_horizon() + refactored _wire_interpreter_source() / _store_forecast()
- `engine/producers/tradfi.py` — uses TRADFI_HORIZONS (4h/24h/3d)
- `engine/producers/ta.py` — uses TECHNICAL_HORIZONS (4h/24h)
- `engine/producers/onchain.py` — uses ONCHAIN_HORIZONS (4h/24h/3d)
- `engine/producers/sentiment.py` — uses SENTIMENT_HORIZONS (4h/24h)
- `tests/unit/test_multi_horizon.py` (new) — 8 tests covering horizons math + integration
- `tests/unit/test_producer_tradfi.py` — updated dual-write test for 3 horizons

## Tests

- [x] New tests added (8 in test_multi_horizon.py)
- [x] All tests pass: 921 passed, 33 warnings in 45.60s

## Checklist

- [x] Branch targets `develop`
- [x] `engine/brain/orchestrator.py` not modified
- [x] No new top-level dependencies
- [x] Ruff clean
- [x] Smoke tests pass