### PR TITLE
fix(ci): bless PRs without mutating head SHA

### DIFF
--- a/.github/workflows/b1e55ing.yml
+++ b/.github/workflows/b1e55ing.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       pull-requests: read
       statuses: write
-      contents: write
 
     steps:
       # ── auto-skip housekeeping PRs ──────────────────────────────
@@ -68,25 +67,12 @@ jobs:
               description: 'Auto-blessed (fork PR)'
             });
 
-      # ── check if already blessed ───────────────────────────────
-      - name: Check if already blessed
+      # ── bless without mutating PR head SHA ─────────────────────
+      # IMPORTANT: Do not push empty blessing commits in PR workflow.
+      # Mutating head SHA with GITHUB_TOKEN can leave CI checks attached to the
+      # prior SHA, creating the appearance that CI never ran on the current head.
+      - name: Set blessing status on current PR head
         if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false'
-        id: blessed
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const commits = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
-            });
-            const blessed = commits.data.some(c => c.commit.message.includes('a b1e55ing'));
-            core.setOutput('already_blessed', blessed ? 'true' : 'false');
-            if (blessed) console.log('✓ Already blessed');
-            else console.log('○ Not yet blessed — will bless inline');
-
-      - name: Set success if already blessed
-        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -96,81 +82,19 @@ jobs:
               sha: context.payload.pull_request.head.sha,
               state: 'success',
               context: 'a b1e55ing',
-              description: 'Already blessed'
+              description: 'Blessed ✓ (status-only, no head mutation)'
             });
 
-      # ── bless: checkout → empty commit → push → success ───────
-      - name: Checkout PR branch
-        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 1
-
-      - name: Commit empty blessing
-        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
-        run: |
-          git config user.name "a b1e55ing"
-          git config user.email "b1e55ing@permanentupperclass.com"
-          git commit --allow-empty -m "chore: a b1e55ing"
-
-      - name: Push blessing and capture SHA
-        id: push
-        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
-        run: |
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
-          # Capture the NEW head SHA (the blessing commit we just pushed)
-          NEW_SHA=$(git rev-parse HEAD)
-          echo "new_sha=$NEW_SHA" >> "$GITHUB_OUTPUT"
-          echo "Blessing commit SHA: $NEW_SHA"
-
-      # Hal Finney received block 170. The handshake completed before anyone moved on.
-      # CRITICAL: GITHUB_TOKEN pushes do NOT re-trigger workflows, so the new HEAD
-      # will never get a status check from a re-run. We must set it here, on both
-      # the original SHA (for the current check-run) and the new SHA (for merge gating).
-      - name: Post success status on both SHAs
-        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const newSha = '${{ steps.push.outputs.new_sha }}';
-            const origSha = context.payload.pull_request.head.sha;
-
-            // Set on new SHA (the blessing commit — this is what merge gating checks)
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: newSha,
-              state: 'success',
-              context: 'a b1e55ing',
-              description: 'Blessed ✓'
-            });
-            console.log(`✓ Status set on new SHA: ${newSha}`);
-
-            // Also set on original SHA (belt and suspenders)
-            if (origSha !== newSha) {
-              await github.rest.repos.createCommitStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha: origSha,
-                state: 'success',
-                context: 'a b1e55ing',
-                description: 'Blessed ✓'
-              });
-              console.log(`✓ Status set on orig SHA: ${origSha}`);
-            }
-
-      # ── signal Telegram (best-effort, after merge is unblocked) ─
+      # ── signal Telegram (best-effort) ──────────────────────────
       - name: Signal agent for egg enhancement
-        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false' && steps.blessed.outputs.already_blessed == 'false'
+        if: steps.skip.outputs.skip == 'false' && steps.fork.outputs.is_fork == 'false'
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           MSG="[b1e55ing] PR #${{ github.event.pull_request.number }} on ${{ github.repository }} — ${{ github.event.pull_request.title }}"
           MSG="${MSG}"$'\n'"Branch: ${{ github.head_ref }}"
-          MSG="${MSG}"$'\n'"Empty blessing committed. Enhance with real eggs when ready."
+          MSG="${MSG}"$'\n'"Status blessed. Egg enhancement can run separately."
           curl -s -X POST \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d "chat_id=${TELEGRAM_CHAT_ID}" \


### PR DESCRIPTION
## Summary

Stop blessing workflow from mutating PR head SHA, which was causing CI checks to attach to stale commits and appear missing on current PR head.

Closes #<!-- issue number -->

---

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

- [x] Labels applied ✅

---

## Changes

- Updated `.github/workflows/b1e55ing.yml` to use status-only blessing on PR head SHA.
- Removed empty commit + push flow that changed PR head SHA.
- Kept Telegram signaling, but no head mutation.
- Dropped unnecessary `contents: write` permission.

---

## Tests

- [ ] New tests added (or explain why not needed)
- [ ] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [ ] Test count: `N/A (workflow-only change)` passing

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [ ] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
