### PR TITLE
fix(schema): hotfix — idx_events_symbol crashes startup on existing DBs

### DIFF
--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -67,7 +67,6 @@ CREATE INDEX IF NOT EXISTS idx_events_dedupe ON events(dedupe_key);
 CREATE INDEX IF NOT EXISTS idx_events_source ON events(source);
 CREATE INDEX IF NOT EXISTS idx_events_contributor ON events(contributor_id);
 CREATE INDEX IF NOT EXISTS idx_events_created_at ON events(created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_events_symbol ON events(symbol);
 
 -- ============================================================
 -- Event Deduplication


### PR DESCRIPTION
## Summary

**Hotfix** — API crashes on startup with `sqlite3.OperationalError: no such column: symbol` on existing databases.

Root cause: `idx_events_symbol` was in the top-level `SCHEMA` string. `executescript(SCHEMA)` ran before the `_ensure_column()` migration added the `symbol` generated column to the `events` table, causing the index creation to fail on any DB that predates #401.

Fix: removed the index from `SCHEMA`. It is now created exclusively in the `_init_schema()` migration block, after `_ensure_column("events", "symbol", ...)` has run.

## Type of change
- [x] `fix` — bug fix

## Labels
- [x] Labels applied ✅

## Changes
- `engine/core/database.py`: removed `CREATE INDEX IF NOT EXISTS idx_events_symbol ON events(symbol)` from the `SCHEMA` constant (1 line deleted)

## Tests
- [x] No new tests needed — existing schema tests cover this
- [x] All existing tests pass

## Checklist
- [x] Branch targets `develop`
- [x] No secrets in committed code
- [x] `engine/brain/orchestrator.py` not modified