### PR TITLE
feat: b1e55ing inline CI — autonomous blessing, auto-skip, never blocks merge

### DIFF
--- a/.github/workflows/b1e55ing-merge.yml
+++ b/.github/workflows/b1e55ing-merge.yml
@@ -21,13 +21,26 @@ jobs:
       pull-requests: write
       contents: read
     steps:
+      - name: Skip housekeeping PRs
+        id: skip
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          if echo "$TITLE" | grep -qiE "^(chore: auto-update|a b1e55ing|chore: a b1e55ing)"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Housekeeping PR — no curse needed"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.skip.outputs.skip == 'false'
         with:
           ref: ${{ github.base_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 20
 
       - name: Check if already blessed
+        if: steps.skip.outputs.skip == 'false'
         id: blessed
         uses: actions/github-script@v7
         with:
@@ -47,7 +60,7 @@ jobs:
             else console.log('○ Oracle was unreachable — delivering the curse');
 
       - name: The oracle was unreachable — deliver the curse
-        if: steps.blessed.outputs.already_blessed == 'false'
+        if: steps.skip.outputs.skip == 'false' && steps.blessed.outputs.already_blessed == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/b1e55ing.yml
+++ b/.github/workflows/b1e55ing.yml
@@ -4,12 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [main, develop]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to bless'
-        required: true
-        type: string
+
+# Wiener's first principle: the feedback loop must close before the system acts.
+# A blessing that blocks the merge is not a blessing. It is a bottleneck.
+# This workflow blesses immediately, then signals for enhancement.
 
 jobs:
   bless:
@@ -17,15 +15,62 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
+      contents: write
 
     steps:
-      - name: Skip fork PRs
-        if: github.event.pull_request.head.repo.fork == true
+      # ── auto-skip housekeeping PRs ──────────────────────────────
+      - name: Check if housekeeping PR
+        id: skip
         run: |
-          echo "Fork PR — post-merge fallback will catch it."
-          exit 0
+          TITLE="${{ github.event.pull_request.title }}"
+          if echo "$TITLE" | grep -qiE "^(chore: auto-update|a b1e55ing|chore: a b1e55ing)"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
+      - name: Auto-bless housekeeping PR
+        if: steps.skip.outputs.skip == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              context: 'a b1e55ing',
+              description: 'Auto-blessed (housekeeping)'
+            });
+
+      # ── skip fork PRs ──────────────────────────────────────────
+      - name: Detect fork PR
+        if: steps.skip.outputs.skip == 'false'
+        id: fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Auto-bless fork PR
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              context: 'a b1e55ing',
+              description: 'Auto-blessed (fork PR)'
+            });
+
+      # ── check if already blessed ───────────────────────────────
       - name: Check if already blessed
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false'
         id: blessed
         uses: actions/github-script@v7
         with:
@@ -38,43 +83,10 @@ jobs:
             const blessed = commits.data.some(c => c.commit.message.includes('a b1e55ing'));
             core.setOutput('already_blessed', blessed ? 'true' : 'false');
             if (blessed) console.log('✓ Already blessed');
-            else console.log('○ Not yet blessed — setting pending, signalling agent');
+            else console.log('○ Not yet blessed — will bless inline');
 
-      # Ashby's Law of Requisite Variety: a controller needs at least as much
-      # variety as the system it controls. One status check -- exactly sufficient.
-      - name: Set pending status (blocks merge until agent blesses)
-        if: steps.blessed.outputs.already_blessed == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'pending',
-              context: 'a b1e55ing',
-              description: 'Waiting for agent blessing…'
-            });
-
-      - name: Signal agent via Telegram
-        if: steps.blessed.outputs.already_blessed == 'false'
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-        run: |
-          MSG="[b1e55ing] PR #${{ github.event.pull_request.number }} opened on ${{ github.repository }} — ${{ github.event.pull_request.title }}"
-          MSG="${MSG}"$'\n'"Branch: ${{ github.head_ref }}"
-          MSG="${MSG}"$'\n'"SHA: ${{ github.event.pull_request.head.sha }}"
-          curl -s -X POST \
-            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -d "chat_id=${TELEGRAM_CHAT_ID}" \
-            --data-urlencode "text=${MSG}" \
-            | python3 -c "import sys,json; r=json.load(sys.stdin); print('Signal sent' if r.get('ok') else 'Signal failed: '+str(r))" \
-            || true
-
-      # Hal Finney received block 170. The handshake completed before anyone moved on.
-      - name: Already blessed — set success
-        if: steps.blessed.outputs.already_blessed == 'true'
+      - name: Set success if already blessed
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -86,3 +98,61 @@ jobs:
               context: 'a b1e55ing',
               description: 'Already blessed'
             });
+
+      # ── bless: checkout → empty commit → push → success ───────
+      - name: Checkout PR branch
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+
+      - name: Commit empty blessing
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
+        run: |
+          git config user.name "a b1e55ing"
+          git config user.email "b1e55ing@permanentupperclass.com"
+          git commit --allow-empty -m "chore: a b1e55ing [skip ci]"
+
+      - name: Push blessing
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
+        run: |
+          git push origin HEAD:${{ github.event.pull_request.head.ref }} || true
+
+      # Hal Finney received block 170. The handshake completed before anyone moved on.
+      - name: Post success status
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Fetch updated PR to get the new HEAD sha after our push
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: pr.data.head.sha,
+              state: 'success',
+              context: 'a b1e55ing',
+              description: 'Blessed ✓'
+            });
+
+      # ── signal Telegram (best-effort, after merge is unblocked) ─
+      - name: Signal agent for egg enhancement
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          MSG="[b1e55ing] PR #${{ github.event.pull_request.number }} on ${{ github.repository }} — ${{ github.event.pull_request.title }}"
+          MSG="${MSG}"$'\n'"Branch: ${{ github.head_ref }}"
+          MSG="${MSG}"$'\n'"Empty blessing committed. Enhance with real eggs when ready."
+          curl -s -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" \
+            || true


### PR DESCRIPTION
## What

Redesigns the b1e55ing workflow so CI never blocks merge.

## Why

- Telegram signals get dropped → PRs stuck indefinitely
- Manual process → wrong branches, merge conflicts
- Zero automation = zero reliability

## How

### b1e55ing.yml (full rewrite)

**Old flow:** PR opens → pending status (blocks merge) → Telegram signal → wait for manual blessing → ???

**New flow:** PR opens → checkout branch → empty blessing commit → push → success status → Telegram (best-effort, async)

- Merge is **never** blocked
- Housekeeping PRs (`chore: auto-update`, `a b1e55ing`) → instant success, no commit
- Fork PRs → instant success
- Telegram sent **after** merge is unblocked, for optional egg enhancement later

### b1e55ing-merge.yml

- Added housekeeping PR skip (no curse comment on auto-update PRs)

### b1e55ing.py

- No changes needed — confirmed no `git checkout` calls, no branch switching
- Script uses PR number for GitHub API context only, all git ops on current branch

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)

## No API keys required

No Anthropic API, no LLM in CI. Egg generation stays via Claude subscription + Telegram async.