### PR TITLE
fix(dashboard): pnl% color + position count in card header

### DIFF
--- a/dashboard/templates/brain.html
+++ b/dashboard/templates/brain.html
@@ -140,7 +140,10 @@
   <div class="panel" hx-get="/partials/positions" hx-trigger="every 30s, refresh from:body" hx-swap="innerHTML">
     <div class="panel-header">
       <span class="panel-title">Positions</span>
-      <span class="panel-age">{{ positions_age | default('—') }}</span>
+      <span style="display:flex; align-items:center; gap:0.75rem;">
+        {% if positions %}<span style="font-size:0.7rem; color:var(--text-dim);">{{ positions | length }} open · 0 pending</span>{% endif %}
+        <span class="panel-age">{{ positions_age | default('—') }}</span>
+      </span>
     </div>
 
     {% if positions %}
@@ -148,7 +151,7 @@
       <div style="margin-bottom: 0.75rem;">
         <div style="display:flex; justify-content:space-between; align-items:baseline;">
           <span class="text-bright" style="font-weight:400;">{{ p.id }} · {{ p.symbol }} {{ p.direction | upper }}</span>
-          <span class="{{ 'text-bull' if p.pnl_pct >= 0 else 'text-bear' }} data-live" style="font-weight:400;">
+          <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }} data-live" style="font-weight:400;">
             {{ '%+.1f' | format(p.pnl_pct) }}%
           </span>
         </div>
@@ -166,7 +169,7 @@
         </div>
       </div>
       {% endfor %}
-      <div style="font-size:0.75rem; color:var(--text-dim);">{{ positions | length }} open · 0 pending</div>
+
     {% else %}
       {% set message = "No open positions" %}
       {% set status = "Brain decisions will appear here" %}

--- a/dashboard/templates/positions.html
+++ b/dashboard/templates/positions.html
@@ -5,9 +5,14 @@
 
 <div style="display:flex; justify-content:space-between; align-items:baseline; margin-bottom:1rem;">
   <h1 style="font-size:0.7rem; font-weight:300; letter-spacing:0.2em; text-transform:uppercase; color:var(--text-dim);">Positions</h1>
-  <div style="display:flex; gap:0.5rem;">
-    <button class="btn {% if view == 'open' %}active{% endif %}" onclick="location.href='/positions?view=open'" style="{% if view == 'open' %}color:var(--text-bright);border-color:var(--border-active);{% endif %}">Open</button>
-    <button class="btn {% if view == 'closed' %}active{% endif %}" onclick="location.href='/positions?view=closed'" style="{% if view == 'closed' %}color:var(--text-bright);border-color:var(--border-active);{% endif %}">Closed</button>
+  <div style="display:flex; align-items:center; gap:0.75rem;">
+    {% if positions %}
+    <span style="font-size:0.75rem; color:var(--text-dim); font-family:var(--mono);">{{ positions | length }} {{ view }}</span>
+    {% endif %}
+    <div style="display:flex; gap:0.5rem;">
+      <button class="btn {% if view == 'open' %}active{% endif %}" onclick="location.href='/positions?view=open'" style="{% if view == 'open' %}color:var(--text-bright);border-color:var(--border-active);{% endif %}">Open</button>
+      <button class="btn {% if view == 'closed' %}active{% endif %}" onclick="location.href='/positions?view=closed'" style="{% if view == 'closed' %}color:var(--text-bright);border-color:var(--border-active);{% endif %}">Closed</button>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Fixes

**brain.html**
- `pnl_pct >= 0` → `pnl_pct > 0 ? green : pnl_pct < 0 ? red : dim` — negative % now correctly shows red
- Moved "N open · 0 pending" from bottom of list to top-right of Positions card header

**positions.html**
- Added position count (`N open` / `N closed`) left of the Open/Closed filter buttons

## Type of change
- [x] Bug fix (non-breaking)