### PR TITLE
fix(api): correct OMS injection in brain scheduler — add preflight and sizer

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -158,9 +158,23 @@ def create_app() -> FastAPI:
                 # Inject OMS for auto-paper-trade if execution mode is paper
                 try:
                     if getattr(_cfg.execution, "mode", "paper") == "paper":
-                        from engine.execution.oms import OMS
+                        from engine.brain.kill_switch import KillSwitch
+                        from engine.execution.oms import OMS, default_sizer_from_config
+                        from engine.execution.preflight import Preflight, default_policy_from_risk
 
-                        orchestrator._oms = OMS(config=_cfg, db=_db)
+                        _policy = default_policy_from_risk(
+                            max_daily_loss_usd=float(_cfg.risk.daily_loss_limit_pct) * float(_cfg.risk.portfolio_value_usd),
+                            max_position_size_pct=float(_cfg.risk.max_position_pct),
+                            max_leverage_default=float(_cfg.risk.max_leverage),
+                        )
+                        _preflight = Preflight(policy=_policy, kill_switch=KillSwitch(config=_cfg, db=_db))
+                        orchestrator._oms = OMS(
+                            config=_cfg,
+                            db=_db,
+                            preflight=_preflight,
+                            sizer=default_sizer_from_config(_cfg),
+                            policy=_policy,
+                        )
                 except Exception:
                     _log.debug("OMS injection skipped", exc_info=True)
 


### PR DESCRIPTION
## Summary

The API brain scheduler was calling `OMS(config, db)` but the OMS constructor requires `preflight` and `sizer` kwargs. The exception was caught silently, causing "no OMS injected" logs and zero trades from the scheduled cycles.

## Type of change
- [x] `fix` — bug fix

## Root cause
`api/main.py:163` — `OMS(config=_cfg, db=_db)` missing required kwargs. The CLI path (`engine/cli/main.py:877`) passes all args correctly. This patch makes the API path match the CLI path exactly.

## Fix
Constructs OMS with full `preflight` (Preflight + default_policy_from_risk) and `sizer` (default_sizer_from_config), identical to the working CLI path.