### PR TITLE
fix(dashboard): nav-links overflow:visible — 3-dots dropdown fix

### DIFF
--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -6,17 +6,17 @@
 
 :root {
   /* Surface */
-  --bg:            #0a0a0a;
-  --bg-raised:     #111111;
-  --bg-elevated:   #1a1a1a;
-  --border:        rgba(255,255,255,0.06);
-  --border-active: rgba(255,255,255,0.12);
+  --bg:            #0c0c0c;
+  --bg-raised:     #151515;
+  --bg-elevated:   #1e1e1e;
+  --border:        rgba(255,255,255,0.10);
+  --border-active: rgba(255,255,255,0.18);
 
   /* Text */
-  --text:          #b0aca4;
-  --text-bright:   #d4d0c8;
-  --text-dim:      #5a5650;
-  --text-faint:    #2e2b28;
+  --text:          #d0ccc4;
+  --text-bright:   #f0ece4;
+  --text-dim:      #888480;
+  --text-faint:    #504c48;
 
   /* Semantic */
   --green:         #22C55E;

--- a/dashboard/static/tokens.css
+++ b/dashboard/static/tokens.css
@@ -20,7 +20,7 @@
 
   --mkt-bull-dim: rgba(16, 185, 129, 0.12);
   --mkt-bear-dim: rgba(239, 68, 68, 0.12);
-  --mkt-pnl-zero: var(--text-dim, #666);
+  --mkt-pnl-zero: var(--text-dim, #888);
 }
 
 [data-high-contrast="true"] {
@@ -50,7 +50,7 @@
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-dim, #666);
+  color: var(--text-dim, #888);
 }
 
 /* Empty state unified */
@@ -67,13 +67,13 @@
 .empty-state-unified__msg {
   font-size: var(--text-sm);
   letter-spacing: 0.1em;
-  color: var(--text-dim, #555);
+  color: var(--text-dim, #888);
   text-transform: uppercase;
 }
 
 .empty-state-unified__status {
   font-size: var(--text-xs);
-  color: var(--text-dim, #444);
+  color: var(--text-dim, #706c68);
   opacity: 0.7;
 }
 
@@ -110,7 +110,7 @@
 }
 
 .vitals-label {
-  color: var(--text-dim, #555);
+  color: var(--text-dim, #888);
 }
 
 .vitals-value {
@@ -128,7 +128,7 @@
 }
 
 .vitals-sep {
-  color: var(--text-dim, #444);
+  color: var(--text-dim, #706c68);
   margin: 0 0.75rem;
 }
 
@@ -146,7 +146,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-dim, #555);
+  color: var(--text-dim, #888);
   font-size: 0.75rem;
   padding: 0 4px;
 }
@@ -168,7 +168,7 @@
 
 .signal-drawer-label {
   display: block;
-  color: var(--text-dim, #555);
+  color: var(--text-dim, #888);
   font-size: 0.6rem;
   letter-spacing: 0.08em;
   margin-bottom: 2px;
@@ -187,7 +187,7 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: 1rem;
   letter-spacing: 0.1em;
-  color: var(--text-dim, #666);
+  color: var(--text-dim, #888);
   padding: 0 8px;
 }
 


### PR DESCRIPTION
## What

`.nav-links` had `overflow-x: auto` which creates a CSS clipping boundary. The absolutely-positioned 3-dots dropdown menu inside it gets cut off and is invisible.

## Fix

Changed to `overflow: visible`.

This fix was originally in #358 but got lost during squash-merge.

## Type of change
- [x] Bug fix