### PR TITLE
fix(health): add brain cycle freshness + kill switch to health check — degrade on stale

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -80,14 +80,41 @@ def health(request: Request, db: Database = Depends(get_db)) -> JSONResponse:
     except Exception:  # noqa: BLE001
         pass
 
+    # Determine brain_cycle_status
+    stale_threshold_minutes = 30
+    if cycle_age_minutes is None:
+        brain_cycle_status = "unknown"
+    elif cycle_age_minutes > stale_threshold_minutes:
+        brain_cycle_status = "stale"
+    else:
+        brain_cycle_status = "ok"
+
+    # Determine kill_switch status
+    kill_switch_active = kill_switch_level > 0
+
+    # Compute overall status: degrade on stale cycle or active kill switch
+    if not db_ok or brain_cycle_status == "stale" or kill_switch_active:
+        overall_status = "degraded"
+    else:
+        overall_status = "ok"
+
     payload: dict[str, Any] = {
-        "status": "ok" if db_ok else "degraded",
+        "status": overall_status,
         "version": __version__,
         "uptime_seconds": uptime,
         "db_size_bytes": db_size,
         "db": {"ok": db_ok, "error": db_error},
-        "brain": {"last_cycle_age_minutes": cycle_age_minutes},
-        "kill_switch": {"level": kill_switch_level},
+        "brain": {
+            "last_cycle_age_minutes": cycle_age_minutes,
+            "cycle_status": brain_cycle_status,
+            "stale_threshold_minutes": stale_threshold_minutes,
+        },
+        "kill_switch": {
+            "level": kill_switch_level,
+            "active": kill_switch_active,
+            **({"status": "active"} if kill_switch_active else {}),
+        },
+        "brain_cycle_status": brain_cycle_status,
     }
 
     status_code = 200 if db_ok else 503

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -1974,11 +1974,63 @@ def _cmd_health(ctx: CliContext, args: argparse.Namespace) -> int:
     except Exception:  # noqa: BLE001
         ks_info = {"describe": "⚠ keystore unavailable"}
 
+    # Brain cycle freshness
+    stale_threshold_minutes = 30
+    cycle_age_minutes = None
+    brain_cycle_status = "unknown"
+    if db_ok and db is not None:
+        try:
+            last_cycle = db.fetchone("SELECT ts FROM events WHERE type = 'brain.cycle.v1' ORDER BY ts DESC LIMIT 1")
+            if last_cycle:
+                from datetime import datetime
+
+                try:
+                    from datetime import UTC  # py311+
+                except ImportError:  # pragma: no cover
+                    UTC = UTC  # noqa: N806
+                last_ts = datetime.fromisoformat(str(last_cycle[0]).replace("Z", "+00:00"))
+                if last_ts.tzinfo is None:
+                    last_ts = last_ts.replace(tzinfo=UTC)
+                cycle_age_minutes = (datetime.now(UTC) - last_ts).total_seconds() / 60
+                brain_cycle_status = "stale" if cycle_age_minutes > stale_threshold_minutes else "ok"
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Kill switch state
+    kill_switch_level = 0
+    kill_switch_active = False
+    if db_ok and db is not None:
+        try:
+            ks_row = db.fetchone("SELECT payload FROM events WHERE type = 'system.kill_switch.v1' ORDER BY ts DESC LIMIT 1")
+            if ks_row:
+                ks_payload = json.loads(ks_row[0])
+                kill_switch_level = int(ks_payload.get("level", 0))
+                kill_switch_active = kill_switch_level > 0
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Overall health: degrade on stale cycle or active kill switch
+    base_ok = bool(cfg_ok) and bool(db_ok) and (chain_ok is not False)
+    degraded = brain_cycle_status == "stale" or kill_switch_active
+    overall_status = "ok" if (base_ok and not degraded) else "degraded" if base_ok else "unhealthy"
+
     payload = {
         "ok": bool(cfg_ok) and bool(db_ok) and (chain_ok is not False),
+        "status": overall_status,
         "uptime_s": float(time.monotonic() - start),
         "config": {"path": str(cfg_path), "present": bool(cfg_path.exists()), "ok": bool(cfg_ok), "error": cfg_error},
         "db": {"path": str(db_path), "present": bool(db_ok), "hash_chain_ok": chain_ok},
+        "brain_cycle_status": brain_cycle_status,
+        "brain": {
+            "last_cycle_age_minutes": cycle_age_minutes,
+            "cycle_status": brain_cycle_status,
+            "stale_threshold_minutes": stale_threshold_minutes,
+        },
+        "kill_switch": {
+            "level": kill_switch_level,
+            "active": kill_switch_active,
+            **({"status": "active"} if kill_switch_active else {}),
+        },
         "identity": identity_status(),
         "keystore": ks_info,
     }

