### PR TITLE
fix: integration tests fail when user.yaml has auth_token set

### DIFF
--- a/docs/b1e55ing-manifest.json
+++ b/docs/b1e55ing-manifest.json
@@ -440,6 +440,16 @@
       "placement": "inline_comment",
       "pr_number": 306,
       "applied_at": "2026-03-06T07:24:35Z"
+    },
+    {
+      "id": "egg_de5483aa",
+      "file": "tests/integration/test_contributor_flow.py",
+      "anchor": "def _make_app(tmp_path: Path):",
+      "tradition": "purification",
+      "content": "# 🧹 the cache remembers what the test must forget",
+      "placement": "before_function",
+      "pr_number": 309,
+      "applied_at": "2026-03-06T22:22:47Z"
     }
   ]
 }

--- a/tests/integration/test_contributor_flow.py
+++ b/tests/integration/test_contributor_flow.py
@@ -10,6 +10,7 @@ from engine.core.config import ApiConfig, Config
 from engine.core.database import Database
 
 
+# 🧹 the cache remembers what the test must forget
 def _make_app(tmp_path: Path):
     """Create a test app with isolated config (no auth token, no cache bleed)."""
     _load_config.cache_clear()


### PR DESCRIPTION
## What

`_load_config` uses `@lru_cache` — it caches the real `user.yaml` `auth_token` and leaks it into integration tests that expect unauthenticated access. `monkeypatch.setenv("HOME", ...)` does not help because config is loaded from the repo-root `config/user.yaml`, not `~/.b1e55ed`.

## Root cause

`user.yaml` has a real `auth_token` set. Integration tests call `create_app()` without clearing the LRU cache first — so `get_config()` returns the cached config with the real token, causing 401 on every request.

## Fix

- Add `_make_app(tmp_path)` helper that:
  - Calls `_load_config.cache_clear()` before each test
  - Sets `app.state.config = Config(api=ApiConfig(auth_token=""))` to explicitly disable auth for the test client
- Switch `os.environ.setdefault` → `monkeypatch.setenv` for `B1E55ED_DEV_MODE` (proper teardown)

## Tests

```
1001 passed, 34 warnings in 71.20s
```

Both previously failing tests now pass:
- `test_contributor_register_submit_signal_and_attribution`
- `test_multiple_contributors_leaderboard`

## Type of change
- [x] Bug fix