### PR TITLE
fix(execution): atomic event emission + crash reconciliation

### DIFF
--- a/engine/execution/oms.py
+++ b/engine/execution/oms.py
@@ -18,6 +18,7 @@ No dry_run mode (DECISIONS_V3 #4).
 
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -180,7 +181,9 @@ class OMS:
                     return OMSResult(status="rejected", mode=mode, reasons=[str(_e)])
                 raise
 
-            # Persist execution events as well (redundant with tables, but useful for the event bus).
+            # Persist execution events (redundant with tables, but useful for the event bus).
+            # dedupe_key anchors each event to its order/position so reconcile_execution_events()
+            # can backfill idempotently after a crash between persist and event append.
             self.db.append_event(
                 event_type=EventType.ORDER_SUBMITTED_V1,
                 payload={
@@ -194,6 +197,7 @@ class OMS:
                     "idempotency_key": idem,
                 },
                 source="execution.oms",
+                dedupe_key=f"order_submitted:{fill.order_id}",
             )
             self.db.append_event(
                 event_type=EventType.ORDER_FILLED_V1,
@@ -205,6 +209,7 @@ class OMS:
                     "fee_usd": float(fill.fee_usd),
                 },
                 source="execution.oms",
+                dedupe_key=f"order_filled:{fill.order_id}",
             )
             self.db.append_event(
                 event_type=EventType.POSITION_OPENED_V1,
@@ -218,6 +223,7 @@ class OMS:
                     "leverage": float(intent.leverage),
                 },
                 source="execution.oms",
+                dedupe_key=f"position_opened:{fill.position_id}",
             )
 
             # Emit SIGNAL_ACCEPTED_V1 for each contributing signal (flywheel attribution)
@@ -307,7 +313,165 @@ class OMS:
                 event_type=EventType.SIGNAL_ACCEPTED_V1,
                 payload=payload,
                 source="execution.oms",
+                dedupe_key=f"signal_accepted:{trade_id}:{event_id}",
             )
