### PR TITLE
feat(universe): add tradfi and hyperliquid bundle packs

### DIFF
--- a/api/routes/universe.py
+++ b/api/routes/universe.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import yaml
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from api.auth import AuthDep
 from api.deps import get_config
 from api.errors import B1e55edError
+from engine.core.bundle_packs import bundle_template_from_pack, get_bundle_pack, list_bundle_packs
 from engine.core.config import Config, UniverseBundle
 from engine.core.paths import config_dir
 
@@ -25,15 +26,27 @@ class UniverseBundlesResponse(BaseModel):
     total: int = 0
 
 
+class UniverseBundlePacksResponse(BaseModel):
+    items: list[dict[str, Any]] = Field(default_factory=list)
+    total: int = 0
+
+
 class CreateBundleRequest(BaseModel):
     id: str | None = None
-    name: str
-    symbols: list[str] = Field(default_factory=list)
-    tags: list[str] = Field(default_factory=list)
-    asset_class: str = "crypto"
-    venue: str = "global"
+    pack_id: str | None = None
+    name: str | None = None
+    symbols: list[str] | None = None
+    tags: list[str] | None = None
+    asset_class: str | None = None
+    venue: str | None = None
     enabled: bool = True
     source: Literal["wizard", "user", "system"] = "user"
+
+    @field_validator("pack_id", mode="before")
+    @classmethod
+    def _normalize_pack_id(cls, v: Any) -> str | None:
+        text = str(v or "").strip().lower()
+        return text or None
 
 
 class UpdateBundleRequest(BaseModel):
@@ -53,8 +66,10 @@ class ActiveUniverseResponse(BaseModel):
     enabled_bundle_ids: list[str] = Field(default_factory=list)
     asset_classes: list[str] = Field(default_factory=list)
     venues: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
     asset_class_symbols: dict[str, list[str]] = Field(default_factory=dict)
     venue_symbols: dict[str, list[str]] = Field(default_factory=dict)
+    tag_symbols: dict[str, list[str]] = Field(default_factory=dict)
 
 
 def _config_path() -> Path:
@@ -101,14 +116,20 @@ def _active_payload(config: Config) -> ActiveUniverseResponse:
 
     asset_class_map: dict[str, list[str]] = defaultdict(list)
     venue_map: dict[str, list[str]] = defaultdict(list)
+    tag_map: dict[str, list[str]] = defaultdict(list)
+
     for bundle in enabled:
         if bundle.asset_class:
             asset_class_map[bundle.asset_class].extend(bundle.symbols)
         if bundle.venue:
             venue_map[bundle.venue].extend(bundle.symbols)
+        for tag in bundle.tags:
+            if tag:
+                tag_map[tag].extend(bundle.symbols)
 
     asset_class_symbols = {k: universe.normalize_symbols(v) for k, v in asset_class_map.items() if k}
     venue_symbols = {k: universe.normalize_symbols(v) for k, v in venue_map.items() if k}
+    tag_symbols = {k: universe.normalize_symbols(v) for k, v in tag_map.items() if k}
 
     return ActiveUniverseResponse(
         symbols=active_symbols,
@@ -118,9 +139,17 @@ def _active_payload(config: Config) -> ActiveUniverseResponse:
         enabled_bundle_ids=[b.id for b in enabled],
         asset_classes=sorted(asset_class_symbols.keys()),
         venues=sorted(venue_symbols.keys()),
+        tags=sorted(tag_symbols.keys()),
         asset_class_symbols=asset_class_symbols,
         venue_symbols=venue_symbols,
+        tag_symbols=tag_symbols,
     )
+
+
+@router.get("/packs", response_model=UniverseBundlePacksResponse)
+def list_packs() -> UniverseBundlePacksResponse:
+    items = list_bundle_packs()
+    return UniverseBundlePacksResponse(items=items, total=len(items))
 
 
 @router.get("/bundles", response_model=UniverseBundlesResponse)
@@ -135,23 +164,64 @@ def create_bundle(
     payload: CreateBundleRequest,
     config: Config = Depends(get_config),
 ) -> UniverseBundle:
-    if not payload.name.strip():
-        raise B1e55edError(code="universe.bundle_name_required", message="Bundle name is required", status=400)
-    if not payload.symbols:
-        raise B1e55edError(code="universe.bundle_symbols_required", message="Bundle symbols are required", status=400)
-
     bundles = list(config.universe.bundles)
     ids = {b.id for b in bundles}
-    candidate = payload.id.strip() if payload.id else payload.name
+
+    name = str(payload.name or "").strip()
+    symbols = list(payload.symbols or [])
+    tags = list(payload.tags or [])
+    asset_class = str(payload.asset_class or "").strip() or "crypto"
+    venue = str(payload.venue or "").strip() or "global"
+
+    if payload.pack_id:
+        pack = get_bundle_pack(payload.pack_id)
+        if pack is None:
+            raise B1e55edError(
+                code="universe.bundle_pack_not_found",
+                message="Bundle pack not found",
+                status=404,
+                pack_id=payload.pack_id,
+            )
+
+        template = bundle_template_from_pack(
+            payload.pack_id,
+            source=payload.source,
+            enabled=payload.enabled,
+            name=name or None,
+            symbols=symbols or None,
+            tags=tags or None,
+            asset_class=asset_class if payload.asset_class is not None else None,
+            venue=venue if payload.venue is not None else None,
+        )
+        if template is None:
+            raise B1e55edError(
+                code="universe.bundle_pack_not_found",
+                message="Bundle pack not found",
+                status=404,
+                pack_id=payload.pack_id,
+            )
+
+        name = str(template.get("name") or "").strip()
+        symbols = list(template.get("symbols") or [])
+        tags = list(template.get("tags") or [])
+        asset_class = str(template.get("asset_class") or "crypto")
+        venue = str(template.get("venue") or "global")
+
+    if not name:
+        raise B1e55edError(code="universe.bundle_name_required", message="Bundle name is required", status=400)
+    if not symbols:
+        raise B1e55edError(code="universe.bundle_symbols_required", message="Bundle symbols are required", status=400)
+
+    candidate = payload.id.strip() if payload.id else (payload.pack_id or name)
     bundle_id = _alloc_bundle_id(candidate=candidate, existing=ids)
 
     new_bundle = UniverseBundle(
         id=bundle_id,
-        name=payload.name,
-        symbols=payload.symbols,
-        tags=payload.tags,
-        asset_class=payload.asset_class,
-        venue=payload.venue,
+        name=name,
+        symbols=symbols,
+        tags=tags,
+        asset_class=asset_class,
+        venue=venue,
         enabled=payload.enabled,
         source=payload.source,
     )

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -475,7 +475,29 @@ def _normalize_symbols(values: list[str]) -> list[str]:
     return out
 
 
