### PR TITLE
fix(dashboard): P&L color — remove data-live from pnl spans (CSS specificity bug)

### DIFF
--- a/dashboard/templates/brain.html
+++ b/dashboard/templates/brain.html
@@ -151,7 +151,7 @@
       <div style="margin-bottom: 0.75rem;">
         <div style="display:flex; justify-content:space-between; align-items:baseline;">
           <span class="text-bright" style="font-weight:400;">{{ p.id }} · {{ p.symbol }} {{ p.direction | upper }}</span>
-          <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }} data-live" style="font-weight:400;">
+          <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }}" style="font-weight:400;">
             {{ '%+.1f' | format(p.pnl_pct) }}%
           </span>
         </div>

--- a/dashboard/templates/partials/position_detail_panel.html
+++ b/dashboard/templates/partials/position_detail_panel.html
@@ -5,7 +5,7 @@
     <span class="badge" style="margin-left:0.5rem; border-color:rgba(245,158,11,0.35); color:var(--amber);">⚠ conviction conflict</span>
     {% endif %}
   </span>
-  <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }} data-live" style="font-size:0.85rem; font-weight:400;">
+  <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }}" style="font-size:0.85rem; font-weight:400;">
     {{ '%+.1f' | format(p.pnl_pct) }}%
   </span>
 </div>
@@ -29,7 +29,7 @@
   </div>
   <div>
     <span class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">P&L</span><br>
-    <span class="{{ 'text-bull' if p.pnl_usd > 0 else ('text-bear' if p.pnl_usd < 0 else 'text-dim') }} data-live">${{ '%+.0f' | format(p.pnl_usd) }}</span>
+    <span class="{{ 'text-bull' if p.pnl_usd > 0 else ('text-bear' if p.pnl_usd < 0 else 'text-dim') }}">${{ '%+.0f' | format(p.pnl_usd) }}</span>
   </div>
 </div>
 

--- a/dashboard/templates/partials/positions_panel.html
+++ b/dashboard/templates/partials/positions_panel.html
@@ -11,7 +11,7 @@
   <div style="margin-bottom: 0.75rem;">
     <div style="display:flex; justify-content:space-between; align-items:baseline;">
       <span class="text-bright" style="font-weight:400;">{{ p.id }} · {{ p.symbol }} {{ p.direction | upper }}</span>
-      <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }} data-live" style="font-weight:400;">
+      <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }}" style="font-weight:400;">
         {{ '%+.1f' | format(p.pnl_pct) }}%
       </span>
     </div>

--- a/dashboard/templates/positions.html
+++ b/dashboard/templates/positions.html
@@ -26,7 +26,7 @@
         <span class="badge" style="margin-left:0.5rem; border-color:rgba(245,158,11,0.35); color:var(--amber);">⚠ conviction conflict</span>
         {% endif %}
       </span>
-      <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }} data-live" style="font-size:0.85rem; font-weight:400;">
+      <span class="{{ 'text-bull' if p.pnl_pct > 0 else ('text-bear' if p.pnl_pct < 0 else 'text-dim') }}" style="font-size:0.85rem; font-weight:400;">
         {{ '%+.1f' | format(p.pnl_pct) }}%
       </span>
     </div>
@@ -51,7 +51,7 @@
       </div>
       <div>
         <span class="text-dim" style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.1em;">P&L</span><br>
-        <span class="{{ 'text-bull' if p.pnl_usd > 0 else ('text-bear' if p.pnl_usd < 0 else 'text-dim') }} data-live">${{ '%+.0f' | format(p.pnl_usd) }}</span>
+        <span class="{{ 'text-bull' if p.pnl_usd > 0 else ('text-bear' if p.pnl_usd < 0 else 'text-dim') }}">${{ '%+.0f' | format(p.pnl_usd) }}</span>
       </div>
     </div>
 


### PR DESCRIPTION
Root cause found: `.data-live { color: var(--green) }` is defined after `.text-bear` in the stylesheet, so it always wins specificity and forces green on all P&L spans regardless of sign.

Fix: remove `data-live` from all P&L percentage and dollar spans. Current price spans keep `data-live` (those should always be green).

Affected templates: `positions_panel.html`, `position_detail_panel.html`, `positions.html`, `brain.html`

## Type of change
- [x] Bug fix (non-breaking)