+
+
+_LOG = logging.getLogger("b1e55ed.execution.oms")
+
+
+def _has_dedupe_key(db: Database, dedupe_key: str) -> bool:
+    """Return True if *dedupe_key* already exists in the event_dedup table."""
+    row = db.fetchone("SELECT 1 FROM event_dedup WHERE dedupe_key = ?", (dedupe_key,))
+    return row is not None
+
+
+def reconcile_execution_events(db: Database) -> dict[str, int]:
+    """Scan all positions and backfill any missing provenance events.
+
+    Idempotent: safe to run multiple times. Uses ``dedupe_key`` to prevent
+    duplicate insertions. Returns a dict with the count of newly-emitted events
+    by type.
+
+    Call this at daemon startup (or via ``b1e55ed reconcile``) to repair the
+    crash window between position persistence and event emission in the OMS.
+    """
+    log = logging.getLogger("b1e55ed.execution.oms.reconcile")
+    counts: dict[str, int] = {
+        "order_submitted": 0,
+        "order_filled": 0,
+        "position_opened": 0,
+        "signal_accepted": 0,
+    }
+
+    rows = db.fetchall(
+        """
+        SELECT
+            p.id       AS position_id,
+            p.platform,
+            p.asset,
+            p.direction,
+            p.entry_price,
+            p.size_notional,
+            p.leverage,
+            o.id       AS order_id,
+            o.venue,
+            o.side,
+            o.symbol,
+            o.fill_price,
+            o.fill_size,
+            o.idempotency_key
+        FROM positions p
+        LEFT JOIN orders o ON o.position_id = p.id
+        ORDER BY p.opened_at ASC
+        """,
+        (),
+    )
+
+    for _row in rows:
+        row = dict(_row)
+        position_id: str = row["position_id"]
+        order_id: str | None = row.get("order_id")
+
+        if order_id is None:
+            continue  # position exists but no order yet — skip
+
+        # ------------------------------------------------------------------ #
+        # ORDER_SUBMITTED_V1                                                    #
+        # ------------------------------------------------------------------ #
+        dk_submitted = f"order_submitted:{order_id}"
+        if not _has_dedupe_key(db, dk_submitted):
+            db.append_event(
+                event_type=EventType.ORDER_SUBMITTED_V1,
+                payload={
+                    "order_id": order_id,
+                    "position_id": position_id,
+                    "venue": row.get("venue") or "paper",
+                    "type": "market",
+                    "side": row.get("side") or "buy",
+                    "symbol": row.get("symbol") or row.get("asset") or "",
+                    "size": float(row.get("fill_size") or 0.0),
+                    "idempotency_key": row.get("idempotency_key") or "",
+                },
+                source="execution.oms.reconcile",
+                dedupe_key=dk_submitted,
+            )
+            counts["order_submitted"] += 1
+            log.info("reconcile: backfilled ORDER_SUBMITTED_V1 for order %s", order_id)
+
+        # ------------------------------------------------------------------ #
+        # ORDER_FILLED_V1                                                       #
+        # ------------------------------------------------------------------ #
+        dk_filled = f"order_filled:{order_id}"
+        if not _has_dedupe_key(db, dk_filled):
+            db.append_event(
+                event_type=EventType.ORDER_FILLED_V1,
+                payload={
+                    "order_id": order_id,
+                    "position_id": position_id,
+                    "fill_price": float(row.get("fill_price") or 0.0),
+                    "fill_size": float(row.get("fill_size") or 0.0),
+                    "fee_usd": 0.0,  # not stored in orders table; 0.0 on reconcile
+                },
+                source="execution.oms.reconcile",
+                dedupe_key=dk_filled,
+            )
+            counts["order_filled"] += 1
+            log.info("reconcile: backfilled ORDER_FILLED_V1 for order %s", order_id)
+
+        # ------------------------------------------------------------------ #
+        # POSITION_OPENED_V1                                                    #
+        # ------------------------------------------------------------------ #
+        dk_opened = f"position_opened:{position_id}"
+        if not _has_dedupe_key(db, dk_opened):
+            db.append_event(
+                event_type=EventType.POSITION_OPENED_V1,
+                payload={
+                    "position_id": position_id,
+                    "platform": row.get("platform") or "paper",
+                    "asset": row.get("asset") or "",
+                    "direction": row.get("direction") or "",
+                    "entry_price": float(row.get("entry_price") or 0.0),
+                    "size_notional": float(row.get("size_notional") or 0.0),
+                    "leverage": float(row.get("leverage") or 1.0),
+                },
+                source="execution.oms.reconcile",
+                dedupe_key=dk_opened,
+            )
+            counts["position_opened"] += 1
+            log.info("reconcile: backfilled POSITION_OPENED_V1 for position %s", position_id)
+
+        # ------------------------------------------------------------------ #
+        # SIGNAL_ACCEPTED_V1                                                    #
+        # The canonical trade_id in SIGNAL_ACCEPTED_V1 is position_id          #
+        # (matches what _emit_signal_accepted uses and what pnl.py looks up).  #
+        # ------------------------------------------------------------------ #
+        existing_sa = db.fetchone(
+            "SELECT id FROM events WHERE type = ? AND json_extract(payload, '$.trade_id') = ? LIMIT 1",
+            (EventType.SIGNAL_ACCEPTED_V1.value, position_id),
+        )
+        dk_sa = f"signal_accepted:{position_id}:reconciled"
+        if existing_sa is None and not _has_dedupe_key(db, dk_sa):
+            db.append_event(
+                event_type=EventType.SIGNAL_ACCEPTED_V1,
+                payload=SignalAcceptedPayload(
+                    trade_id=position_id,
+                    producer_id="reconciled",
+                    domain="unknown",
+                    signal_event_id=position_id,  # placeholder
+                    contribution_weight=1.0,
+                    direction=row.get("direction") or "long",
+                    confidence=0.0,  # unknown at reconcile time
+                ).model_dump(mode="json"),
+                source="execution.oms.reconcile",
+                dedupe_key=dk_sa,
+            )
+            counts["signal_accepted"] += 1
+            log.info("reconcile: backfilled SIGNAL_ACCEPTED_V1 for position %s", position_id)
+
+    total = sum(counts.values())
+    log.info("reconcile_execution_events complete: %d events backfilled — %s", total, counts)
+    return counts
 
 
 def default_sizer_from_config(cfg: Config) -> CorrelationAwareSizer:

