### PR TITLE
fix: remove [skip ci] from blessing commits

### DIFF
--- a/.github/workflows/b1e55ing.yml
+++ b/.github/workflows/b1e55ing.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           git config user.name "a b1e55ing"
           git config user.email "b1e55ing@permanentupperclass.com"
-          git commit --allow-empty -m "chore: a b1e55ing [skip ci]"
+          git commit --allow-empty -m "chore: a b1e55ing"
 
       - name: Push blessing and capture SHA
         id: push


### PR DESCRIPTION
## Root Cause

Blessing commits had `[skip ci]` in the message. GitHub applies this to ALL workflows, not just the one that pushed. So after every blessing push, CI (tests, lint, build, docker, docs, etc.) never ran.

## Fix

Remove `[skip ci]` from the blessing commit message. The blessing workflow already self-skips via title matching (line 26: `chore: a b1e55ing` matches the housekeeping pattern), so `[skip ci]` was redundant.

## Impact

After this merges, every PR will get full CI after blessing. No more missing check-runs.