### PR TITLE
fix(brain+dashboard): stale conviction scores + TradFi config hot-reload

### DIFF
--- a/api/routes/brain.py
+++ b/api/routes/brain.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from api.auth import AuthDep
 from api.deps import get_config, get_db, get_kill_switch
@@ -213,20 +213,49 @@ def trigger_cycle(
 
 
 @router.get("/convictions")
-def get_convictions(db: Database = Depends(get_db), limit: int = 20) -> list[dict]:
-    """Latest conviction scores, one per asset (most recent)."""
-    rows = db.execute(
-        """
-        SELECT symbol, direction, confidence, magnitude, timeframe, regime, pcs_score, cts_score, ts
-        FROM conviction_scores
-        WHERE (symbol, ts) IN (
-            SELECT symbol, MAX(ts) FROM conviction_scores GROUP BY symbol
-        )
-        ORDER BY confidence DESC, magnitude DESC
-        LIMIT ?
-        """,
-        (limit,),
-    ).fetchall()
+def get_convictions(request: Request, db: Database = Depends(get_db), limit: int = 20) -> list[dict]:
+    """Latest conviction scores for active universe symbols (max 48h old)."""
+    # Only return symbols in the active universe — prevents stale wizard symbols polluting the view
+    active: list[str] = []
+    try:
+        cfg = getattr(getattr(request, "app", None), "state", None)
+        if cfg:
+            cfg = getattr(cfg, "config", None)
+        if cfg:
+            active = [s.upper() for s in cfg.universe.active_symbols()]
+    except Exception:
+        pass
+
+    if active:
+        placeholders = ",".join("?" * len(active))
+        rows = db.execute(
+            f"""
+            SELECT symbol, direction, confidence, magnitude, timeframe, regime, pcs_score, cts_score, ts
+            FROM conviction_scores
+            WHERE symbol IN ({placeholders})
+              AND (symbol, ts) IN (
+                SELECT symbol, MAX(ts) FROM conviction_scores GROUP BY symbol
+              )
+              AND ts >= datetime('now', '-48 hours')
+            ORDER BY confidence DESC, magnitude DESC
+            LIMIT ?
+            """,
+            (*active, limit),
+        ).fetchall()
+    else:
+        rows = db.execute(
+            """
+            SELECT symbol, direction, confidence, magnitude, timeframe, regime, pcs_score, cts_score, ts
+            FROM conviction_scores
+            WHERE (symbol, ts) IN (
+                SELECT symbol, MAX(ts) FROM conviction_scores GROUP BY symbol
+            )
+              AND ts >= datetime('now', '-48 hours')
+            ORDER BY confidence DESC, magnitude DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
     result = []
     for r in rows:
         result.append(

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1894,21 +1894,41 @@ def system_page_redirect(request: Request) -> HTMLResponse:
 
 @app.post("/api/settings/universe/tradfi", response_class=HTMLResponse)
 def settings_tradfi_symbols(request: Request, symbols: str = Form("")) -> HTMLResponse:
-    """Save TradFi symbols list to user config."""
+    """Save TradFi symbols list to user config via API (triggers hot-reload)."""
     sym_list = [s.strip().upper() for s in symbols.split(",") if s.strip()]
     try:
-        import yaml as _yaml
+        client = _api(request)
+        # Fetch current config, merge tradfi_symbols, POST back via API so daemon hot-reloads
+        cfg_res = client._get_json("/config")
+        cfg_data: dict[str, Any] = {}
+        if cfg_res.ok and isinstance(cfg_res.data, dict):
+            # Strip redacted sentinel values so we don't overwrite real secrets with "***REDACTED***"
+            import copy as _copy
 
-        cfg_path = Path(os.environ.get("B1E55ED_CONFIG_PATH", os.path.expanduser("~/.b1e55ed/config/user.yaml")))
-        if cfg_path.exists():
-            with open(cfg_path) as f:
-                cfg_data = _yaml.safe_load(f) or {}
-        else:
-            cfg_data = {}
+            cfg_data = _copy.deepcopy(cfg_res.data)
+            for _section in cfg_data.values():
+                if not isinstance(_section, dict):
+                    continue
+                for _k, _v in list(_section.items()):
+                    if isinstance(_v, str) and _v == "***REDACTED***":
+                        del _section[_k]
         cfg_data.setdefault("universe", {})["tradfi_symbols"] = sym_list
-        with open(cfg_path, "w") as f:
-            _yaml.dump(cfg_data, f, default_flow_style=False)
-        status_ok, status_msg = True, f"Saved {len(sym_list)} TradFi symbols"
+        save_res = client._post_json("/config", cfg_data)
+        if save_res.ok:
+            status_ok, status_msg = True, f"Saved {len(sym_list)} TradFi symbols"
+        else:
+            # Fallback: write yaml directly if API unavailable
+            import yaml as _yaml
+
+            cfg_path = Path(os.environ.get("B1E55ED_CONFIG_PATH", os.path.expanduser("~/.b1e55ed/config/user.yaml")))
+            raw: dict[str, Any] = {}
+            if cfg_path.exists():
+                with open(cfg_path) as f:
+                    raw = _yaml.safe_load(f) or {}
+            raw.setdefault("universe", {})["tradfi_symbols"] = sym_list
+            with open(cfg_path, "w") as f:
+                _yaml.dump(raw, f, default_flow_style=False)
+            status_ok, status_msg = True, f"Saved {len(sym_list)} TradFi symbols (yaml fallback)"
     except Exception as e:
         status_ok, status_msg = False, str(e)
 


### PR DESCRIPTION
## What

### Bug 1: 50 stale tickers from wizard install
GET /convictions had no time filter and no universe filter. Symbols from the initial wizard run (50 tickers) stayed in the DB forever and showed as stale in the brain view.

**Fix**: Filter to active universe symbols only + 48h recency window. The brain view now shows only what the engine is actually scoring today.

### Bug 2: TradFi symbols don't take effect
Settings panel wrote tradfi_symbols directly to yaml, bypassing the API. The running daemon never saw the change — it still processed only the original base symbols.

**Fix**: Save via POST /config API which calls request.app.state.config = cfg — hot-reloads the config in the running process. Falls back to direct yaml write if API unreachable.

## Type of change
- [x] Bug fix

## Tests
- Existing conviction tests pass
- Mypy/ruff clean on changed files