### PR TITLE
fix(wave2): business logic — shorts, attribution, position sizing

### DIFF
--- a/api/routes/cockpit.py
+++ b/api/routes/cockpit.py
@@ -166,4 +166,5 @@ def cockpit_state(db: Database = Depends(get_db)) -> dict[str, Any]:
         "producer_signals": producer_signals,
         "benchmarks": benchmarks,
         "system": system,
+        "conviction": top_call.get("pcs_score") if top_call else None,
     }

--- a/api/routes/positions.py
+++ b/api/routes/positions.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, Path, Query
+from pydantic import BaseModel
 
 from api.auth import AuthDep
-from api.deps import get_db
+from api.deps import get_config, get_db
 from api.errors import B1e55edError
 from api.schemas.positions import PositionResponse
+from engine.core.config import Config
 from engine.core.database import Database
 
 router = APIRouter(prefix="/positions", dependencies=[AuthDep])
@@ -47,6 +49,20 @@ def _row_to_position(r) -> PositionResponse:
     )
 
 
+def _fetch_row(db: Database, position_id: str):
+    return db.execute(
+        """
+        SELECT id, platform, asset, direction, entry_price, size_notional, leverage, margin_type,
+               stop_loss, take_profit, opened_at, closed_at, status, realized_pnl, conviction_id,
+               regime_at_entry, pcs_at_entry, cts_at_entry
+        FROM positions
+        WHERE id = ?
+        LIMIT 1
+        """,
+        (position_id,),
+    ).fetchone()
+
+
 @router.get("", response_model=list[PositionResponse])
 def list_positions(
     db: Database = Depends(get_db),
@@ -72,19 +88,129 @@ def get_position(
     position_id: str = Path(..., description="Position id"),
     db: Database = Depends(get_db),
 ) -> PositionResponse:
-    r = db.execute(
-        """
-        SELECT id, platform, asset, direction, entry_price, size_notional, leverage, margin_type,
-               stop_loss, take_profit, opened_at, closed_at, status, realized_pnl, conviction_id,
-               regime_at_entry, pcs_at_entry, cts_at_entry
-        FROM positions
-        WHERE id = ?
-        LIMIT 1
-        """,
-        (position_id,),
-    ).fetchone()
+    r = _fetch_row(db, position_id)
 
     if r is None:
         raise B1e55edError(code="not_found", message="Position not found", status=404)
 
     return _row_to_position(r)
+
+
+# ---- Mutation body schemas ------------------------------------------------
+
+
+class ClosePositionBody(BaseModel):
+    exit_price: float | None = None
+    reason: str = "dashboard"
+
+
+class AdjustStopBody(BaseModel):
+    stop_loss: float
+
+
+class AdjustTargetBody(BaseModel):
+    take_profit: float
+
+
+# ---- Mutation endpoints ---------------------------------------------------
+
+
+@router.post("/{position_id}/close", response_model=PositionResponse)
+def close_position(
+    position_id: str = Path(..., description="Position id"),
+    body: ClosePositionBody = ClosePositionBody(),
+    db: Database = Depends(get_db),
+    config: Config = Depends(get_config),
+) -> PositionResponse:
+    """Close an open position, realising P&L."""
+    r = _fetch_row(db, position_id)
+    if r is None:
+        raise B1e55edError(code="not_found", message="Position not found", status=404)
+
+    status = str(r[12])
+    if status != "open":
+        raise B1e55edError(
+            code="position_not_open",
+            message=f"Position is already {status}",
+            status=409,
+        )
+
+    # Resolve exit price: use provided value or fall back to entry price (flat close).
+    exit_price = body.exit_price if body.exit_price is not None else float(r[4])
+
+    from engine.execution.pnl import PnLTracker
+
+    tracker = PnLTracker(db=db, config=config)
+    try:
+        tracker.close_position(
+            position_id=position_id,
+            exit_price=exit_price,
+            reason=body.reason,
+        )
+    except ValueError as exc:
+        raise B1e55edError(code="close_failed", message=str(exc), status=422) from exc
+
+    updated = _fetch_row(db, position_id)
+    if updated is None:  # pragma: no cover
+        raise B1e55edError(code="not_found", message="Position not found after close", status=404)
+    return _row_to_position(updated)
+
+
+@router.patch("/{position_id}/stop", response_model=PositionResponse)
+def adjust_stop(
+    position_id: str = Path(..., description="Position id"),
+    body: AdjustStopBody = ...,
+    db: Database = Depends(get_db),
+) -> PositionResponse:
+    """Update stop_loss on an open position."""
+    r = _fetch_row(db, position_id)
+    if r is None:
+        raise B1e55edError(code="not_found", message="Position not found", status=404)
+
+    if str(r[12]) != "open":
+        raise B1e55edError(
+            code="position_not_open",
+            message="Can only adjust stop on open positions",
+            status=409,
+        )
+
+    db.execute(
+        "UPDATE positions SET stop_loss = ? WHERE id = ? AND status = 'open'",
+        (body.stop_loss, position_id),
+    )
+    db.conn.commit()
+
+    updated = _fetch_row(db, position_id)
+    if updated is None:  # pragma: no cover
+        raise B1e55edError(code="not_found", message="Position not found after update", status=404)
+    return _row_to_position(updated)
+
+
+@router.patch("/{position_id}/target", response_model=PositionResponse)
+def adjust_target(
+    position_id: str = Path(..., description="Position id"),
+    body: AdjustTargetBody = ...,
+    db: Database = Depends(get_db),
+) -> PositionResponse:
+    """Update take_profit on an open position."""
+    r = _fetch_row(db, position_id)
+    if r is None:
+        raise B1e55edError(code="not_found", message="Position not found", status=404)
+
+    if str(r[12]) != "open":
+        raise B1e55edError(
+            code="position_not_open",
+            message="Can only adjust target on open positions",
+            status=409,
+        )
+
+    db.execute(
+        "UPDATE positions SET take_profit = ? WHERE id = ? AND status = 'open'",
+        (body.take_profit, position_id),
+    )
+    db.conn.commit()
+
+    updated = _fetch_row(db, position_id)
+    if updated is None:  # pragma: no cover
+        raise B1e55edError(code="not_found", message="Position not found after update", status=404)
+    return _row_to_position(updated)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2375,12 +2375,35 @@ async def run_producer_now(name: str, request: Request) -> HTMLResponse:
     return HTMLResponse('<span class="text-bear">✗ Failed</span>')
 
 
+@app.post("/api/positions/{position_id}/close", response_class=HTMLResponse)
+async def close_position_proxy(position_id: str, request: Request) -> HTMLResponse:
+    """Proxy close-position to the API and return an HTMX status fragment."""
+    form = await request.form()
+    exit_price_raw = form.get("exit_price")
+    body: dict = {"reason": "dashboard"}
+    if exit_price_raw:
+        with contextlib.suppress(ValueError, TypeError):
+            body["exit_price"] = float(exit_price_raw)
+    client = _api(request)
+    result = client._post_json(f"/positions/{position_id}/close", body)
+    if result.ok:
+        pnl = ""
+        if isinstance(result.data, dict):
+            pnl_val = result.data.get("realized_pnl")
+            if pnl_val is not None:
+                with contextlib.suppress(TypeError, ValueError):
+                    sign = "+" if float(pnl_val) >= 0 else ""
+                    pnl = f" (PnL: {sign}${float(pnl_val):.2f})"
+        return HTMLResponse(f'<span class="text-bull">✓ Position closed{pnl}</span>')
+    return HTMLResponse('<span class="text-bear">✗ Failed to close position</span>')
+
+
 @app.post("/api/positions/{position_id}/adjust-stop", response_class=HTMLResponse)
 async def adjust_stop(position_id: str, request: Request) -> HTMLResponse:
     form = await request.form()
     price = float(form.get("price", 0))
     client = _api(request)
-    result = client._post_json(f"/positions/{position_id}/stop", {"price": price})
+    result = client._patch_json(f"/positions/{position_id}/stop", {"stop_loss": price})
     if result.ok:
         return HTMLResponse(f'<span class="text-bull">Stop set to ${price:.2f}</span>')
     return HTMLResponse('<span class="text-bear">Failed to set stop</span>')
@@ -2391,10 +2414,81 @@ async def adjust_target(position_id: str, request: Request) -> HTMLResponse:
     form = await request.form()
     price = float(form.get("price", 0))
     client = _api(request)
-    result = client._post_json(f"/positions/{position_id}/target", {"price": price})
+    result = client._patch_json(f"/positions/{position_id}/target", {"take_profit": price})
     if result.ok:
         return HTMLResponse(f'<span class="text-bull">Target set to ${price:.2f}</span>')
     return HTMLResponse('<span class="text-bear">Failed to set target</span>')
+
+
+# ---- Karma settle proxy (3.5) --------------------------------------------
+
+
+@app.post("/api/karma/settle", response_class=HTMLResponse)
+async def karma_settle(request: Request) -> HTMLResponse:
+    """Proxy karma settle to the API and return an HTMX fragment."""
+    client = _api(request)
+    result = client._post_json("/karma/settle", {})
+    if result.ok:
+        settled = ""
+        if isinstance(result.data, dict):
+            n = result.data.get("settled") or result.data.get("count")
+            if n is not None:
+                settled = f" ({n} settled)"
+        return HTMLResponse(f'<span class="text-bull">✓ Karma settled{settled}</span>')
+    return HTMLResponse('<span class="text-warn">⚠ Karma settle failed — check API availability.</span>')
+
+
+# ---- Events verify-chain (3.6) -------------------------------------------
+
+
+@app.post("/api/events/verify-chain", response_class=HTMLResponse)
+async def events_verify_chain(request: Request) -> HTMLResponse:
+    """Verify the brain.db event hash chain and return an HTMX fragment."""
+    db_path = _get_brain_db()
+    if not db_path:
+        return HTMLResponse('<span class="text-warn">⚠ brain.db not found</span>')
+    try:
+        from engine.core.database import Database as _Database
+
+        db = _Database(db_path)
+        # Count events for context
+        row = db.conn.execute("SELECT COUNT(*) FROM events").fetchone()
+        event_count = int(row[0]) if row else 0
+        valid = db.verify_hash_chain(fast=True)
+        db.close()
+        if valid:
+            return HTMLResponse(f'<span class="text-bull">✓ Chain valid — {event_count:,} events checked</span>')
+        return HTMLResponse(f'<span class="text-bear">✗ Chain INVALID — {event_count:,} events checked. Possible tampering.</span>')
+    except Exception as exc:
+        return HTMLResponse(f'<span class="text-warn">⚠ Verify failed: {exc}</span>')
+
+
+# ---- Events export (3.7) -------------------------------------------------
+
+
+@app.get("/api/events/export")
+async def events_export(request: Request) -> Response:
+    """Export up to 10,000 recent events from brain.db as a JSON attachment."""
+    import json as _json
+
+    db_path = _get_brain_db()
+    if not db_path:
+        return HTMLResponse('<span class="text-warn">brain.db not found</span>', status_code=404)
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT id, type, payload, ts, source, trace_id, schema_version FROM events ORDER BY id DESC LIMIT 10000").fetchall()
+        conn.close()
+        # Reverse so oldest-first order in the export
+        events = [dict(r) for r in reversed(rows)]
+        body = _json.dumps({"count": len(events), "events": events}, default=str)
+        return Response(
+            content=body,
+            media_type="application/json",
+            headers={"Content-Disposition": 'attachment; filename="events.json"'},
+        )
+    except Exception as exc:
+        return HTMLResponse(f'<span class="text-warn">Export failed: {exc}</span>', status_code=500)
 
 
 @app.get("/config", response_class=HTMLResponse)

--- a/engine/brain/decision.py
+++ b/engine/brain/decision.py
@@ -56,16 +56,23 @@ class DefaultDecisionPolicy:
         # Direction from PCS around 50.
         direction = "long" if ctx.pcs >= 55.0 else "short" if ctx.pcs <= 45.0 else "long"
 
-        # Sizing tiers.
-        if ctx.pcs >= 90.0:
+        # Sizing tiers — use effective conviction so shorts are reachable.
+        # For short trades, invert PCS: PCS=10 (strong short) → effective=90.
+        # For long trades, use PCS directly: PCS=90 (strong long) → effective=90.
+        if direction == "short":
+            effective_pcs = 100.0 - ctx.pcs
+        else:
+            effective_pcs = ctx.pcs
+
+        if effective_pcs >= 90.0:
             size_pct = 0.10
             leverage = min(2.0, self.config.risk.max_leverage)
             rationale = "approval_required: high conviction over consensus"
-        elif ctx.pcs >= 75.0:
+        elif effective_pcs >= 75.0:
             size_pct = 0.05
             leverage = min(2.0, self.config.risk.max_leverage)
             rationale = "enter: strong conviction"
-        elif ctx.pcs >= 60.0:
+        elif effective_pcs >= 60.0:
             size_pct = 0.02
             leverage = 1.0
             rationale = "enter: moderate conviction"

--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -447,10 +447,15 @@ class BrainOrchestrator:
 
             # Emit immutable audit event for accepted signals so acceptance
             # decisions are part of the hash-chained event log.
+            # NOTE: SIGNAL_ACCEPTED_V1 requires {trade_id, producer_id, domain, signal_event_id,
+            # direction, confidence} — those are only available after a trade is submitted.
+            # At synthesis time we emit AUDIT_V1 to preserve the bulk-acceptance record.
+            # The canonical SIGNAL_ACCEPTED_V1 events (one per signal) are emitted by OMS._emit_signal_accepted().
             if snap.source_event_ids:
                 self.db.append_event(
-                    event_type=EventType.SIGNAL_ACCEPTED_V1,
+                    event_type=EventType.AUDIT_V1,
                     payload={
+                        "reason": "signals_ingested_for_cycle",
                         "cycle_id": cycle_id,
                         "event_ids": list(snap.source_event_ids),
                         "symbol": sym,
@@ -584,7 +589,7 @@ class BrainOrchestrator:
                         if self._oms is None:
                             _log.warning("auto-paper-trade skipped: no OMS injected")
                             continue
-                        oms_result = self._oms.submit(ti, mid_price=mid_price, equity_usd=10000.0)
+                        oms_result = self._oms.submit(ti, mid_price=mid_price, equity_usd=float(self.config.risk.portfolio_value_usd))
                         _log.info("auto-paper-trade: %s %s @ %.2f -> %s", sym, direction, mid_price, oms_result.status)
                     except Exception:
                         _log.exception("auto-paper-trade failed for %s -- brain cycle continues", sym)
@@ -612,6 +617,29 @@ class BrainOrchestrator:
                     _mark = self._resolve_mid_price(_asset)
                     if _mark is None:
                         continue
+
+                    # Track max_drawdown_during: update each cycle before checking stop/target.
+                    try:
+                        _dd_row = self.db.fetchone(
+                            "SELECT entry_price, max_drawdown_during FROM positions WHERE id = ? AND status = 'open'",
+                            (_pid,),
+                        )
+                        if _dd_row is not None:
+                            _entry_px = float(_dd_row[0] or 0.0)
+                            _existing_dd = float(_dd_row[1] or 0.0)
+                            if _entry_px > 0:
+                                if _dirn == "long":
+                                    _drawdown = max(0.0, (_entry_px - _mark) / _entry_px)
+                                else:  # short
+                                    _drawdown = max(0.0, (_mark - _entry_px) / _entry_px)
+                                if _drawdown > _existing_dd:
+                                    with self.db._lock, self.db.conn:
+                                        self.db.execute(
+                                            "UPDATE positions SET max_drawdown_during = ? WHERE id = ? AND status = 'open'",
+                                            (_drawdown, _pid),
+                                        )
+                    except Exception:
+                        pass  # non-critical; don't disrupt close logic
 
                     _close_reason: str | None = None
                     if _dirn == "long":

--- a/engine/execution/oms.py
+++ b/engine/execution/oms.py
@@ -147,6 +147,19 @@ class OMS:
 
         if mode == "paper":
             try:
+                # Look up cts_score from conviction_scores table using conviction_id.
+                _cts_at_entry: float | None = None
+                if intent.conviction_id is not None:
+                    try:
+                        _cts_row = self.db.fetchone(
+                            "SELECT cts_score FROM conviction_scores WHERE id = ?",
+                            (intent.conviction_id,),
+                        )
+                        if _cts_row is not None and _cts_row[0] is not None:
+                            _cts_at_entry = float(_cts_row[0])
+                    except Exception:
+                        pass  # cts_at_entry remains None — non-critical
+
                 fill = self.paper.execute_market(
                     symbol=intent.symbol,
                     direction=intent.direction,
@@ -159,6 +172,7 @@ class OMS:
                     conviction_id=intent.conviction_id,
                     regime_at_entry=str(intent.regime) if intent.regime else None,
                     pcs_at_entry=float(intent.conviction_score),
+                    cts_at_entry=_cts_at_entry,
                 )
             except ValueError as _e:
                 # Deduplication rejection: same symbol already has an open position.

--- a/engine/execution/paper.py
+++ b/engine/execution/paper.py
@@ -89,6 +89,7 @@ class PaperBroker:
         conviction_id: int | None = None,
         regime_at_entry: str | None = None,
         pcs_at_entry: float | None = None,
+        cts_at_entry: float | None = None,
     ) -> PaperFill:
         sym = str(symbol).upper().strip()
         dirn = str(direction).lower().strip()
@@ -152,8 +153,8 @@ class PaperBroker:
                 INSERT INTO positions (
                   id, platform, asset, direction, entry_price, size_notional, leverage,
                   stop_loss, take_profit, opened_at, status, conviction_id,
-                  regime_at_entry, pcs_at_entry
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?)
+                  regime_at_entry, pcs_at_entry, cts_at_entry
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
                 """,
                 (
                     position_id,
@@ -169,6 +170,7 @@ class PaperBroker:
                     int(conviction_id) if conviction_id is not None else None,
                     str(regime_at_entry) if regime_at_entry is not None else None,
                     float(pcs_at_entry) if pcs_at_entry is not None else None,
+                    float(cts_at_entry) if cts_at_entry is not None else None,
                 ),
             )
             self.db.execute(

--- a/tests/unit/test_api_positions.py
+++ b/tests/unit/test_api_positions.py
@@ -6,36 +6,172 @@ from api.main import create_app
 from engine.core.database import Database
 from tests.unit._api_test_client import make_client
 
+HEADERS = {"Authorization": "Bearer secret"}
 
-@pytest.mark.anyio
-async def test_positions_list_and_get(temp_dir, test_config):
+
+def _make_app(temp_dir, test_config):
     test_config = test_config.model_copy(update={"api": test_config.api.model_copy(update={"auth_token": "secret"})})
-
     db = Database(temp_dir / "brain.db")
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = db
+    return app, db
+
+
+def _insert_position(db: Database, pos_id: str = "pos-1", status: str = "open", entry_price: float = 100.0) -> None:
     with db.conn:
         db.conn.execute(
             """
             INSERT INTO positions (id, platform, asset, direction, entry_price, size_notional, leverage, margin_type,
                                    stop_loss, take_profit, opened_at, status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), 'open')
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), ?)
             """,
-            ("pos-1", "paper", "BTC", "long", 100.0, 1000.0, 1.0, "isolated", None, None),
+            (pos_id, "paper", "BTC", "long", entry_price, 1000.0, 1.0, "isolated", None, None, status),
         )
 
-    app = create_app()
-    app.state.config = test_config
-    app.state.db = db
 
-    headers = {"Authorization": "Bearer secret"}
+@pytest.mark.anyio
+async def test_positions_list_and_get(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_position(db)
+
     async with make_client(app) as ac:
-        r = await ac.get("/api/v1/positions", headers=headers)
+        r = await ac.get("/api/v1/positions", headers=HEADERS)
         assert r.status_code == 200
         items = r.json()
         assert len(items) == 1
         assert items[0]["id"] == "pos-1"
 
-        r2 = await ac.get("/api/v1/positions/pos-1", headers=headers)
+        r2 = await ac.get("/api/v1/positions/pos-1", headers=HEADERS)
         assert r2.status_code == 200
         assert r2.json()["asset"] == "BTC"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_close_position_marks_as_closed(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_position(db, entry_price=50000.0)
+
+    async with make_client(app) as ac:
+        r = await ac.post(
+            "/api/v1/positions/pos-1/close",
+            headers=HEADERS,
+            json={"exit_price": 55000.0, "reason": "test"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "closed"
+        assert data["closed_at"] is not None
+        # long: (55000 - 50000) * (1000 / 50000) = 5000 * 0.02 = 100
+        assert data["realized_pnl"] == pytest.approx(100.0, abs=0.01)
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_close_position_defaults_to_flat(temp_dir, test_config):
+    """If no exit_price provided, should close at entry (flat, 0 PnL)."""
+    app, db = _make_app(temp_dir, test_config)
+    _insert_position(db, entry_price=50000.0)
+
+    async with make_client(app) as ac:
+        r = await ac.post("/api/v1/positions/pos-1/close", headers=HEADERS, json={})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "closed"
+        assert data["realized_pnl"] == pytest.approx(0.0, abs=0.01)
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_close_nonexistent_position_returns_404(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+
+    async with make_client(app) as ac:
+        r = await ac.post("/api/v1/positions/no-such/close", headers=HEADERS, json={})
+        assert r.status_code == 404
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_close_already_closed_position_returns_409(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_position(db, status="closed")
+
+    async with make_client(app) as ac:
+        r = await ac.post("/api/v1/positions/pos-1/close", headers=HEADERS, json={})
+        assert r.status_code == 409
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_adjust_stop_updates_stop_loss(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_position(db, entry_price=50000.0)
+
+    async with make_client(app) as ac:
+        r = await ac.patch(
+            "/api/v1/positions/pos-1/stop",
+            headers=HEADERS,
+            json={"stop_loss": 45000.0},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["stop_loss"] == pytest.approx(45000.0)
+        assert data["status"] == "open"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_adjust_target_updates_take_profit(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_position(db, entry_price=50000.0)
+
+    async with make_client(app) as ac:
+        r = await ac.patch(
+            "/api/v1/positions/pos-1/target",
+            headers=HEADERS,
+            json={"take_profit": 60000.0},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["take_profit"] == pytest.approx(60000.0)
+        assert data["status"] == "open"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_adjust_stop_nonexistent_returns_404(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+
+    async with make_client(app) as ac:
+        r = await ac.patch(
+            "/api/v1/positions/no-such/stop",
+            headers=HEADERS,
+            json={"stop_loss": 45000.0},
+        )
+        assert r.status_code == 404
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_adjust_target_nonexistent_returns_404(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+
+    async with make_client(app) as ac:
+        r = await ac.patch(
+            "/api/v1/positions/no-such/target",
+            headers=HEADERS,
+            json={"take_profit": 60000.0},
+        )
+        assert r.status_code == 404
 
     db.close()


### PR DESCRIPTION
## Wave 2 Business Logic Fixes

From deep system audit.

### Changes
- DecisionEngine: invert PCS for short sizing (shorts were unreachable)
- SIGNAL_ACCEPTED_V1: align orchestrator payload to canonical schema
- PaperBroker: write cts_at_entry (was always NULL)
- PnLTracker: track max_drawdown_during for open positions
- orchestrator: replace hardcoded equity_usd=10000 with config value
- cockpit_state: add conviction key

## Type of change
- [x] Bug fix
- [x] New feature