### PR TITLE
fix(dashboard): conviction gauge normalization + signal timeline null-ts scatter

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -591,6 +591,16 @@ def _map_signals(resp: Any) -> list[dict[str, Any]]:
 
         ts = s.get("ts")
         ts_dt = _parse_dt(ts)
+        # Fallback: try ts_epoch_ms directly, or parse ts_iso if ts_dt is still None
+        if ts_dt is None:
+            epoch_ms = s.get("ts_epoch_ms")
+            if epoch_ms is not None:
+                with contextlib.suppress(Exception):
+                    ts_dt = datetime.fromtimestamp(float(epoch_ms) / 1000, tz=UTC)
+        if ts_dt is None:
+            ts_iso_raw = s.get("ts_iso")
+            if ts_iso_raw:
+                ts_dt = _parse_dt(ts_iso_raw)
         ts_hm = ts_dt.strftime("%H:%M") if ts_dt is not None else "—"
         ts_iso = ts_dt.isoformat() if ts_dt is not None else (str(ts) if ts is not None else "")
         ts_ms = int(ts_dt.timestamp() * 1000) if ts_dt is not None else None

--- a/dashboard/templates/brain.html
+++ b/dashboard/templates/brain.html
@@ -426,6 +426,8 @@
   }
 
   cv = parseFloat(cv);
+  // normalize: pcs_score is 0-100, gauge expects 0-10
+  if (cv > 10) cv = cv / 10;
   var color = cv < 3 ? 'var(--red)' : (cv < 7 ? 'var(--amber)' : 'var(--green)');
   var label = cv < 3 ? 'BEAR' : (cv < 7 ? 'NEUTRAL' : 'BULL');
 

--- a/dashboard/templates/partials/cockpit_content.html
+++ b/dashboard/templates/partials/cockpit_content.html
@@ -55,6 +55,8 @@
       }
 
       cv = parseFloat(cv);
+      // normalize: pcs_score is 0-100, gauge expects 0-10
+      if (cv > 10) cv = cv / 10;
       var color = cv < 3 ? 'var(--red)' : (cv < 7 ? 'var(--amber)' : 'var(--green)');
       var label = cv < 3 ? 'BEAR' : (cv < 7 ? 'NEUTRAL' : 'BULL');
 

--- a/dashboard/templates/signals.html
+++ b/dashboard/templates/signals.html
@@ -210,14 +210,14 @@
     }
 
     var raw = s.ts;
-    if (raw === null || raw === undefined) return now;
+    if (raw === null || raw === undefined) return null;
 
     if (typeof raw === 'number' && isFinite(raw)) {
       return Math.abs(raw) < 1e11 ? raw * 1000 : raw;
     }
 
     var txt = String(raw).trim();
-    if (!txt) return now;
+    if (!txt) return null;
 
     if (/^-?\d+(\.\d+)?$/.test(txt)) {
       var numeric = Number(txt);
@@ -235,7 +235,7 @@
     if (!isNaN(parsed)) return parsed;
 
     parsed = Date.parse(txt);
-    return isNaN(parsed) ? now : parsed;
+    return isNaN(parsed) ? null : parsed;
   }
 
   // Parse timestamps
@@ -243,8 +243,8 @@
     s._time = parseSignalTs(s);
   });
 
-  // Filter to last 24h & sort
-  signals = signals.filter(function(s) { return s._time >= t24h; });
+  // Filter to last 24h & sort; exclude signals with no parseable timestamp
+  signals = signals.filter(function(s) { return s._time !== null && s._time >= t24h; });
   signals.sort(function(a, b) { return a._time - b._time; });
 
   // X position


### PR DESCRIPTION
## Summary

Two visual bugs on the brain/signals pages.

### Bug 1 — Conviction gauge needle pointing wrong

`api/routes/cockpit.py` was passing `pcs_score` (0–100) as `conviction`, but the gauge JS formula `180 - (cv / 10) * 180` expected 0–10. A value of 57.7 produced ~-858° needle angle.

**Fix**: JS normalization added in both `cockpit_content.html` and `brain.html`:
```js
// normalize: pcs_score is 0-100, gauge expects 0-10
if (cv > 10) cv = cv / 10;
```

### Bug 2 — Signal timeline all dots at "now"

`parseSignalTs()` returned `now` as fallback for unparseable timestamps, so any signal with a null/bad `ts` piled up at the right edge.

**Fix**: Return `null` on parse failure, filter those signals out before plotting. Also added server-side fallback chain in `_map_signals()`: tries `ts_epoch_ms` → `ts_iso` before giving up.

## Type of change
- [x] `fix` — bug fix

## Checklist
- [x] Branch targets `develop`
- [x] `engine/brain/orchestrator.py` not modified