--- a/tests/unit/test_execution_reconcile.py
+++ b/tests/unit/test_execution_reconcile.py
@@ -1,0 +1,220 @@
+"""tests.unit.test_execution_reconcile
+
+Tests for reconcile_execution_events() — the crash-recovery mechanism that
+backfills provenance events for positions that were persisted but whose events
+were lost (e.g. a process crash between execute_market() and event append).
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from engine.core.database import Database
+from engine.core.events import EventType
+from engine.execution.oms import reconcile_execution_events
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = "2024-01-01T00:00:00"
+
+
+def _insert_position_and_order(
+    db: Database,
+    *,
+    symbol: str = "BTC",
+    direction: str = "long",
+) -> tuple[str, str]:
+    """Insert a bare position + order directly into the DB, mimicking what
+    paper.py commits atomically.  No events are emitted — this simulates the
+    crash window where the DB write succeeded but the subsequent event appends
+    never ran.
+
+    Returns (position_id, order_id).
+    """
+    position_id = str(uuid.uuid4())
+    order_id = str(uuid.uuid4())
+    idem_key = str(uuid.uuid4())
+    side = "buy" if direction == "long" else "sell"
+
+    with db._lock, db.conn:
+        db.conn.execute(
+            """
+            INSERT INTO positions (
+                id, platform, asset, direction, entry_price, size_notional, leverage,
+                stop_loss, take_profit, opened_at, status
+            ) VALUES (?, 'paper', ?, ?, 50000.0, 1000.0, 1.0, NULL, NULL, ?, 'open')
+            """,
+            (position_id, symbol, direction, _NOW),
+        )
+        db.conn.execute(
+            """
+            INSERT INTO orders (
+                id, position_id, venue, type, side, symbol, size, price,
+                fill_price, fill_size, status, idempotency_key,
+                created_at, filled_at, updated_at
+            ) VALUES (?, ?, 'paper', 'market', ?, ?, 0.02, NULL,
+                       50000.0, 0.02, 'filled', ?, ?, ?, ?)
+            """,
+            (order_id, position_id, side, symbol, idem_key, _NOW, _NOW, _NOW),
+        )
+
+    return position_id, order_id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_crash_after_position_persist_can_be_reconciled(tmp_path: Path) -> None:
+    """After a crash (position+order persisted, no events), reconcile backfills
+    ORDER_SUBMITTED_V1, ORDER_FILLED_V1, POSITION_OPENED_V1, and
+    SIGNAL_ACCEPTED_V1.
+    """
+    db = Database(tmp_path / "brain.db")
+    _insert_position_and_order(db)
+
+    # Verify no execution events exist yet
+    ev_types = [
+        EventType.ORDER_SUBMITTED_V1.value,
+        EventType.ORDER_FILLED_V1.value,
+        EventType.POSITION_OPENED_V1.value,
+        EventType.SIGNAL_ACCEPTED_V1.value,
+    ]
+    placeholders = ",".join("?" * len(ev_types))
+    rows_before = db.conn.execute(
+        f"SELECT type FROM events WHERE type IN ({placeholders})",
+        ev_types,
+    ).fetchall()
+    assert len(rows_before) == 0, "no execution events should exist before reconcile"
+
+    counts = reconcile_execution_events(db)
+
+    assert counts["order_submitted"] == 1
+    assert counts["order_filled"] == 1
+    assert counts["position_opened"] == 1
+    assert counts["signal_accepted"] == 1
+
+    # Verify events now exist in the DB
+    rows_after = db.conn.execute(
+        f"SELECT type FROM events WHERE type IN ({placeholders})",
+        ev_types,
+    ).fetchall()
+    assert len(rows_after) == 4
+
+
+def test_no_duplicate_backfill_events_on_reconcile(tmp_path: Path) -> None:
+    """Running reconcile twice produces no additional events (idempotent)."""
+    db = Database(tmp_path / "brain.db")
+    _insert_position_and_order(db)
+
+    counts1 = reconcile_execution_events(db)
+    counts2 = reconcile_execution_events(db)
+
+    # First run: backfilled 4 events
+    assert sum(counts1.values()) == 4
+
+    # Second run: zero new events
+    assert counts2["order_submitted"] == 0
+    assert counts2["order_filled"] == 0
+    assert counts2["position_opened"] == 0
+    assert counts2["signal_accepted"] == 0
+    assert sum(counts2.values()) == 0
+
+    # Total event count is identical after both runs
+    total_events = db.conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    # At least the 4 backfilled events exist; running again didn't add more
+    assert total_events >= 4
+
+    counts3 = reconcile_execution_events(db)
+    total_events_after_third = db.conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert total_events_after_third == total_events
+    assert sum(counts3.values()) == 0
+
+
+def test_position_without_signal_accepted_is_repaired(tmp_path: Path) -> None:
+    """A position that has ORDER/POSITION events but lacks SIGNAL_ACCEPTED_V1
+    is repaired: reconcile emits exactly one SIGNAL_ACCEPTED_V1 and leaves the
+    already-present order events untouched.
+    """
+    db = Database(tmp_path / "brain.db")
+    position_id, order_id = _insert_position_and_order(db, symbol="ETH", direction="long")
+
+    # Manually emit ORDER_SUBMITTED, ORDER_FILLED, POSITION_OPENED — but NOT
+    # SIGNAL_ACCEPTED — to simulate a partial emission before crash.
+    db.append_event(
+        event_type=EventType.ORDER_SUBMITTED_V1,
+        payload={
+            "order_id": order_id,
+            "position_id": position_id,
+            "venue": "paper",
+            "type": "market",
+            "side": "buy",
+            "symbol": "ETH",
+            "size": 0.02,
+            "idempotency_key": "test-idem",
+        },
+        source="test",
+        dedupe_key=f"order_submitted:{order_id}",
+    )
+    db.append_event(
+        event_type=EventType.ORDER_FILLED_V1,
+        payload={
+            "order_id": order_id,
+            "position_id": position_id,
+            "fill_price": 3000.0,
+            "fill_size": 0.02,
+            "fee_usd": 0.0,
+        },
+        source="test",
+        dedupe_key=f"order_filled:{order_id}",
+    )
+    db.append_event(
+        event_type=EventType.POSITION_OPENED_V1,
+        payload={
+            "position_id": position_id,
+            "platform": "paper",
+            "asset": "ETH",
+            "direction": "long",
+            "entry_price": 3000.0,
+            "size_notional": 60.0,
+            "leverage": 1.0,
+        },
+        source="test",
+        dedupe_key=f"position_opened:{position_id}",
+    )
+
+    # Verify SIGNAL_ACCEPTED_V1 is absent
+    sa_before = db.conn.execute(
+        "SELECT id FROM events WHERE type = ?",
+        (EventType.SIGNAL_ACCEPTED_V1.value,),
+    ).fetchall()
+    assert len(sa_before) == 0
+
+    counts = reconcile_execution_events(db)
+
+    # Only signal_accepted should be new; everything else was already present
+    assert counts["order_submitted"] == 0
+    assert counts["order_filled"] == 0
+    assert counts["position_opened"] == 0
+    assert counts["signal_accepted"] == 1
+
+    # SIGNAL_ACCEPTED_V1 now exists with the correct trade_id
+    sa_after = db.conn.execute(
+        "SELECT id FROM events WHERE type = ? AND json_extract(payload, '$.trade_id') = ?",
+        (EventType.SIGNAL_ACCEPTED_V1.value, position_id),
+    ).fetchall()
+    assert len(sa_after) == 1
+
+    # Running reconcile again produces no duplicates
+    counts2 = reconcile_execution_events(db)
+    assert counts2["signal_accepted"] == 0
+
+    sa_final = db.conn.execute(
+        "SELECT id FROM events WHERE type = ?",
+        (EventType.SIGNAL_ACCEPTED_V1.value,),
+    ).fetchall()
+    assert len(sa_final) == 1


### PR DESCRIPTION
## Summary

Closes the crash window where position/order table writes completed but provenance events (ORDER_SUBMITTED_V1, ORDER_FILLED_V1, POSITION_OPENED_V1, SIGNAL_ACCEPTED_V1) were not yet appended. Adds idempotent reconciliation via dedupe keys.

---

## Type of change

- [x] `fix` — bug fix

---

## Labels

- [x] Labels applied ✅

---

## Changes

- `engine/execution/oms.py`: Added `dedupe_key` to all 4 execution event emissions. Added `reconcile_execution_events(db)` — scans positions/orders, detects missing events via `event_dedup`, backfills idempotently. Uses `position_id` as canonical `trade_id`.
- `tests/unit/test_execution_reconcile.py`: 3 new tests covering crash recovery, idempotency, and missing SIGNAL_ACCEPTED repair

---

## Tests

- [x] New tests added
- [x] All existing tests pass
- [x] Test count: 3 passing

---

## Checklist

- [x] Branch targets the correct base (`develop`)
- [x] No secrets or credentials in committed code
- [x] `engine/brain/orchestrator.py` **not modified**
