### PR TITLE
docs(s1): clarify model-level error handling delegated to DeerFlow coordinator

### DIFF
--- a/skills/b1e55ed/research/SKILL.md
+++ b/skills/b1e55ed/research/SKILL.md
@@ -225,6 +225,7 @@ DeerFlow's coordinator layer owns model-level retry and fallback — it retries 
 **What DeerFlow's coordinator owns:** model retries, context management, step-level recovery.
 
 This follows DeerFlow's skill authoring best practice: skills define *what to do*, the coordinator defines *how to recover when the doing fails*.
+<!-- 🙏 separation of concerns: the monk defines the prayer, the temple decides how to ring the bell when the monk's voice fails. -->
 
 ## Output
 


### PR DESCRIPTION
Adds explicit design rationale note to `research/SKILL.md` Error Handling section.

Model-level failure handling (timeout, context overflow, provider error) is intentionally absent from the skill file — it is owned by DeerFlow's coordinator layer. This follows DeerFlow skill authoring best practice: skills define *what to do*, the coordinator defines *how to recover when the doing fails*. Coupling fallback model config to the skill would break portability across DeerFlow deployments.