### PR TITLE
feat(config): expose auto_paper_trade_min_magnitude as documented config item

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,10 +58,35 @@ risk:
 ```yaml
 brain:
   cycle_interval_seconds: 1800
-  auto_paper_trade: true      # Auto-open paper trades when confidence ≥ 0.65
+  auto_paper_trade: true
+  auto_paper_trade_min_confidence: 0.35
+  auto_paper_trade_min_magnitude: 5.0
 ```
 
-When `auto_paper_trade` is enabled (default: `true`), the brain automatically opens paper trades for any conviction with confidence ≥ 0.65. Disable to require manual confirmation for all trades.
+#### `brain.auto_paper_trade`
+
+- **Type**: bool
+- **Default**: `true`
+- **Description**: Enable automatic paper trading when a conviction meets both the confidence and magnitude thresholds. Set to `false` to require manual confirmation for every trade.
+
+#### `brain.auto_paper_trade_min_confidence`
+
+- **Type**: float
+- **Default**: `0.35`
+- **Range**: 0.0–1.0
+- **Description**: Minimum confidence score required to open a paper trade. Signals scoring below this threshold are observed but not acted on. Lower values allow trades on less-certain signals.
+
+#### `brain.auto_paper_trade_min_magnitude`
+
+- **Type**: float
+- **Default**: `5.0`
+- **Range**: 0.0–10.0
+- **Description**: Minimum conviction magnitude required to open a paper trade. Signals scoring below this threshold are observed but not acted on.
+- **⚠️ Warning**: Values below `3.0` will trade on weak signals. Use lower values only in testing/paper mode. For live trading, keep at `5.0` or above.
+- **Tuning guide**:
+  - `5.0` — production default, high-quality signals only
+  - `3.0–4.9` — testing/paper: moderate signal quality
+  - `< 3.0` — stress testing only: high noise, expect many false trades
 
 ### `execution`
 

--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -543,6 +543,13 @@ class BrainOrchestrator:
 
                     # Fix 2: Minimum magnitude threshold — low-magnitude signals lack conviction.
                     min_magnitude = float(getattr(self.config.brain, "auto_paper_trade_min_magnitude", 5.0) or 5.0)
+                    if min_magnitude < 3.0:
+                        _log.warning(
+                            "auto_paper_trade_min_magnitude=%.1f is below 3.0 — "
+                            "this will trigger trades on weak signals. "
+                            "Suitable for testing only; raise to ≥5.0 before live trading.",
+                            min_magnitude,
+                        )
                     if magnitude < min_magnitude:
                         _log.info(
                             "auto-paper-trade skipped: %s magnitude %.2f < %.2f threshold",

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -118,11 +118,22 @@ class RiskConfig(BaseModel):
 class BrainConfig(BaseModel):
     cycle_interval_seconds: int = 1800
     auto_paper_trade: bool = True
+    """Enable automatic paper trading when a conviction meets the confidence and magnitude
+    thresholds.  Set to ``False`` to require manual confirmation for every trade."""
+
     # Lower default than 0.65 so paper mode can execute in moderate-conviction regimes.
     auto_paper_trade_min_confidence: float = 0.35
-    # Minimum magnitude required to open a paper trade (0–10 scale). Signals below this
-    # lack sufficient conviction and are skipped entirely.
+    """Minimum confidence score (0–1) required to open a paper trade.
+    Lower values allow trades on less-certain signals.  Default: 0.35."""
+
     auto_paper_trade_min_magnitude: float = 5.0
+    """Minimum conviction magnitude (0–10 scale) required to open a paper trade.
+
+    Lower values increase trade frequency but reduce signal quality.
+
+    WARNING: Values below 3.0 will trade on weak signals and are only appropriate
+    for testing.  Default: 5.0 (production-safe).
+    Recommended testing range: 2.5–4.0."""
 
 
 class ExecutionConfig(BaseModel):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -122,3 +122,32 @@ def test_universe_execution_metadata_for_symbol() -> None:
     assert meta["venues"] == ["binance", "global"]
     assert meta["tags"] == ["core", "growth", "paper-only"]
     assert meta["execution_mode_hints"] == ["paper_only"]
+
+
+# ---------------------------------------------------------------------------
+# BrainConfig — auto_paper_trade_min_magnitude
+# ---------------------------------------------------------------------------
+
+
+def test_brain_auto_paper_trade_min_magnitude_default() -> None:
+    """Default value must be 5.0 (production-safe)."""
+    from engine.core.config import BrainConfig
+
+    cfg = BrainConfig()
+    assert cfg.auto_paper_trade_min_magnitude == 5.0
+
+
+def test_brain_auto_paper_trade_min_magnitude_readable_from_dict() -> None:
+    """Value must survive a round-trip through dict construction."""
+    from engine.core.config import BrainConfig
+
+    cfg = BrainConfig(**{"auto_paper_trade_min_magnitude": 2.5})
+    assert cfg.auto_paper_trade_min_magnitude == 2.5
+
+
+def test_brain_auto_paper_trade_min_magnitude_top_level_config() -> None:
+    """BrainConfig is reachable via top-level Config."""
+    from engine.core.config import Config
+
+    cfg = Config()
+    assert cfg.brain.auto_paper_trade_min_magnitude == 5.0


### PR DESCRIPTION
Makes `auto_paper_trade_min_magnitude` a first-class config item with schema, docs, and a runtime warning.

## Changes
- `engine/core/config.py` — full docstrings on `auto_paper_trade`, `auto_paper_trade_min_confidence`, and `auto_paper_trade_min_magnitude` in `BrainConfig`
- `engine/brain/orchestrator.py` — warning log when magnitude < 3.0 (testing-only gate)
- `docs/configuration.md` — documented all three params with type, default, range, ⚠️ warning, and tuning guide
- `tests/unit/test_config.py` — 3 new tests for default, dict construction, top-level reachability

## Tuning guide
- `5.0` — production default
- `3.0–4.9` — paper/testing
- `< 3.0` — stress testing only (triggers runtime warning)

## Type of change
- [x] New feature (non-breaking)