### PR TITLE
feat(p4.3): cross-producer awareness — novelty penalty via aggregate brain conviction

### DIFF
--- a/engine/brain/conviction_state.py
+++ b/engine/brain/conviction_state.py
@@ -1,0 +1,162 @@
+"""engine.brain.conviction_state
+
+Aggregated brain conviction state — safe cross-producer signal.
+
+Exposes per-asset aggregate conviction as a single signed float:
+positive = bullish, negative = bearish, near-zero = neutral/conflicted.
+
+This is the ONLY information producers receive about other producers.
+No identities, no domain breakdown, no individual confidence values.
+
+Design:
+- Reads recent FORECAST_V1 events from the DB
+- Aggregates by asset: weighted average of (confidence × direction_sign)
+- Direction sign: long=+1, short=-1, no_forecast=0
+- Lookback window: configurable, default 2h
+- Returns 0.0 (neutral) on any error or empty data
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    from datetime import timezone as _tz  # noqa: PLC0415
+
+    UTC = _tz.utc  # noqa: N806, UP017
+
+from engine.core.events import EventType
+
+logger = logging.getLogger(__name__)
+
+# Direction sign mapping
+_DIRECTION_SIGN: dict[str, float] = {
+    "long": 1.0,
+    "short": -1.0,
+    "flat": 0.0,
+    "no_forecast": 0.0,
+}
+
+DEFAULT_LOOKBACK_MINUTES = 120
+MIN_FORECASTS_FOR_SIGNAL = 2
+MAX_ROWS = 200
+
+
+@dataclass(frozen=True, slots=True)
+class ConvictionState:
+    """Aggregate conviction for one asset."""
+
+    asset: str
+    conviction: float  # signed float: [-1, +1], positive=bullish
+    forecast_count: int  # number of forecasts aggregated
+    lookback_minutes: int
+
+
+class ConvictionStateReader:
+    """Reads aggregate conviction from recent FORECAST_V1 events.
+
+    Designed to be instantiated once and queried per cycle.
+    Fails silently — returns 0.0 on any error.
+    """
+
+    def __init__(self, db: Any, lookback_minutes: int = DEFAULT_LOOKBACK_MINUTES) -> None:
+        self.db = db
+        self.lookback_minutes = lookback_minutes
+
+    def get(self, asset: str) -> ConvictionState:
+        """Return aggregate conviction for one asset. Never raises."""
+        try:
+            return self._query(asset)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("conviction_state_read_failed asset=%s error=%s", asset, exc)
+            return ConvictionState(
+                asset=asset,
+                conviction=0.0,
+                forecast_count=0,
+                lookback_minutes=self.lookback_minutes,
+            )
+
+    @staticmethod
+    def _connection(db: Any) -> Any:
+        return getattr(db, "conn", db)
+
+    @staticmethod
+    def _decode_payload(raw: Any) -> dict[str, Any] | None:
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except Exception:  # noqa: BLE001
+                return None
+            return decoded if isinstance(decoded, dict) else None
+        return None
+
+    def _query(self, asset: str) -> ConvictionState:
+        conn = self._connection(self.db)
+        since_iso = (datetime.now(tz=UTC) - timedelta(minutes=self.lookback_minutes)).isoformat()
+
+        rows = conn.execute(
+            """
+            SELECT payload
+            FROM events
+            WHERE type = ?
+              AND ts >= ?
+            ORDER BY ts DESC
+            LIMIT ?
+            """,
+            (EventType.FORECAST_V1.value, since_iso, MAX_ROWS),
+        ).fetchall()
+
+        total_weight = 0.0
+        weighted_sum = 0.0
+        count = 0
+        target_asset = str(asset).upper()
+
+        for row in rows:
+            payload = self._decode_payload(row[0])
+            if payload is None:
+                continue
+
+            if str(payload.get("asset", "")).upper() != target_asset:
+                continue
+
+            action = str(payload.get("action", "no_forecast")).lower()
+            sign = _DIRECTION_SIGN.get(action, 0.0)
+            if sign == 0.0:
+                continue
+
+            try:
+                confidence = float(payload.get("confidence", 0.0))
+            except (TypeError, ValueError):
+                continue
+
+            weight = max(0.0, confidence)
+            if weight == 0.0:
+                continue
+
+            weighted_sum += sign * weight
+            total_weight += weight
+            count += 1
+
+        if count < MIN_FORECASTS_FOR_SIGNAL or total_weight == 0.0:
+            return ConvictionState(
+                asset=asset,
+                conviction=0.0,
+                forecast_count=count,
+                lookback_minutes=self.lookback_minutes,
+            )
+
+        conviction = max(-1.0, min(1.0, weighted_sum / total_weight))
+        return ConvictionState(
+            asset=asset,
+            conviction=round(conviction, 4),
+            forecast_count=count,
+            lookback_minutes=self.lookback_minutes,
+        )

--- a/engine/core/interpreter.py
+++ b/engine/core/interpreter.py
@@ -17,9 +17,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
+from engine.brain.conviction_state import ConvictionStateReader
 from engine.core.events import AbstentionReason, ForecastPayload
 from engine.core.forecast import abstain, compute_reasoning_hash
 from engine.core.llm_critic import LLMCritic
+from engine.core.novelty import NOVELTY_MIN_CONFIDENCE, NoveltyResult, compute_novelty_penalty
 from engine.core.prosecutor import ProsecutionResult, Prosecutor
 from engine.core.regime import REGIME_CAPS as _REGIME_CAPS
 from engine.core.regime import RegimeMatrix
@@ -578,3 +580,96 @@ class ProsecutorInterpreter(Interpreter):
                 return candidate.model_copy(update={"confidence": round(new_confidence, 4)})
 
         return candidate
+
+
+class NoveltyInterpreter(Interpreter):
+    """Wraps an Interpreter and applies a novelty penalty from aggregate conviction.
+
+    The producer sees only one number per asset: aggregate signed conviction.
+    No producer identities, no domain breakdown.
+
+    - High agreement with strong conviction -> suppress confidence (low novelty)
+    - Contrarian signal -> slight confidence boost
+    - shadow=True (default): observe only, do not mutate
+    - db=None: pass-through
+
+    Position in stack: last gate (after Prosecutor) or standalone.
+    """
+
+    def __init__(
+        self,
+        inner: Interpreter,
+        db: Any | None = None,
+        shadow: bool = True,
+        lookback_minutes: int = 120,
+    ) -> None:
+        self.inner = inner
+        self.shadow = shadow
+        self._reader = ConvictionStateReader(db, lookback_minutes=lookback_minutes) if db is not None else None
+
+        # Mirror identity at init; producer wiring may update self.* later.
+        self.producer_name = inner.producer_name
+        self.producer_version = inner.producer_version
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        # Keep source identity aligned with BaseProducer.emit_forecast() wiring.
+        self.inner.producer_name = self.producer_name
+        self.inner.producer_version = self.producer_version
+
+        candidate = self.inner.safe_interpret(
+            asset=asset,
+            horizon=horizon,
+            signals=signals,
+            regime_tag=regime_tag,
+            visible_signal_refs=visible_signal_refs,
+        )
+
+        if candidate.action == "no_forecast" or self._reader is None:
+            return candidate
+
+        state = self._reader.get(asset)
+        result: NoveltyResult = compute_novelty_penalty(
+            candidate_action=candidate.action,
+            candidate_confidence=float(candidate.confidence),
+            brain_conviction=float(state.conviction),
+        )
+
+        logger.info(
+            "novelty_result: producer=%s asset=%s action=%s confidence=%.4f "
+            "brain_conviction=%.4f forecast_count=%d agreement=%.4f delta=%+.4f applied=%s shadow=%s reason=%s",
+            self.producer_name,
+            asset,
+            candidate.action,
+            float(candidate.confidence),
+            float(state.conviction),
+            int(state.forecast_count),
+            float(result.agreement),
+            float(result.confidence_delta),
+            result.applied,
+            self.shadow,
+            result.reason,
+        )
+
+        if self.shadow or not result.applied:
+            return candidate
+
+        new_confidence = clamp(float(candidate.confidence) + float(result.confidence_delta), NOVELTY_MIN_CONFIDENCE, 1.0)
+        if new_confidence < 0.15:
+            return abstain(
+                source=candidate.source,
+                asset=asset,
+                horizon=horizon,
+                reason=AbstentionReason.LOW_CONFIDENCE,
+                regime_tag=regime_tag,
+                visible_signal_refs=candidate.visible_signal_refs,
+            )
+
+        return candidate.model_copy(update={"confidence": round(new_confidence, 4)})

--- a/engine/core/novelty.py
+++ b/engine/core/novelty.py
@@ -1,0 +1,104 @@
+"""engine.core.novelty
+
+Novelty penalty: suppress confidence when a producer's forecast agrees
+with existing brain conviction without adding new information.
+
+"Brain is already 0.75 bullish on BTC. Am I adding signal or noise?"
+
+Rules:
+- High agreement + high existing conviction → suppress (low novelty)
+- Disagreement with conviction → preserve or boost slightly (contrarian = information)
+- Conviction near zero → no penalty (brain is uncertain, all signals valuable)
+
+Novelty penalty is applied AFTER interpretation, BEFORE emit.
+Action is NEVER changed directly — only confidence is modulated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from engine.brain.conviction_state import _DIRECTION_SIGN
+
+# Tuning constants
+NOVELTY_CONVICTION_THRESHOLD = 0.5
+NOVELTY_AGREEMENT_PENALTY = 0.15
+NOVELTY_CONTRARIAN_BOOST = 0.05
+NOVELTY_MIN_CONFIDENCE = 0.1
+
+
+@dataclass(frozen=True, slots=True)
+class NoveltyResult:
+    confidence_delta: float  # signed adjustment to apply
+    applied: bool
+    reason: str
+    brain_conviction: float  # the aggregate conviction seen
+    agreement: float  # -1=full disagreement, +1=full agreement
+
+
+def compute_novelty_penalty(
+    *,
+    candidate_action: str,
+    candidate_confidence: float,
+    brain_conviction: float,
+) -> NoveltyResult:
+    """Compute novelty-based confidence adjustment.
+
+    Never changes action. Only modulates confidence.
+    Returns NoveltyResult with confidence_delta to apply.
+    """
+
+    candidate_sign = _DIRECTION_SIGN.get(str(candidate_action).lower(), 0.0)
+    if candidate_sign == 0.0:
+        return NoveltyResult(
+            confidence_delta=0.0,
+            applied=False,
+            reason="abstention_pass_through",
+            brain_conviction=brain_conviction,
+            agreement=0.0,
+        )
+
+    agreement = float(candidate_sign * brain_conviction)
+    conviction_strength = abs(float(brain_conviction))
+
+    if conviction_strength < NOVELTY_CONVICTION_THRESHOLD:
+        return NoveltyResult(
+            confidence_delta=0.0,
+            applied=False,
+            reason="brain_conviction_weak",
+            brain_conviction=brain_conviction,
+            agreement=agreement,
+        )
+
+    if agreement > 0.3:
+        # Agreeing with strong conviction → low novelty → penalize.
+        penalty = NOVELTY_AGREEMENT_PENALTY * agreement * conviction_strength
+        penalty_cap = max(float(candidate_confidence) - NOVELTY_MIN_CONFIDENCE, 0.0)
+        delta = -round(min(penalty, penalty_cap), 4)
+        return NoveltyResult(
+            confidence_delta=delta,
+            applied=True,
+            reason=f"low_novelty agreement={agreement:.2f} conviction={brain_conviction:.2f}",
+            brain_conviction=brain_conviction,
+            agreement=agreement,
+        )
+
+    if agreement < -0.3:
+        # Disagreeing with strong conviction → contrarian signal → small boost.
+        boost = NOVELTY_CONTRARIAN_BOOST * abs(agreement) * conviction_strength
+        delta = round(boost, 4)
+        return NoveltyResult(
+            confidence_delta=delta,
+            applied=True,
+            reason=f"contrarian_signal agreement={agreement:.2f} conviction={brain_conviction:.2f}",
+            brain_conviction=brain_conviction,
+            agreement=agreement,
+        )
+
+    return NoveltyResult(
+        confidence_delta=0.0,
+        applied=False,
+        reason="neutral_agreement",
+        brain_conviction=brain_conviction,
+        agreement=agreement,
+    )

