### PR TITLE
fix(dashboard): performance trade history, closed position UX, PnL colors

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -404,7 +404,9 @@ def _map_positions(raw: Any) -> list[dict[str, Any]]:
 
         if status.lower() == "closed":
             pnl_usd = float(p.get("realized_pnl") or 0.0)
-            pnl_pct = float(p.get("pnl_pct") or 0.0)
+            # Compute pct from realized_pnl / notional (positions table has no pnl_pct col)
+            _notional = abs(float(p.get("size_notional") or 0.0))
+            pnl_pct = (pnl_usd / _notional * 100.0) if _notional > 0 else 0.0
         else:
             if direction in {"short", "sell"}:
                 pnl_pct = ((entry - current) / entry * 100.0) if entry > 0 else 0.0
@@ -1069,7 +1071,8 @@ def brain_overview(request: Request) -> HTMLResponse:
     regime_ctx = _regime_banner_context(regime_res.data, stale=not regime_res.ok)
 
     pos_res = client.get_positions()
-    positions = _annotate_positions_with_convictions(_map_positions(pos_res.data), client)
+    _all_pos = _annotate_positions_with_convictions(_map_positions(pos_res.data), client)
+    positions = [p for p in _all_pos if str(p.get("status") or "").lower() != "closed"]
     positions_age = "—" if pos_res.ok else "stale"
 
     sig_res = client.get_signals(domain=None)

--- a/dashboard/templates/partials/position_detail_panel.html
+++ b/dashboard/templates/partials/position_detail_panel.html
@@ -75,8 +75,10 @@
   {% endif %}
 </div>
 
+{% if p.status != 'closed' %}
 <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
   <button class="btn" hx-post="/api/positions/{{ p.id }}/adjust-stop" hx-confirm="Adjust stop loss?">Adjust Stop</button>
   <button class="btn" hx-post="/api/positions/{{ p.id }}/adjust-target" hx-confirm="Adjust target?">Adjust Target</button>
   <button class="btn btn-danger" hx-post="/api/positions/{{ p.id }}/close" hx-confirm="Close position {{ p.id }}?">Close Position</button>
 </div>
+{% endif %}


### PR DESCRIPTION
## Summary

Three dashboard fixes post #389.

## Type of change
- [x] `fix` — bug fix

## Changes

### Performance page trade history
Was hardcoded to `total_trades: 0`. Now reads real data from `positions` (closed) and `orders` (filled). Shows win rate, avg PnL, total PnL, equity curve, trade log.

### Closed position UX
- Brain page initial render now filters out closed positions (partial refresh already did this but SSR did not)
- Action buttons (Adjust Stop, Adjust Target, Close Position) hidden on closed position cards
- Closed position PnL color now correct — was always green because `pnl_pct` column does not exist; now computed from `realized_pnl / size_notional`

### Template type fix
`win_rate` was formatted as a string (`"50.0%"`) causing `TypeError: > not supported between str and int` in template comparison. Now passed as raw float.