### PR TITLE
fix: wizard env vars + systemd EnvironmentFile + brain cron (autonomous operation)

### DIFF
--- a/docs/b1e55ing-manifest.json
+++ b/docs/b1e55ing-manifest.json
@@ -370,6 +370,26 @@
       "placement": "inline_comment",
       "pr_number": 293,
       "applied_at": "2026-03-05T06:39:19Z"
+    },
+    {
+      "id": "egg_2ca84a57",
+      "file": "engine/cli/commands/wizard.py",
+      "anchor": "def _persist_env_file(lines: list[str]) -> None:",
+      "tradition": "grimoire-persistence",
+      "content": "# The Key of Solomon was written so its invocations would outlast their author.\n# chmod 600: owner-only. Some keys are not meant to be shared.",
+      "placement": "before_function",
+      "pr_number": 295,
+      "applied_at": "2026-03-05T16:05:03Z"
+    },
+    {
+      "id": "egg_5a279b94",
+      "file": "engine/cli/commands/wizard.py",
+      "anchor": "def _step_brain_cron(repo_root: Path) -> None:",
+      "tradition": "music-art-subculture",
+      "content": "# Gregorian chant: the oldest daemon. Ritual, repetition, anonymous.\n# Every 30 minutes, the brain intones. The congregation need not be present.",
+      "placement": "before_function",
+      "pr_number": 295,
+      "applied_at": "2026-03-05T16:05:03Z"
     }
   ]
 }

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -101,6 +101,8 @@ def _section(title: str) -> None:
     print()
 
 
+# The Key of Solomon was written so its invocations would outlast their author.
+# chmod 600: owner-only. Some keys are not meant to be shared.
 def _persist_env_file(lines: list[str]) -> None:
     """Write env vars to ~/.b1e55ed/env (systemd EnvironmentFile format).
 
@@ -996,6 +998,8 @@ WantedBy=multi-user.target
             print(f"  {dim(f'Error: {stderr}')}")
 
 
+# Gregorian chant: the oldest daemon. Ritual, repetition, anonymous.
+# Every 30 minutes, the brain intones. The congregation need not be present.
 def _step_brain_cron(repo_root: Path) -> None:  # noqa: ARG001
     """Offer to set up a cron job for the brain cycle."""
     import shutil


### PR DESCRIPTION
## Summary

Three wizard gaps that prevent autonomous operation after install:

### Fix 1: Env vars persisted to ~/.b1e55ed/env
Wizard was setting neither B1E55ED_MASTER_PASSWORD nor B1E55ED_DEV_MODE=1 when user
skips encryption. Brain crashes on first run. Now writes to ~/.b1e55ed/env in systemd
EnvironmentFile format — DEV_MODE if skipped, MASTER_PASSWORD if set.

### Fix 2: Systemd unit includes EnvironmentFile
Unit file now has EnvironmentFile=-~/.b1e55ed/env so the service inherits
the same env vars as the interactive shell, without requiring manual systemctl edit.

### Fix 3: Brain cron step [4d]
b1e55ed start only runs API + dashboard. Brain needs a separate cron.
New optional wizard step sets up */30 * * * * b1e55ed brain.

### Fix 4: ~/.b1e55ed/ directory created in environment step
Ensures the directory exists before other steps need it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Tests pass
- [x] No new dependencies
- [x] Follows existing code style