--- a/tests/unit/test_cross_producer_awareness.py
+++ b/tests/unit/test_cross_producer_awareness.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from engine.brain.conviction_state import ConvictionStateReader
+from engine.core.events import AbstentionReason, EventType, ForecastLifecycleState, ForecastPayload
+from engine.core.forecast import make_forecast_id
+from engine.core.interpreter import Interpreter, NoveltyInterpreter
+from engine.core.novelty import compute_novelty_penalty
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    from datetime import timezone as _tz  # noqa: PLC0415
+
+    UTC = _tz.utc  # noqa: N806, UP017
+
+
+class _ConnDB:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+
+
+class _StaticInterpreter(Interpreter):
+    producer_name = "unit-producer"
+    producer_version = "1.0.0"
+
+    def __init__(self, payload: ForecastPayload) -> None:
+        self.payload = payload
+
+    def interpret(
+        self,
+        *,
+        asset: str,
+        horizon: str,
+        signals: list[dict[str, Any]],
+        regime_tag: str = "unknown",
+        visible_signal_refs: list[str] | None = None,
+    ) -> ForecastPayload:
+        return self.payload.model_copy(deep=True)
+
+
+class _BrokenConn:
+    def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise sqlite3.OperationalError("boom")
+
+
+class _BrokenDB:
+    def __init__(self) -> None:
+        self.conn = _BrokenConn()
+
+
+def _mk_payload(*, action: str = "long", confidence: float = 0.6) -> ForecastPayload:
+    kwargs: dict[str, Any] = {
+        "forecast_id": make_forecast_id(),
+        "asset": "BTC",
+        "horizon": "4h",
+        "action": action,
+        "confidence": confidence,
+        "source": "unit-producer@1.0.0",
+        "regime_tag": "unknown",
+        "lifecycle_state": ForecastLifecycleState.NEW,
+        "visible_signal_refs": ["evt-1"],
+        "used_signal_refs": ["evt-1"],
+    }
+    if action == "no_forecast":
+        kwargs["confidence"] = 0.0
+        kwargs["abstention_reason"] = AbstentionReason.INSUFFICIENT_DATA
+    return ForecastPayload(**kwargs)
+
+
+def _insert_forecast(
+    conn: sqlite3.Connection,
+    *,
+    asset: str,
+    action: str,
+    confidence: float,
+    minutes_ago: int = 0,
+) -> None:
+    ts = (datetime.now(tz=UTC) - timedelta(minutes=minutes_ago)).isoformat()
+    payload = {
+        "forecast_id": str(uuid.uuid4()),
+        "asset": asset,
+        "horizon": "4h",
+        "action": action,
+        "confidence": confidence,
+        "source": "seed@1.0.0",
+        "lifecycle_state": "new",
+        "visible_signal_refs": [],
+        "used_signal_refs": [],
+    }
+    conn.execute(
+        "INSERT INTO events (id, type, ts, payload) VALUES (?, ?, ?, ?)",
+        (str(uuid.uuid4()), EventType.FORECAST_V1.value, ts, json.dumps(payload)),
+    )
+    conn.commit()
+
+
+@pytest.fixture()
+def forecast_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE events (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            ts TEXT NOT NULL,
+            payload TEXT NOT NULL
+        )
+        """
+    )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_conviction_state_reader_empty_db_returns_neutral(forecast_conn: sqlite3.Connection) -> None:
+    state = ConvictionStateReader(_ConnDB(forecast_conn)).get("BTC")
+
+    assert state.conviction == pytest.approx(0.0)
+    assert state.forecast_count == 0
+
+
+def test_conviction_state_reader_long_only_is_positive(forecast_conn: sqlite3.Connection) -> None:
+    for _ in range(3):
+        _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.7)
+
+    state = ConvictionStateReader(_ConnDB(forecast_conn)).get("BTC")
+
+    assert state.forecast_count == 3
+    assert state.conviction > 0
+
+
+def test_conviction_state_reader_mixed_long_short_near_zero(forecast_conn: sqlite3.Connection) -> None:
+    _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.7)
+    _insert_forecast(forecast_conn, asset="BTC", action="short", confidence=0.7)
+    _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.3)
+    _insert_forecast(forecast_conn, asset="BTC", action="short", confidence=0.3)
+
+    state = ConvictionStateReader(_ConnDB(forecast_conn)).get("BTC")
+
+    assert state.forecast_count == 4
+    assert abs(state.conviction) < 0.05
+
+
+def test_conviction_state_reader_db_error_returns_neutral() -> None:
+    state = ConvictionStateReader(_BrokenDB()).get("BTC")
+
+    assert state.conviction == pytest.approx(0.0)
+    assert state.forecast_count == 0
+
+
+def test_compute_novelty_penalty_agreement_suppresses_confidence() -> None:
+    result = compute_novelty_penalty(
+        candidate_action="long",
+        candidate_confidence=0.7,
+        brain_conviction=0.8,
+    )
+
+    assert result.applied is True
+    assert result.confidence_delta < 0
+
+
+def test_compute_novelty_penalty_contrarian_boosts_confidence() -> None:
+    result = compute_novelty_penalty(
+        candidate_action="short",
+        candidate_confidence=0.7,
+        brain_conviction=0.8,
+    )
+
+    assert result.applied is True
+    assert result.confidence_delta > 0
+
+
+def test_compute_novelty_penalty_weak_conviction_no_penalty() -> None:
+    result = compute_novelty_penalty(
+        candidate_action="long",
+        candidate_confidence=0.7,
+        brain_conviction=0.3,
+    )
+
+    assert result.applied is False
+    assert result.confidence_delta == pytest.approx(0.0)
+
+
+def test_compute_novelty_penalty_abstention_passes_through() -> None:
+    result = compute_novelty_penalty(
+        candidate_action="no_forecast",
+        candidate_confidence=0.0,
+        brain_conviction=0.8,
+    )
+
+    assert result.applied is False
+    assert result.confidence_delta == pytest.approx(0.0)
+
+
+def test_novelty_interpreter_shadow_mode_keeps_candidate_unchanged(forecast_conn: sqlite3.Connection) -> None:
+    for _ in range(3):
+        _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.7)
+
+    candidate = _mk_payload(action="long", confidence=0.6)
+    wrapped = NoveltyInterpreter(inner=_StaticInterpreter(candidate), db=_ConnDB(forecast_conn), shadow=True)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "long"
+    assert out.confidence == pytest.approx(candidate.confidence)
+
+
+def test_novelty_interpreter_live_mode_suppresses_confidence_for_low_novelty(forecast_conn: sqlite3.Connection) -> None:
+    for _ in range(3):
+        _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.7)
+
+    candidate = _mk_payload(action="long", confidence=0.6)
+    wrapped = NoveltyInterpreter(inner=_StaticInterpreter(candidate), db=_ConnDB(forecast_conn), shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "long"
+    assert out.confidence < candidate.confidence
+
+
+def test_novelty_interpreter_live_mode_boosts_contrarian_signal(forecast_conn: sqlite3.Connection) -> None:
+    for _ in range(3):
+        _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.7)
+
+    candidate = _mk_payload(action="short", confidence=0.6)
+    wrapped = NoveltyInterpreter(inner=_StaticInterpreter(candidate), db=_ConnDB(forecast_conn), shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == "short"
+    assert out.confidence > candidate.confidence
+
+
+def test_novelty_interpreter_without_db_is_passthrough() -> None:
+    candidate = _mk_payload(action="long", confidence=0.61)
+    wrapped = NoveltyInterpreter(inner=_StaticInterpreter(candidate), db=None, shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == candidate.action
+    assert out.confidence == pytest.approx(candidate.confidence)
+
+
+@pytest.mark.parametrize("action", ["long", "short"])
+def test_novelty_interpreter_preserves_action_identity(action: str, forecast_conn: sqlite3.Connection) -> None:
+    for _ in range(3):
+        _insert_forecast(forecast_conn, asset="BTC", action="long", confidence=0.7)
+
+    candidate = _mk_payload(action=action, confidence=0.9)
+    wrapped = NoveltyInterpreter(inner=_StaticInterpreter(candidate), db=_ConnDB(forecast_conn), shadow=False)
+
+    out = wrapped.interpret(asset="BTC", horizon="4h", signals=[], regime_tag="BULL")
+
+    assert out.action == action


### PR DESCRIPTION
## Summary

Closes #187

Producers see aggregate brain conviction (single signed float per asset) and apply a novelty penalty when their forecast agrees with strong existing conviction. Hard constraints preserved: no producer identities, no domain breakdown, action immutable.

## Type of change
- [x] `feat` — new feature

## Changes

- `engine/brain/conviction_state.py` (new) — `ConvictionStateReader`, `ConvictionState`
- `engine/core/novelty.py` (new) — `compute_novelty_penalty()`, `NoveltyResult`
- `engine/core/interpreter.py` — `NoveltyInterpreter` wrapper
- `tests/unit/test_cross_producer_awareness.py` (new)

## Tests

- [x] New tests added
- [x] All tests pass: ====================== 935 passed, 33 warnings in 59.95s =======================

## Checklist

- [x] Branch targets `develop`
- [x] shadow=True by default
- [x] Action never changes
- [x] `engine/brain/orchestrator.py` not modified