### PR TITLE
fix(signals): preserve raw timestamps for timeline plotting

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -443,7 +443,9 @@ def _map_signals(resp: Any) -> list[dict[str, Any]]:
 
         out.append(
             {
-                "ts": ts_hm,
+                # Keep raw timestamp for timeline plotting; use ts_hm for display-only chips.
+                "ts": str(ts) if ts is not None else "",
+                "ts_hm": ts_hm,
                 "domain": domain,
                 "asset": str(asset),
                 "desc": str(desc),

--- a/dashboard/templates/signals.html
+++ b/dashboard/templates/signals.html
@@ -105,7 +105,7 @@
 
   // Parse signal data from the rendered page (safe server-side JSON serialization)
   {% set signal_data = [] %}
-  {% for s in signals %}{% set _ = signal_data.append({'ts': s.ts, 'domain': s.domain, 'asset': s.asset, 'desc': s.desc, 'score': s.score|default(0), 'direction': s.direction}) %}{% endfor %}
+  {% for s in signals %}{% set _ = signal_data.append({'ts': s.ts, 'ts_hm': s.ts_hm, 'domain': s.domain, 'asset': s.asset, 'desc': s.desc, 'score': s.score|default(0), 'direction': s.direction}) %}{% endfor %}
   var signals = {{ signal_data | tojson }};
 
   if (!signals.length) return;

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -193,6 +193,28 @@ def test_settings_actions_are_truthful_and_config_paths_exist() -> None:
         assert "/api/settings/config/save" in page.text
 
 
+class SignalTimelineApiClient(DummyApiClient):
+    def get_signals(self, domain: str | None = None) -> _Res:
+        return _Res(
+            {
+                "items": [
+                    {
+                        "type": "signal.ta.rsi.v1",
+                        "ts": "2026-03-12T18:00:00Z",
+                        "payload": {"symbol": "BTC", "desc": "RSI oversold", "score": 7.2, "direction": "▲"},
+                    },
+                    {
+                        "type": "signal.social.sentiment.v1",
+                        "ts": "2026-03-12T19:00:00Z",
+                        "payload": {"symbol": "SOL", "desc": "Social velocity", "score": 6.4, "direction": "▲"},
+                    },
+                ],
+                "total": 2,
+            },
+            True,
+        )
+
+
 class SocialPanelApiClient(DummyApiClient):
     def get_social_status(self) -> _Res:
         return _Res(
@@ -227,6 +249,16 @@ class SocialPanelApiClient(DummyApiClient):
             },
             True,
         )
+
+
+def test_signals_page_uses_raw_timestamps_for_timeline() -> None:
+    with TestClient(app) as client:
+        client.app.state.api_client = SignalTimelineApiClient()
+        resp = client.get("/signals")
+        assert resp.status_code == 200
+        # Raw ISO timestamps must be present for timeline placement JS.
+        assert "2026-03-12T18:00:00Z" in resp.text
+        assert "2026-03-12T19:00:00Z" in resp.text
 
 
 def test_sentiment_map_partial_shows_live_source_counts() -> None:


### PR DESCRIPTION
## Summary

Fix the Signals timeline chart so dots are positioned by real event timestamps instead of collapsing to "now" due to display-only `HH:MM` timestamp mapping.

Closes #<!-- issue number -->

---

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

- [x] Labels applied ✅

---

## Changes

- `dashboard/app.py`
  - `_map_signals` now preserves raw `ts` for timeline plotting and adds `ts_hm` for display-only text.
- `dashboard/templates/signals.html`
  - timeline data payload now includes both `ts` and `ts_hm`.
- `tests/unit/test_dashboard.py`
  - added regression test to ensure raw ISO timestamps are present in rendered signals page timeline payload.

---

## Tests

- [x] New tests added (or explain why not needed)
- [ ] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: `7` passing (targeted `tests/unit/test_dashboard.py`)

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [ ] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
