### PR TITLE
fix: wizard uses installed b1e55ed CLI for identity forge subprocess

### DIFF
--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -506,8 +506,13 @@ def _step3_identity(repo_root: Path) -> None:
             print(f"  {dim('Running: b1e55ed identity forge')}")
             print()
             try:
+                import shutil as _shutil
+
+                _b1e55ed = _shutil.which("b1e55ed")
+                _forge_cmd: list[str] = [_b1e55ed, "identity", "forge"] if _b1e55ed is not None else [sys.executable, "-m", "engine.cli", "identity", "forge"]
+
                 proc = subprocess.run(
-                    [sys.executable, "-m", "engine.cli", "identity", "forge"],
+                    _forge_cmd,
                     cwd=str(repo_root),
                     check=False,
                 )
@@ -533,8 +538,13 @@ def _step3_identity(repo_root: Path) -> None:
             print(f"  {dim('Running: b1e55ed identity forge')}")
             print()
             try:
+                import shutil as _shutil
+
+                _b1e55ed = _shutil.which("b1e55ed")
+                _forge_cmd = [_b1e55ed, "identity", "forge"] if _b1e55ed is not None else [sys.executable, "-m", "engine.cli", "identity", "forge"]
+
                 proc = subprocess.run(
-                    [sys.executable, "-m", "engine.cli", "identity", "forge"],
+                    _forge_cmd,
                     cwd=str(repo_root),
                     check=False,
                 )


### PR DESCRIPTION
## Root cause

When `b1e55ed wizard` spawns `identity forge`, it called:
```
sys.executable -m engine.cli identity forge
```
with `cwd=repo_root` where `repo_root = Path.cwd()` on a production install (e.g. `/home/ubuntu`). Python cannot find the `engine` package, subprocess silently fails, and the 90-min Python grinder runs instead of the 5-second Rust binary.

## Fix

Both forge subprocess calls in `_step3_identity()` now resolve the installed `b1e55ed` CLI via `shutil.which("b1e55ed")` and call that directly. Falls back to `sys.executable -m engine.cli` only in dev environments where `b1e55ed` is not in PATH.

## Verified on

First production deploy (blessed-patient-zero, Ubuntu x86_64). Rust binary confirmed working at 92k candidates/sec when called directly.

## Type of change
- [x] Bug fix