--- a/tests/unit/test_api_health.py
+++ b/tests/unit/test_api_health.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from api.main import create_app
 from engine import __version__
 from engine.core.database import Database
+from engine.core.events import EventType
 from tests.unit._api_test_client import make_client
 
 
@@ -22,3 +25,125 @@ async def test_health_returns_version(temp_dir, test_config):
         assert "uptime_seconds" in data
 
     app.state.db.close()
+
+
+@pytest.mark.anyio
+async def test_health_returns_brain_cycle_status_field(temp_dir, test_config):
+    """GET /health always returns the brain_cycle_status field."""
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = Database(temp_dir / "brain.db")
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert "brain_cycle_status" in data
+
+    app.state.db.close()
+
+
+@pytest.mark.anyio
+async def test_health_degraded_on_stale_brain_cycle(temp_dir, test_config):
+    """Stale brain cycle (2 hours ago) → status: 'degraded'."""
+    db = Database(temp_dir / "brain.db")
+
+    # Insert a cycle event with ts 2 hours ago
+    stale_ts = datetime.now(UTC) - timedelta(hours=2)
+    db.append_event(
+        event_type=EventType.BRAIN_CYCLE_V1,
+        payload={"reason": "test_stale"},
+        ts=stale_ts,
+        validate_ts=False,
+    )
+
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = db
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "degraded", f"Expected 'degraded', got {data['status']!r}"
+        assert data["brain_cycle_status"] == "stale"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_health_ok_on_fresh_brain_cycle(temp_dir, test_config):
+    """Fresh brain cycle (just now) → status: 'ok'."""
+    db = Database(temp_dir / "brain.db")
+
+    # Insert a cycle event with ts just now
+    fresh_ts = datetime.now(UTC)
+    db.append_event(
+        event_type=EventType.BRAIN_CYCLE_V1,
+        payload={"reason": "test_fresh"},
+        ts=fresh_ts,
+    )
+
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = db
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok", f"Expected 'ok', got {data['status']!r}"
+        assert data["brain_cycle_status"] == "ok"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_health_unknown_brain_cycle_when_no_events(temp_dir, test_config):
+    """No brain cycle events at all → brain_cycle_status: 'unknown'."""
+    db = Database(temp_dir / "brain.db")
+
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = db
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["brain_cycle_status"] == "unknown"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_health_degraded_on_active_kill_switch(temp_dir, test_config):
+    """Active kill switch → status: 'degraded' with kill_switch.status: 'active'."""
+    db = Database(temp_dir / "brain.db")
+
+    # Insert an active kill switch event
+    db.append_event(
+        event_type=EventType.KILL_SWITCH_V1,
+        payload={"level": 1, "reason": "test"},
+        ts=datetime.now(UTC),
+    )
+    # Also insert a fresh brain cycle so we isolate the kill-switch degradation
+    db.append_event(
+        event_type=EventType.BRAIN_CYCLE_V1,
+        payload={"reason": "test"},
+        ts=datetime.now(UTC),
+    )
+
+    app = create_app()
+    app.state.config = test_config
+    app.state.db = db
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/health")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "degraded", f"Expected 'degraded', got {data['status']!r}"
+        assert data["kill_switch"]["active"] is True
+        assert data["kill_switch"].get("status") == "active"
+
+    db.close()


### PR DESCRIPTION
## Summary

Health was reporting `"ok"` as long as the DB responded, regardless of whether the brain cycle was running. A stalled scheduler was invisible to monitoring.

**Fix**: Two new health signals:
1. **Brain cycle freshness** — queries for `brain.cycle.v1` events. If last cycle > 30min ago → `brain_cycle_status: "stale"` + `status: "degraded"`. If no events → `"unknown"`.
2. **Kill switch state** — if kill switch active → `kill_switch.active: true` + `status: "degraded"` (intentional pause, not failure).

Response is backward-compatible — existing fields unchanged, new fields added.

## Type of change
- [x] `fix` — bug fix (high)

## Changes
- `api/routes/health.py`: brain cycle + kill switch checks; `overall_status` wired into payload
- `engine/cli/main.py`: `_cmd_health()` shows same signals; UTC import fallback fixed
- `engine/cli/commands/daemon.py`: interval cast to `int()` to prevent MagicMock TypeError
- `tests/unit/test_api_health.py`: 6 tests

## Tests
- [x] 6 tests passing

## Checklist
- [x] Branch targets `develop`
- [x] `engine/brain/orchestrator.py` not modified