+def _normalize_tags(values: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        tag = str(raw or "").strip().lower()
+        if not tag or tag in seen:
+            continue
+        seen.add(tag)
+        out.append(tag)
+    return out
+
+
 def _universe_bundle_context(client: Any) -> dict[str, Any]:
+    packs: list[dict[str, Any]] = []
+    get_packs = getattr(client, "get_universe_packs", None)
+    if callable(get_packs):
+        packs_res = get_packs()
+        packs_data = packs_res.data if (packs_res.ok and isinstance(packs_res.data, dict)) else {}
+        packs_raw = packs_data.get("items") if isinstance(packs_data, dict) else []
+        packs = [p for p in packs_raw if isinstance(p, dict)] if isinstance(packs_raw, list) else []
+
+    pack_map = {str(p.get("id") or ""): p for p in packs if str(p.get("id") or "")}
+
     bundles_res = client.get_universe_bundles()
     bundles_data = bundles_res.data if (bundles_res.ok and isinstance(bundles_res.data, dict)) else {}
     bundles_raw = bundles_data.get("items") if isinstance(bundles_data, dict) else []
@@ -529,18 +551,39 @@ def _universe_bundle_context(client: Any) -> dict[str, Any]:
             agg_v.setdefault(venue, []).extend(bundle_symbol_map.get(str(b.get("id")), []))
         venue_symbol_map = {k: _normalize_symbols(v) for k, v in agg_v.items()}
 
+    tag_symbol_map: dict[str, list[str]] = {}
+    raw_tag_map = active_data.get("tag_symbols") if isinstance(active_data, dict) else {}
+    if isinstance(raw_tag_map, dict) and raw_tag_map:
+        for k, v in raw_tag_map.items():
+            tag_symbol_map[str(k)] = _normalize_symbols(v if isinstance(v, list) else [])
+    else:
+        agg_t: dict[str, list[str]] = {}
+        for b in bundles:
+            if str(b.get("id") or "") not in enabled_bundle_ids:
+                continue
+            tags = _normalize_tags(b.get("tags") if isinstance(b.get("tags"), list) else [])
+            symbols = bundle_symbol_map.get(str(b.get("id")), [])
+            for tag in tags:
+                agg_t.setdefault(tag, []).extend(symbols)
+        tag_symbol_map = {k: _normalize_symbols(v) for k, v in agg_t.items()}
+
     asset_classes = sorted(asset_class_symbol_map.keys())
     venues = sorted(venue_symbol_map.keys())
+    tags = sorted(tag_symbol_map.keys())
 
     return {
+        "packs": packs,
+        "pack_map": pack_map,
         "bundles": bundles,
         "active_symbols": active_symbols,
         "enabled_bundle_ids": sorted(enabled_bundle_ids),
         "bundle_symbol_map": bundle_symbol_map,
         "asset_class_symbol_map": asset_class_symbol_map,
         "venue_symbol_map": venue_symbol_map,
+        "tag_symbol_map": tag_symbol_map,
         "asset_classes": asset_classes,
         "venues": venues,
+        "tags": tags,
         "fallback_to_symbols": bool(active_data.get("fallback_to_symbols", True)) if isinstance(active_data, dict) else True,
     }
 
@@ -1246,6 +1289,7 @@ def signals_page(
     bundle: str | None = None,
     asset_class: str | None = None,
     venue: str | None = None,
+    tag: str | None = None,
 ) -> HTMLResponse:
     client = _api(request)
     res = client.get_signals(domain=domain)
@@ -1256,6 +1300,7 @@ def signals_page(
     bundle_symbol_map = {k: set(v) for k, v in universe_ctx.get("bundle_symbol_map", {}).items()}
     asset_class_symbol_map = {k: set(v) for k, v in universe_ctx.get("asset_class_symbol_map", {}).items()}
     venue_symbol_map = {k: set(v) for k, v in universe_ctx.get("venue_symbol_map", {}).items()}
+    tag_symbol_map = {k: set(v) for k, v in universe_ctx.get("tag_symbol_map", {}).items()}
 
     if bundle:
         allowed = bundle_symbol_map.get(bundle)
@@ -1271,6 +1316,10 @@ def signals_page(
             signals = [s for s in signals if s.get("symbol") in allowed or str(s.get("venue") or "") == venue]
         else:
             signals = [s for s in signals if str(s.get("venue") or "") == venue]
+
+    if tag:
+        allowed = tag_symbol_map.get(tag)
+        signals = [s for s in signals if s.get("symbol") in allowed] if allowed else []
 
     # Build latest-by-domain groups from filtered signals.
     by_domain: dict[str, list[dict[str, Any]]] = {}
@@ -1299,6 +1348,8 @@ def signals_page(
         filter_params["asset_class"] = asset_class
     if venue:
         filter_params["venue"] = venue
+    if tag:
+        filter_params["tag"] = tag
     filter_qs = urlencode(filter_params)
 
     enabled_ids = set(universe_ctx.get("enabled_bundle_ids") or [])
@@ -1318,9 +1369,11 @@ def signals_page(
             "bundle_options": bundle_options,
             "asset_class_options": universe_ctx.get("asset_classes", []),
             "venue_options": universe_ctx.get("venues", []),
+            "tag_options": universe_ctx.get("tags", []),
             "active_bundle": bundle,
             "active_asset_class": asset_class,
             "active_venue": venue,
+            "active_tag": tag,
             "domain_filter_suffix": f"&{filter_qs}" if filter_qs else "",
             "all_filter_query": f"?{filter_qs}" if filter_qs else "",
         },
@@ -1598,6 +1651,8 @@ def settings_page(request: Request) -> HTMLResponse:
             "presets": ["conservative", "balanced", "degen"],
             "cfg": cfg,
             "universe_bundles": universe_ctx.get("bundles", []),
+            "universe_packs": universe_ctx.get("packs", []),
+            "universe_pack_map": universe_ctx.get("pack_map", {}),
             "universe_active_symbols": universe_ctx.get("active_symbols", []),
             "universe_fallback_to_symbols": universe_ctx.get("fallback_to_symbols", True),
             # System page data
@@ -1624,6 +1679,8 @@ def _render_universe_bundles_panel(
         {
             "request": request,
             "universe_bundles": ctx.get("bundles", []),
+            "universe_packs": ctx.get("packs", []),
+            "universe_pack_map": ctx.get("pack_map", {}),
             "universe_active_symbols": ctx.get("active_symbols", []),
             "universe_fallback_to_symbols": ctx.get("fallback_to_symbols", True),
             "bundle_status_message": status_message,
@@ -1641,38 +1698,47 @@ def universe_bundles_partial(request: Request) -> HTMLResponse:
 async def settings_add_universe_bundle(request: Request) -> HTMLResponse:
     form = await request.form()
 
+    pack_id = str(form.get("pack_id") or "").strip().lower() or None
     name = str(form.get("name") or "").strip()
     symbols_raw = str(form.get("symbols") or "")
     tags_raw = str(form.get("tags") or "")
-    asset_class = str(form.get("asset_class") or "crypto").strip() or "crypto"
-    venue = str(form.get("venue") or "global").strip() or "global"
+
+    asset_class_raw = str(form.get("asset_class") or "").strip()
+    venue_raw = str(form.get("venue") or "").strip()
+
     enabled = str(form.get("enabled") or "true").strip().lower() in {"1", "true", "yes", "on"}
 
     symbols = [s.strip().upper() for s in symbols_raw.replace("\n", ",").split(",") if s.strip()]
     tags = [t.strip().lower() for t in tags_raw.replace("\n", ",").split(",") if t.strip()]
 
-    if not name:
+    if not pack_id and not name:
         return _render_universe_bundles_panel(request, status_message="Bundle name is required.", status_ok=False)
-    if not symbols:
+    if not pack_id and not symbols:
         return _render_universe_bundles_panel(request, status_message="At least one symbol is required.", status_ok=False)
 
-    result = _api(request).create_universe_bundle(
-        {
-            "name": name,
-            "symbols": symbols,
-            "tags": tags,
-            "asset_class": asset_class,
-            "venue": venue,
-            "enabled": enabled,
-            "source": "user",
-        }
-    )
+    payload: dict[str, Any] = {
+        "pack_id": pack_id,
+        "name": name or None,
+        "symbols": symbols or None,
+        "tags": tags or None,
+        "asset_class": asset_class_raw or None,
+        "venue": venue_raw or None,
+        "enabled": enabled,
+        "source": "user",
+    }
+
+    if not pack_id:
+        payload["asset_class"] = asset_class_raw or "crypto"
+        payload["venue"] = venue_raw or "global"
+
+    result = _api(request).create_universe_bundle(payload)
 
     if not result.ok:
-        return _render_universe_bundles_panel(request, status_message="Failed to add bundle (API unavailable).", status_ok=False)
+        msg = f"Failed to add bundle{' from pack' if pack_id else ''} (API unavailable)."
+        return _render_universe_bundles_panel(request, status_message=msg, status_ok=False)
 
     created = result.data if isinstance(result.data, dict) else {}
-    label = str(created.get("name") or name)
+    label = str(created.get("name") or name or pack_id or "bundle")
     return _render_universe_bundles_panel(request, status_message=f"Added bundle: {label}", status_ok=True)
 
 

--- a/dashboard/services/api_client.py
+++ b/dashboard/services/api_client.py
@@ -85,6 +85,9 @@ class ApiClient:
             params["domain"] = domain
         return self._get_json("/signals", params=params)
 
+    def get_universe_packs(self) -> ApiResult:
+        return self._get_json("/universe/packs")
+
     def get_universe_bundles(self) -> ApiResult:
         return self._get_json("/universe/bundles")
 

--- a/dashboard/templates/partials/universe_bundles_panel.html
+++ b/dashboard/templates/partials/universe_bundles_panel.html
@@ -5,6 +5,8 @@
 
 <div style="font-size:0.75rem; color:var(--text-dim); margin-bottom:0.75rem; line-height:1.4;">
   Manage runtime symbol bundles. Enabled bundles define the active universe; when no enabled bundles exist, the system falls back to <code>universe.symbols</code>.
+  <br>
+  <strong>Direct</strong> mapping = symbol has first-order feed coverage. <strong>Proxy</strong> mapping = symbol inherits factor context (rates/dollar/vol/beta/liquidity) from a mapped anchor.
 </div>
 
 <div style="display:flex; gap:0.4rem; flex-wrap:wrap; margin-bottom:0.75rem;">
@@ -23,28 +25,43 @@
   hx-post="/api/settings/universe/bundles"
   hx-target="#universe-bundles-panel"
   hx-swap="outerHTML"
-  style="display:grid; grid-template-columns:1.2fr 1.5fr 1fr 0.9fr 0.9fr auto auto; gap:0.5rem; align-items:end; margin-bottom:1rem;"
+  style="display:grid; grid-template-columns:1.1fr 1.2fr 1.5fr 1fr 0.9fr 0.9fr auto auto; gap:0.5rem; align-items:end; margin-bottom:1rem;"
 >
   <label>
-    <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Name</div>
-    <input class="btn" style="width:100%; text-align:left;" name="name" placeholder="Crypto Core" required>
+    <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Pack template</div>
+    <select class="btn" style="width:100%; text-align:left;" name="pack_id">
+      <option value="">Custom (manual)</option>
+      {% for p in universe_packs %}
+      <option value="{{ p.id }}">{{ p.name }} · {{ p.mapping_summary.direct }}D/{{ p.mapping_summary.proxy }}P</option>
+      {% endfor %}
+    </select>
   </label>
+
+  <label>
+    <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Name</div>
+    <input class="btn" style="width:100%; text-align:left;" name="name" placeholder="Optional if pack selected">
+  </label>
+
   <label>
     <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Symbols (comma)</div>
-    <input class="btn" style="width:100%; text-align:left;" name="symbols" placeholder="BTC,ETH,SOL" required>
+    <input class="btn" style="width:100%; text-align:left;" name="symbols" placeholder="Optional if pack selected">
   </label>
+
   <label>
     <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Tags</div>
-    <input class="btn" style="width:100%; text-align:left;" name="tags" placeholder="core,liquid">
+    <input class="btn" style="width:100%; text-align:left;" name="tags" placeholder="meme,high-beta">
   </label>
+
   <label>
     <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Asset class</div>
-    <input class="btn" style="width:100%; text-align:left;" name="asset_class" value="crypto">
+    <input class="btn" style="width:100%; text-align:left;" name="asset_class" placeholder="optional override">
   </label>
+
   <label>
     <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Venue</div>
-    <input class="btn" style="width:100%; text-align:left;" name="venue" value="global">
+    <input class="btn" style="width:100%; text-align:left;" name="venue" placeholder="optional override">
   </label>
+
   <label style="display:flex; align-items:center; gap:0.35rem; padding-bottom:0.35rem;">
     <input type="checkbox" name="enabled" value="true" checked>
     <span class="text-dim" style="font-size:0.75rem;">Enabled</span>
@@ -66,6 +83,7 @@
         <th>Name</th>
         <th>Class</th>
         <th>Venue</th>
+        <th>Tags</th>
         <th>Symbols</th>
         <th>Status</th>
         <th>Source</th>
@@ -78,9 +96,20 @@
         <td>
           <div style="color:var(--text-bright);">{{ b.name }}</div>
           <div class="text-dim" style="font-size:0.65rem;">{{ b.id }}</div>
+          {% if universe_pack_map.get(b.id) %}
+          {% set meta = universe_pack_map.get(b.id) %}
+          <div class="text-dim" style="font-size:0.62rem;">{{ meta.mapping_summary.direct }} direct / {{ meta.mapping_summary.proxy }} proxy</div>
+          {% endif %}
         </td>
         <td>{{ b.asset_class }}</td>
         <td>{{ b.venue }}</td>
+        <td style="max-width:240px;">
+          <div style="display:flex; flex-wrap:wrap; gap:0.25rem;">
+            {% for t in b.tags %}
+            <span class="badge" style="font-size:0.62rem;">{{ t }}</span>
+            {% endfor %}
+          </div>
+        </td>
         <td style="max-width:240px;">
           <div style="display:flex; flex-wrap:wrap; gap:0.25rem;">
             {% for s in b.symbols %}

--- a/dashboard/templates/signals.html
+++ b/dashboard/templates/signals.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<form method="get" class="panel" style="margin-bottom:1rem; padding:0.75rem; display:grid; grid-template-columns:1fr 1fr 1fr auto auto; gap:0.5rem; align-items:end;">
+<form method="get" class="panel" style="margin-bottom:1rem; padding:0.75rem; display:grid; grid-template-columns:1fr 1fr 1fr 1fr auto auto; gap:0.5rem; align-items:end;">
   {% if active_domain %}
   <input type="hidden" name="domain" value="{{ active_domain }}">
   {% endif %}
@@ -45,6 +45,16 @@
       <option value="">All venues</option>
       {% for v in venue_options %}
       <option value="{{ v }}" {% if active_venue == v %}selected{% endif %}>{{ v }}</option>
+      {% endfor %}
+    </select>
+  </label>
+
+  <label>
+    <div class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">Tag</div>
+    <select class="btn" name="tag" style="width:100%; text-align:left; padding:6px 10px;">
+      <option value="">All tags</option>
+      {% for t in tag_options %}
+      <option value="{{ t }}" {% if active_tag == t %}selected{% endif %}>{{ t }}</option>
       {% endfor %}
     </select>
   </label>
@@ -144,7 +154,7 @@
 
   // Parse signal data from the rendered page (safe server-side JSON serialization)
   {% set signal_data = [] %}
-  {% for s in signals %}{% set _ = signal_data.append({'ts': s.ts_iso or s.ts, 'ts_hm': s.ts_hm, 'domain': s.domain, 'asset': s.asset, 'desc': s.desc, 'score': s.score|default(0), 'direction': s.direction}) %}{% endfor %}
+  {% for s in signals %}{% set _ = signal_data.append({'ts': s.ts_iso or s.ts, 'ts_hm': s.ts_hm, 'ts_label': s.ts_hm, 'domain': s.domain, 'asset': s.asset, 'desc': s.desc, 'score': s.score|default(0), 'direction': s.direction}) %}{% endfor %}
   var signals = {{ signal_data | tojson }};
 
   if (!signals.length) return;

--- a/docs/producers/symbol-packs.mdx
+++ b/docs/producers/symbol-packs.mdx
@@ -65,6 +65,21 @@ universe:
   symbols: ["DOGE", "SHIB", "PEPE", "WIF", "BONK"]
 ```
 
+### Runtime bundle packs (wizard/API)
+
+These packs are available in the setup wizard and `GET /api/v1/universe/packs`:
+
+- `tradfi-infra` — direct TradFi plumbing coverage for BTC/ETH/SOL
+- `hl-tradfi-perps` — Hyperliquid-perps style basket with TradFi factor overlays
+- `mixed-market` — blended direct + proxy basket
+
+#### Direct vs Proxy mappings
+
+- **Direct**: the symbol has first-order feed coverage in current producers (higher confidence).
+- **Proxy**: the symbol is mapped to an anchor symbol/factor basket (rates, dollar, vol, beta, liquidity) when direct coverage is weaker.
+
+Proxy mappings are practical scaffolding — they improve coverage without pretending to be a full factor model.
+
 ---
 
 ## Custom pack

--- a/engine/cli/commands/wizard.py
+++ b/engine/cli/commands/wizard.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from engine.core.bundle_packs import bundle_template_from_pack
 from engine.core.paths import b1e55ed_dir, logs_dir
 
 if TYPE_CHECKING:
@@ -288,12 +289,11 @@ _SYMBOL_PACKS: dict[str, dict] = {
     },
 }
 
-_TRADFI_INFRA_STARTER_SYMBOLS: list[str] = ["BTC", "ETH", "SOL"]
-
 _STARTER_BUNDLE_PACKS: dict[str, dict[str, str]] = {
     "1": {"id": "crypto-core", "name": "Crypto core (existing behavior)"},
-    "2": {"id": "tradfi-infra", "name": "TradFi infra starter"},
-    "3": {"id": "mixed", "name": "Mixed (crypto core + tradfi infra)"},
+    "2": {"id": "tradfi-infra", "name": "TradFi infra"},
+    "3": {"id": "hl-tradfi-perps", "name": "Hyperliquid TradFi-perps"},
+    "4": {"id": "mixed-market", "name": "Mixed market (direct + proxy)"},
 }
 
 
@@ -310,32 +310,29 @@ def _normalize_symbols(symbols: list[str]) -> list[str]:
 
 
 def _starter_bundles_for_choice(choice: str, crypto_symbols: list[str]) -> list[dict[str, object]]:
-    crypto_core = {
-        "id": "crypto-core",
-        "name": "Crypto Core",
-        "symbols": _normalize_symbols(crypto_symbols),
-        "tags": ["starter", "crypto"],
-        "asset_class": "crypto",
-        "venue": "global",
-        "enabled": True,
-        "source": "wizard",
-    }
-    tradfi_infra = {
-        "id": "tradfi-infra",
-        "name": "TradFi Infra Starter",
-        "symbols": _normalize_symbols(_TRADFI_INFRA_STARTER_SYMBOLS),
-        "tags": ["starter", "tradfi"],
-        "asset_class": "tradfi",
-        "venue": "binance",
-        "enabled": True,
-        "source": "wizard",
-    }
+    selected = _STARTER_BUNDLE_PACKS.get(choice, _STARTER_BUNDLE_PACKS["1"])
+    pack_id = str(selected.get("id") or "crypto-core")
 
-    if choice == "2":
-        return [tradfi_infra]
-    if choice == "3":
-        return [crypto_core, tradfi_infra]
-    return [crypto_core]
+    if pack_id == "crypto-core":
+        template = bundle_template_from_pack(
+            "crypto-core",
+            source="wizard",
+            enabled=True,
+            symbols=_normalize_symbols(crypto_symbols),
+        )
+        return [template] if isinstance(template, dict) else []
+
+    template = bundle_template_from_pack(pack_id, source="wizard", enabled=True)
+    if isinstance(template, dict):
+        return [template]
+
+    fallback = bundle_template_from_pack(
+        "crypto-core",
+        source="wizard",
+        enabled=True,
+        symbols=_normalize_symbols(crypto_symbols),
+    )
+    return [fallback] if isinstance(fallback, dict) else []
 
 
 def _active_symbols_from_bundles(default_symbols: list[str], bundles: list[dict[str, object]]) -> list[str]:

--- a/engine/core/bundle_packs.py
+++ b/engine/core/bundle_packs.py
@@ -1,0 +1,313 @@
+"""engine.core.bundle_packs
+
+Data-driven runtime universe bundle packs.
+
+A pack bundles symbols plus lightweight mapping metadata:
+- direct mapping: symbol has first-order coverage from the producer stack
+- proxy mapping: symbol is inferred from a mapped proxy symbol/factor basket
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+_ALLOWED_MAPPING_TYPES = {"direct", "proxy"}
+_ALLOWED_CONFIDENCE = {"high", "medium", "low"}
+_ALLOWED_SOURCES = {"wizard", "user", "system"}
+
+_BUNDLE_PACKS_RAW: dict[str, dict[str, Any]] = {
+    "crypto-core": {
+        "id": "crypto-core",
+        "name": "Crypto Core",
+        "description": "Default liquid crypto symbols with direct coverage.",
+        "symbols": ["BTC", "ETH", "SOL"],
+        "tags": ["starter", "crypto", "core"],
+        "asset_class": "crypto",
+        "venue": "global",
+        "mappings": {
+            "BTC": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "liquidity", "beta"],
+            },
+            "ETH": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "liquidity", "beta"],
+            },
+            "SOL": {
+                "mapping": "direct",
+                "confidence": "medium",
+                "factors": ["beta", "vol", "liquidity"],
+            },
+        },
+    },
+    "tradfi-infra": {
+        "id": "tradfi-infra",
+        "name": "TradFi Infra",
+        "description": "TradFi plumbing baseline (basis/funding/OI) using direct symbol coverage.",
+        "symbols": ["BTC", "ETH", "SOL"],
+        "tags": ["starter", "tradfi", "infra", "carry", "basis"],
+        "asset_class": "tradfi",
+        "venue": "binance",
+        "mappings": {
+            "BTC": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "liquidity", "beta"],
+                "note": "Quarterly basis + perp funding + OI available directly.",
+            },
+            "ETH": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "liquidity", "beta"],
+                "note": "Quarterly basis + perp funding + OI available directly.",
+            },
+            "SOL": {
+                "mapping": "direct",
+                "confidence": "medium",
+                "factors": ["beta", "vol", "liquidity"],
+                "note": "Perp funding/OI direct; basis proxy is weaker than BTC/ETH.",
+            },
+        },
+    },
+    "hl-tradfi-perps": {
+        "id": "hl-tradfi-perps",
+        "name": "Hyperliquid TradFi-Perps",
+        "description": "Hyperliquid-style perp basket with TradFi factor overlays.",
+        "symbols": ["HYPE", "SOL", "BTC", "ETH"],
+        "tags": ["starter", "hyperliquid", "tradfi", "perps"],
+        "asset_class": "crypto",
+        "venue": "hyperliquid",
+        "mappings": {
+            "HYPE": {
+                "mapping": "proxy",
+                "confidence": "medium",
+                "proxy_symbol": "SOL",
+                "factors": ["vol", "beta", "liquidity"],
+                "note": "Uses HL liquidation context + SOL/BTC macro proxies for rates/dollar sensitivity.",
+            },
+            "SOL": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["beta", "vol", "liquidity"],
+            },
+            "BTC": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "liquidity"],
+            },
+            "ETH": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "beta", "liquidity"],
+            },
+        },
+    },
+    "mixed-market": {
+        "id": "mixed-market",
+        "name": "Mixed Market",
+        "description": "Balanced cross-market starter: direct majors + proxy extensions.",
+        "symbols": ["BTC", "ETH", "SOL", "HYPE", "SUI"],
+        "tags": ["starter", "mixed", "cross-market"],
+        "asset_class": "mixed",
+        "venue": "global",
+        "mappings": {
+            "BTC": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "liquidity"],
+            },
+            "ETH": {
+                "mapping": "direct",
+                "confidence": "high",
+                "factors": ["rates", "dollar", "beta", "liquidity"],
+            },
+            "SOL": {
+                "mapping": "direct",
+                "confidence": "medium",
+                "factors": ["beta", "vol", "liquidity"],
+            },
+            "HYPE": {
+                "mapping": "proxy",
+                "confidence": "medium",
+                "proxy_symbol": "SOL",
+                "factors": ["vol", "beta", "liquidity"],
+            },
+            "SUI": {
+                "mapping": "proxy",
+                "confidence": "low",
+                "proxy_symbol": "SOL",
+                "factors": ["beta", "liquidity"],
+            },
+        },
+    },
+}
+
+
+def _normalize_symbols(values: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        sym = str(raw or "").strip().upper()
+        if not sym or sym in seen:
+            continue
+        seen.add(sym)
+        out.append(sym)
+    return out
+
+
+def _normalize_tags(values: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        tag = str(raw or "").strip().lower()
+        if not tag or tag in seen:
+            continue
+        seen.add(tag)
+        out.append(tag)
+    return out
+
+
+def _normalize_mapping(symbol: str, raw: dict[str, Any]) -> dict[str, Any]:
+    mapping = str(raw.get("mapping") or "direct").strip().lower()
+    if mapping not in _ALLOWED_MAPPING_TYPES:
+        mapping = "direct"
+
+    confidence = str(raw.get("confidence") or "medium").strip().lower()
+    if confidence not in _ALLOWED_CONFIDENCE:
+        confidence = "medium"
+
+    factors = _normalize_tags(raw.get("factors") if isinstance(raw.get("factors"), list) else [])
+
+    proxy_symbol = str(raw.get("proxy_symbol") or "").strip().upper() or None
+    note = str(raw.get("note") or "").strip() or None
+
+    normalized: dict[str, Any] = {
+        "symbol": symbol,
+        "mapping": mapping,
+        "confidence": confidence,
+        "factors": factors,
+    }
+    if proxy_symbol:
+        normalized["proxy_symbol"] = proxy_symbol
+    if note:
+        normalized["note"] = note
+    return normalized
+
+
+def _normalize_pack(raw_pack: dict[str, Any]) -> dict[str, Any]:
+    pack = deepcopy(raw_pack)
+
+    pack_id = str(pack.get("id") or "").strip().lower()
+    if not pack_id:
+        raise ValueError("Bundle pack id is required")
+
+    name = str(pack.get("name") or pack_id).strip() or pack_id
+    description = str(pack.get("description") or "").strip()
+
+    raw_mappings_obj = pack.get("mappings")
+    raw_mappings: dict[str, Any] = raw_mappings_obj if isinstance(raw_mappings_obj, dict) else {}
+
+    raw_symbols_obj = pack.get("symbols")
+    raw_symbols: list[str] = raw_symbols_obj if isinstance(raw_symbols_obj, list) else list(raw_mappings.keys())
+    symbols = _normalize_symbols(raw_symbols)
+
+    for key in raw_mappings:
+        sym = str(key or "").strip().upper()
+        if sym and sym not in symbols:
+            symbols.append(sym)
+
+    mappings: dict[str, dict[str, Any]] = {}
+    factor_tags: set[str] = set()
+    direct_count = 0
+    proxy_count = 0
+
+    for symbol in symbols:
+        raw_meta = raw_mappings.get(symbol, {})
+        raw_meta = raw_meta if isinstance(raw_meta, dict) else {}
+        meta = _normalize_mapping(symbol, raw_meta)
+        mappings[symbol] = meta
+        factor_tags.update(meta.get("factors") or [])
+        if meta.get("mapping") == "proxy":
+            proxy_count += 1
+        else:
+            direct_count += 1
+
+    raw_tags = pack.get("tags") if isinstance(pack.get("tags"), list) else []
+    tags = _normalize_tags([*raw_tags, *sorted(factor_tags), f"pack:{pack_id}"])
+
+    asset_class = str(pack.get("asset_class") or "crypto").strip().lower() or "crypto"
+    venue = str(pack.get("venue") or "global").strip().lower() or "global"
+
+    return {
+        "id": pack_id,
+        "name": name,
+        "description": description,
+        "symbols": symbols,
+        "tags": tags,
+        "asset_class": asset_class,
+        "venue": venue,
+        "factor_tags": sorted(factor_tags),
+        "mapping_summary": {"direct": direct_count, "proxy": proxy_count},
+        "mappings": mappings,
+    }
+
+
+def list_bundle_packs() -> list[dict[str, Any]]:
+    """Return normalized runtime bundle packs sorted by id."""
+    packs = [_normalize_pack(v) for v in _BUNDLE_PACKS_RAW.values()]
+    return sorted(packs, key=lambda p: str(p.get("id") or ""))
+
+
+def get_bundle_pack(pack_id: str) -> dict[str, Any] | None:
+    """Return a single normalized bundle pack by id."""
+    pid = str(pack_id or "").strip().lower()
+    if not pid:
+        return None
+    raw = _BUNDLE_PACKS_RAW.get(pid)
+    if raw is None:
+        return None
+    return _normalize_pack(raw)
+
+
+def bundle_template_from_pack(
+    pack_id: str,
+    *,
+    source: str = "system",
+    enabled: bool = True,
+    name: str | None = None,
+    symbols: list[str] | None = None,
+    tags: list[str] | None = None,
+    asset_class: str | None = None,
+    venue: str | None = None,
+) -> dict[str, Any] | None:
+    """Build a UniverseBundle-compatible template from a pack definition."""
+    pack = get_bundle_pack(pack_id)
+    if pack is None:
+        return None
+
+    final_symbols = _normalize_symbols(symbols if symbols else list(pack.get("symbols") or []))
+    base_tags = list(pack.get("tags") or [])
+    extra_tags = tags if isinstance(tags, list) else []
+    final_tags = _normalize_tags([*base_tags, *extra_tags])
+
+    source_value = str(source or "system").strip().lower()
+    if source_value not in _ALLOWED_SOURCES:
+        source_value = "system"
+
+    name_value = str(name or "").strip() or str(pack.get("name") or pack.get("id") or "Bundle")
+    asset_class_value = str(asset_class or "").strip().lower() or str(pack.get("asset_class") or "crypto")
+    venue_value = str(venue or "").strip().lower() or str(pack.get("venue") or "global")
+
+    return {
+        "id": str(pack.get("id")),
+        "name": name_value,
+        "symbols": final_symbols,
+        "tags": final_tags,
+        "asset_class": asset_class_value,
+        "venue": venue_value,
+        "enabled": bool(enabled),
+        "source": source_value,
+    }

--- a/tests/unit/test_api_universe.py
+++ b/tests/unit/test_api_universe.py
@@ -79,6 +79,8 @@ async def test_universe_bundle_crud_and_active_resolution(temp_dir: Path, test_c
         assert active_js["fallback_to_symbols"] is False
         assert active_js["asset_class_symbols"]["crypto"] == ["SOL", "BTC"]
         assert active_js["asset_class_symbols"]["tradfi"] == ["SPY"]
+        assert active_js["tags"] == ["core"]
+        assert active_js["tag_symbols"]["core"] == ["SOL", "BTC"]
 
         disable_crypto = await ac.patch(
             f"/api/v1/universe/bundles/{b1['id']}",
@@ -106,5 +108,55 @@ async def test_universe_bundle_crud_and_active_resolution(temp_dir: Path, test_c
     raw = yaml.safe_load(user_cfg.read_text(encoding="utf-8"))
     assert "universe" in raw
     assert "bundles" in raw["universe"]
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_universe_pack_catalog_and_pack_based_bundle_creation(temp_dir: Path, test_config, monkeypatch: pytest.MonkeyPatch):
+    home = temp_dir / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    cfg = test_config.model_copy(
+        update={
+            "api": test_config.api.model_copy(update={"auth_token": "secret"}),
+            "universe": test_config.universe.model_copy(update={"symbols": ["BTC", "ETH"], "bundles": []}),
+        }
+    )
+
+    db = Database(temp_dir / "brain-universe-packs.db")
+    app = create_app()
+    app.state.config = cfg
+    app.state.db = db
+
+    headers = {"Authorization": "Bearer secret"}
+    async with make_client(app) as ac:
+        packs = await ac.get("/api/v1/universe/packs", headers=headers)
+        assert packs.status_code == 200
+        packs_js = packs.json()
+        pack_ids = {item["id"] for item in packs_js["items"]}
+        assert {"tradfi-infra", "hl-tradfi-perps", "mixed-market"}.issubset(pack_ids)
+
+        create_from_pack = await ac.post(
+            "/api/v1/universe/bundles",
+            headers=headers,
+            json={
+                "pack_id": "hl-tradfi-perps",
+                "source": "system",
+            },
+        )
+        assert create_from_pack.status_code == 200, create_from_pack.text
+        bundle = create_from_pack.json()
+        assert bundle["id"] == "hl-tradfi-perps"
+        assert bundle["symbols"] == ["HYPE", "SOL", "BTC", "ETH"]
+        assert "pack:hl-tradfi-perps" in bundle["tags"]
+        assert "vol" in bundle["tags"]
+
+        active = await ac.get("/api/v1/universe/active", headers=headers)
+        assert active.status_code == 200
+        active_js = active.json()
+        assert active_js["symbols"] == ["HYPE", "SOL", "BTC", "ETH"]
+        assert "vol" in active_js["tags"]
+        assert active_js["tag_symbols"]["vol"] == ["HYPE", "SOL", "BTC", "ETH"]
 
     db.close()

--- a/tests/unit/test_bundle_packs.py
+++ b/tests/unit/test_bundle_packs.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from engine.core.bundle_packs import bundle_template_from_pack, get_bundle_pack, list_bundle_packs
+
+
+def test_required_tradfi_and_hl_pack_ids_present() -> None:
+    pack_ids = {p["id"] for p in list_bundle_packs()}
+    assert {"tradfi-infra", "hl-tradfi-perps", "mixed-market"}.issubset(pack_ids)
+
+
+def test_pack_symbol_sets_match_expected_initial_coverage() -> None:
+    tradfi = get_bundle_pack("tradfi-infra")
+    hl = get_bundle_pack("hl-tradfi-perps")
+    mixed = get_bundle_pack("mixed-market")
+
+    assert tradfi is not None
+    assert hl is not None
+    assert mixed is not None
+
+    assert tradfi["symbols"] == ["BTC", "ETH", "SOL"]
+    assert hl["symbols"] == ["HYPE", "SOL", "BTC", "ETH"]
+    assert mixed["symbols"] == ["BTC", "ETH", "SOL", "HYPE", "SUI"]
+
+
+def test_hl_pack_contains_proxy_mapping_metadata_and_factor_tags() -> None:
+    pack = get_bundle_pack("hl-tradfi-perps")
+    assert pack is not None
+
+    hype = pack["mappings"]["HYPE"]
+    assert hype["mapping"] == "proxy"
+    assert hype["confidence"] == "medium"
+    assert hype["proxy_symbol"] == "SOL"
+    assert {"vol", "beta", "liquidity"}.issubset(set(hype["factors"]))
+
+    assert pack["mapping_summary"]["proxy"] >= 1
+    assert {"rates", "dollar", "vol", "beta", "liquidity"}.issubset(set(pack["factor_tags"]))
+
+
+def test_bundle_template_from_pack_includes_pack_tag_and_defaults() -> None:
+    template = bundle_template_from_pack("tradfi-infra", source="wizard")
+    assert template is not None
+
+    assert template["id"] == "tradfi-infra"
+    assert template["asset_class"] == "tradfi"
+    assert template["venue"] == "binance"
+    assert "pack:tradfi-infra" in template["tags"]

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -24,6 +24,9 @@ class DummyApiClient:
     def get_signals(self, domain: str | None = None) -> _Res:
         return _Res({"items": [], "total": 0, "limit": 100, "offset": 0}, False)
 
+    def get_universe_packs(self) -> _Res:
+        return _Res({"items": [], "total": 0}, True)
+
     def get_universe_bundles(self) -> _Res:
         return _Res({"items": [], "total": 0}, True)
 
@@ -37,8 +40,10 @@ class DummyApiClient:
                 "enabled_bundle_ids": [],
                 "asset_classes": [],
                 "venues": [],
+                "tags": [],
                 "asset_class_symbols": {},
                 "venue_symbols": {},
+                "tag_symbols": {},
             },
             True,
         )
@@ -252,7 +257,7 @@ class UniverseDashboardApiClient(DummyApiClient):
                 "id": "crypto-core",
                 "name": "Crypto Core",
                 "symbols": ["BTC", "ETH"],
-                "tags": ["starter", "crypto"],
+                "tags": ["starter", "crypto", "beta"],
                 "asset_class": "crypto",
                 "venue": "global",
                 "enabled": True,
@@ -262,11 +267,28 @@ class UniverseDashboardApiClient(DummyApiClient):
                 "id": "tradfi-infra",
                 "name": "TradFi Infra",
                 "symbols": ["SPY"],
-                "tags": ["starter", "tradfi"],
+                "tags": ["starter", "tradfi", "rates"],
                 "asset_class": "tradfi",
                 "venue": "nyse",
                 "enabled": True,
                 "source": "wizard",
+            },
+        ]
+        self.packs = [
+            {
+                "id": "tradfi-infra",
+                "name": "TradFi Infra",
+                "mapping_summary": {"direct": 3, "proxy": 0},
+            },
+            {
+                "id": "hl-tradfi-perps",
+                "name": "Hyperliquid TradFi-Perps",
+                "mapping_summary": {"direct": 3, "proxy": 1},
+            },
+            {
+                "id": "mixed-market",
+                "name": "Mixed Market",
+                "mapping_summary": {"direct": 3, "proxy": 2},
             },
         ]
 
@@ -311,6 +333,25 @@ class UniverseDashboardApiClient(DummyApiClient):
                     out[key].append(s)
         return out
 
+    def _tag_map(self) -> dict[str, list[str]]:
+        out: dict[str, list[str]] = {}
+        for bundle in self.bundles:
+            if not bundle.get("enabled", True):
+                continue
+            symbols = [str(sym).upper() for sym in bundle.get("symbols", [])]
+            for tag in bundle.get("tags", []):
+                key = str(tag).strip().lower()
+                if not key:
+                    continue
+                out.setdefault(key, [])
+                for sym in symbols:
+                    if sym not in out[key]:
+                        out[key].append(sym)
+        return out
+
+    def get_universe_packs(self) -> _Res:
+        return _Res({"items": self.packs, "total": len(self.packs)}, True)
+
     def get_universe_bundles(self) -> _Res:
         return _Res({"items": self.bundles, "total": len(self.bundles)}, True)
 
@@ -324,8 +365,10 @@ class UniverseDashboardApiClient(DummyApiClient):
                 "enabled_bundle_ids": [str(b["id"]) for b in self.bundles if b.get("enabled", True)],
                 "asset_classes": sorted(self._asset_class_map().keys()),
                 "venues": sorted(self._venue_map().keys()),
+                "tags": sorted(self._tag_map().keys()),
                 "asset_class_symbols": self._asset_class_map(),
                 "venue_symbols": self._venue_map(),
+                "tag_symbols": self._tag_map(),
             },
             True,
         )
@@ -348,15 +391,39 @@ class UniverseDashboardApiClient(DummyApiClient):
         return _Res({"items": items, "total": len(items), "limit": 100, "offset": 0}, True)
 
     def create_universe_bundle(self, body: dict) -> _Res:
-        name = str(body.get("name") or "Bundle").strip()
-        slug = name.lower().replace(" ", "-")
+        pack_id = str(body.get("pack_id") or "").strip().lower()
+
+        if pack_id == "hl-tradfi-perps":
+            default_name = "Hyperliquid TradFi-Perps"
+            default_symbols = ["HYPE", "SOL", "BTC", "ETH"]
+            default_tags = ["starter", "hyperliquid", "tradfi", "vol", "pack:hl-tradfi-perps"]
+            default_asset_class = "crypto"
+            default_venue = "hyperliquid"
+        elif pack_id == "tradfi-infra":
+            default_name = "TradFi Infra"
+            default_symbols = ["BTC", "ETH", "SOL"]
+            default_tags = ["starter", "tradfi", "rates", "pack:tradfi-infra"]
+            default_asset_class = "tradfi"
+            default_venue = "binance"
+        else:
+            default_name = "Bundle"
+            default_symbols = []
+            default_tags = []
+            default_asset_class = "crypto"
+            default_venue = "global"
+
+        name = str(body.get("name") or default_name).strip() or default_name
+        symbols_raw = body.get("symbols") or default_symbols
+        tags_raw = body.get("tags") or default_tags
+
+        slug = pack_id or name.lower().replace(" ", "-")
         bundle = {
             "id": slug,
             "name": name,
-            "symbols": [str(s).upper() for s in body.get("symbols", [])],
-            "tags": [str(t) for t in body.get("tags", [])],
-            "asset_class": body.get("asset_class") or "crypto",
-            "venue": body.get("venue") or "global",
+            "symbols": [str(s).upper() for s in symbols_raw],
+            "tags": [str(t) for t in tags_raw],
+            "asset_class": body.get("asset_class") or default_asset_class,
+            "venue": body.get("venue") or default_venue,
             "enabled": bool(body.get("enabled", True)),
             "source": body.get("source") or "user",
         }
@@ -375,7 +442,7 @@ class UniverseDashboardApiClient(DummyApiClient):
         return _Res({"ok": True, "deleted": bundle_id}, True)
 
 
-def test_signals_page_filters_by_bundle_and_asset_class() -> None:
+def test_signals_page_filters_by_bundle_asset_class_and_tag() -> None:
     with TestClient(app) as client:
         client.app.state.api_client = UniverseDashboardApiClient()
 
@@ -389,10 +456,25 @@ def test_signals_page_filters_by_bundle_and_asset_class() -> None:
         assert "SPY basis" in by_asset_class.text
         assert "BTC momentum" not in by_asset_class.text
 
+        by_tag = client.get("/signals?tag=rates")
+        assert by_tag.status_code == 200
+        assert "SPY basis" in by_tag.text
+        assert "BTC momentum" not in by_tag.text
+
 
 def test_settings_universe_bundle_controls_use_live_routes() -> None:
     with TestClient(app) as client:
         client.app.state.api_client = UniverseDashboardApiClient()
+
+        add_pack_resp = client.post(
+            "/api/settings/universe/bundles",
+            data={
+                "pack_id": "hl-tradfi-perps",
+                "enabled": "true",
+            },
+        )
+        assert add_pack_resp.status_code == 200
+        assert "Added bundle: Hyperliquid TradFi-Perps" in add_pack_resp.text
 
         add_resp = client.post(
             "/api/settings/universe/bundles",

--- a/tests/unit/test_dashboard_routes.py
+++ b/tests/unit/test_dashboard_routes.py
@@ -24,6 +24,9 @@ class DummyApiClient:
     def get_signals(self, domain: str | None = None) -> _Res:
         return _Res({"items": [], "total": 0, "limit": 100, "offset": 0}, False)
 
+    def get_universe_packs(self) -> _Res:
+        return _Res({"items": [], "total": 0}, True)
+
     def get_universe_bundles(self) -> _Res:
         return _Res({"items": [], "total": 0}, True)
 
@@ -37,8 +40,10 @@ class DummyApiClient:
                 "enabled_bundle_ids": [],
                 "asset_classes": [],
                 "venues": [],
+                "tags": [],
                 "asset_class_symbols": {},
                 "venue_symbols": {},
+                "tag_symbols": {},
             },
             True,
         )

--- a/tests/unit/test_wizard_bundles.py
+++ b/tests/unit/test_wizard_bundles.py
@@ -12,19 +12,24 @@ def test_starter_bundle_pack_selection() -> None:
     assert [b["id"] for b in tradfi_only] == ["tradfi-infra"]
     assert tradfi_only[0]["asset_class"] == "tradfi"
 
-    mixed = wizard._starter_bundles_for_choice("3", ["BTC", "ETH", "SOL"])
-    assert [b["id"] for b in mixed] == ["crypto-core", "tradfi-infra"]
+    hl_pack = wizard._starter_bundles_for_choice("3", ["BTC", "ETH", "SOL"])
+    assert [b["id"] for b in hl_pack] == ["hl-tradfi-perps"]
+    assert hl_pack[0]["venue"] == "hyperliquid"
+
+    mixed_pack = wizard._starter_bundles_for_choice("4", ["BTC", "ETH", "SOL"])
+    assert [b["id"] for b in mixed_pack] == ["mixed-market"]
+    assert "SUI" in mixed_pack[0]["symbols"]
 
 
 def test_active_symbols_resolve_from_enabled_bundles_with_fallback() -> None:
     base = ["BTC", "ETH"]
-    mixed = wizard._starter_bundles_for_choice("3", base)
-    active = wizard._active_symbols_from_bundles(base, mixed)
-    assert active == ["BTC", "ETH", "SOL"]
+    hl = wizard._starter_bundles_for_choice("3", base)
+    active = wizard._active_symbols_from_bundles(base, hl)
+    assert active == ["HYPE", "SOL", "BTC", "ETH"]
 
-    for bundle in mixed:
+    for bundle in hl:
         bundle["enabled"] = False
-    fallback = wizard._active_symbols_from_bundles(base, mixed)
+    fallback = wizard._active_symbols_from_bundles(base, hl)
     assert fallback == ["BTC", "ETH"]
 
 
@@ -32,8 +37,7 @@ def test_bundles_yaml_block_renders_expected_shape() -> None:
     bundles = wizard._starter_bundles_for_choice("3", ["BTC", "ETH", "SOL"])
     yaml_block = wizard._bundles_yaml_block(bundles)
 
-    assert 'id: "crypto-core"' in yaml_block
-    assert 'id: "tradfi-infra"' in yaml_block
+    assert 'id: "hl-tradfi-perps"' in yaml_block
     assert 'asset_class: "crypto"' in yaml_block
-    assert 'asset_class: "tradfi"' in yaml_block
+    assert 'venue: "hyperliquid"' in yaml_block
     assert 'source: "wizard"' in yaml_block


### PR DESCRIPTION
## Summary

Adds data-driven universe bundle packs for TradFi and Hyperliquid workflows, wires pack selection into API + wizard + dashboard, and introduces direct-vs-proxy mapping metadata so operators can see how symbols are represented.

Closes #<!-- issue number -->

---

## Type of change

<!-- Check all that apply -->

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no behaviour change
- [ ] `test` — tests only
- [ ] `chore` — tooling, deps, config

---

## Labels

> **Required before requesting review.** Apply via the Labels panel on the right.

| Label | When to apply |
|-------|---------------|
| `feat` | New capability |
| `fix` | Bug fix |
| `docs` | Docs-only change |
| `producer` | Touches `engine/producers/` |
| `brain` | Touches `engine/brain/` |
| `flywheel` | Touches attribution, stratification, or paper trading |
| `mcp` | Touches MCP layer |
| `events` | Events domain producer |
| `backlog` | Not yet scheduled for a sprint |
| `roadmap` | Part of phased producer roadmap |

- [x] Labels applied ✅

---

## Changes

- Added `engine/core/bundle_packs.py` with runtime pack definitions and helpers:
  - packs: `crypto-core`, `tradfi-infra`, `hl-tradfi-perps`, `mixed-market`
  - per-symbol mapping metadata (`mapping`, `confidence`, `factors`, optional `proxy_symbol`)
  - helper APIs: `list_bundle_packs()`, `get_bundle_pack()`, `bundle_template_from_pack()`
- Universe API updates in `api/routes/universe.py`:
  - new `GET /universe/packs`
  - bundle create supports `pack_id`
  - active universe payload now includes `tags` and `tag_symbols`
- Wizard updates in `engine/cli/commands/wizard.py`:
  - pack-driven starter bundle choices (TradFi infra, HL tradfi-perps, mixed market)
- Dashboard updates:
  - pack selector + explanatory direct/proxy UX
  - signals tag filtering support in backend + templates
- Docs update:
  - `docs/producers/symbol-packs.mdx` now documents runtime packs and direct-vs-proxy semantics

---

## Tests

- [x] New tests added (or explain why not needed)
- [ ] All existing tests pass: `.venv/bin/python -m pytest --tb=short -q`
- [x] Test count: targeted suite passed

Targeted validation run:
- `.venv/bin/pytest -q tests/unit/test_bundle_packs.py tests/unit/test_api_universe.py tests/unit/test_wizard_bundles.py tests/unit/test_dashboard.py tests/unit/test_dashboard_routes.py`
- Result: `33 passed`

---

## Checklist

- [x] Branch targets the correct base (`develop` for features; `feat/mcp` for MCP-dependent work)
- [ ] `docs/dependencies-docs.md` updated if new file dependencies introduced
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified** (parallel emission only)
