### PR TITLE
docs(producers): consolidate SPI docs into producers section, merge nav groups

### DIFF
--- a/docs/dependencies-docs.md
+++ b/docs/dependencies-docs.md
@@ -558,10 +558,13 @@ docs/api/karma.mdx          → KARMA-SPEC.md
 ### Producers
 
 ```text
-docs/producers/overview.mdx    → producers.md
-docs/producers/reference.mdx   → producers.md
+docs/producers/overview.mdx          → producers.md
 docs/producers/symbol-packs.mdx
-docs/producers/tuning-guide.mdx → configuration.md
+docs/producers/tuning-guide.mdx      → configuration.md
+docs/producers/external-producers.mdx → docs/producers/spi-interface.mdx, docs/producers/spi-adapter.mdx
+docs/producers/spi-interface.mdx     (standalone — formal SPI protocol contract)
+docs/producers/spi-adapter.mdx       → docs/producers/external-producers.mdx
+docs/producers/reference.mdx         → all producers/* pages, tutorial-agent-producer.md, producer-intelligence.md
 ```
 
 ### Contributing
@@ -726,18 +729,40 @@ docs/signal-benchmarking-ops-guide.md (standalone — operational guide for orac
 ## SPI External Producer Guide
 
 ```text
-docs/spi/README.md
-  depends on: docs/spi/interface-spec.md, docs/spi/adapter-spec.md
+docs/producers/external-producers.mdx
+  depends on: docs/producers/spi-interface.mdx, docs/producers/spi-adapter.mdx
 ```
 
 ## SPI Interface Specification
 
 ```text
-docs/spi/interface-spec.md (standalone — formal SPI protocol contract)
+docs/producers/spi-interface.mdx (standalone — formal SPI protocol contract)
 ```
 
 ## SPI Adapter Spec
 
 ```text
-docs/spi/adapter-spec.md (standalone — YAML adapter spec reference)
+docs/producers/spi-adapter.mdx
+  → docs/producers/external-producers.mdx  (back-reference for native mode)
 ```
+
+## Tutorial: Agent Producer
+
+```text
+docs/tutorial-agent-producer.md (standalone — step-by-step guide to building a custom agent producer)
+```
+
+**Referenced by:**
+- docs/producers/reference.mdx
+
+## Producer Intelligence
+
+```text
+docs/producer-intelligence.md (standalone — intelligence layer, signal synthesis)
+```
+
+**Referenced by:**
+- docs/producers/reference.mdx
+- docs/architecture.md
+- docs/learning-loop.md
+- docs/producers.md

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,15 +66,10 @@
           "producers/overview",
           "producers/symbol-packs",
           "producers/tuning-guide",
+          "producers/external-producers",
+          "producers/spi-interface",
+          "producers/spi-adapter",
           "producers/reference"
-        ]
-      },
-      {
-        "group": "Signal Producers",
-        "pages": [
-          "spi/README",
-          "spi/interface-spec",
-          "spi/adapter-spec"
         ]
       },
       {

--- a/docs/producers/external-producers.mdx
+++ b/docs/producers/external-producers.mdx
@@ -1,3 +1,8 @@
+---
+title: "External Producers (SPI)"
+description: "How to integrate as an external signal producer using the Standard Producer Interface."
+---
+
 # SPI — External Producer Guide
 
 **Standard Producer Interface v1 · b1e55ed**
@@ -255,7 +260,7 @@ If you have an existing REST API that already serves signals, the operator can c
 
 **Reference spec:** `engine/external/specs/post_fiat_signals.yaml`
 
-See [Adapter Spec](./adapter-spec.md) for the full YAML format.
+See [Adapter Spec](./spi-adapter) for the full YAML format.
 
 ---
 
@@ -275,7 +280,6 @@ See [Adapter Spec](./adapter-spec.md) for the full YAML format.
 
 ## Questions?
 
-- **Spec:** [`docs/spi/interface-spec.md`](./interface-spec.md)
-- **Adapter format:** [`docs/spi/adapter-spec.md`](./adapter-spec.md)
-- **Full interface contract:** [`docs/spi/interface-spec.md`](./interface-spec.md)
+- **Spec:** [SPI Interface Spec](./spi-interface)
+- **Adapter format:** [Adapter Spec](./spi-adapter)
 - **Contact:** Reach the operator to request registration or raise issues

--- a/docs/producers/reference.mdx
+++ b/docs/producers/reference.mdx
@@ -1,20 +1,66 @@
 ---
 title: "Producer Reference"
-description: "Reference links for producer interfaces, configuration, and examples."
+description: "Index of all producer-related documentation, CLI commands, and extended reading."
 ---
 
-This page links to the best current producer reference material in the repo.
+## Producer Documentation
 
-## Key docs
+| Page | Description |
+|------|-------------|
+| [Overview](./overview) | What producers are, domains, weights, and the core producer catalog |
+| [Symbol Packs](./symbol-packs) | Configuring per-producer symbol sets |
+| [Tuning Guide](./tuning-guide) | Adjusting domain weights and producer knobs |
+| [External Producers (SPI)](./external-producers) | Integrating as an external signal producer |
+| [SPI Interface Spec](./spi-interface) | Formal contract: signal schema, scoring, idempotency |
+| [SPI Adapter Spec](./spi-adapter) | Pull-mode adapter YAML format for operator-side integrations |
 
-- `docs/tutorial-agent-producer.md` — building / wiring an agent producer
-- `docs/agent-interfaces.md` — how agents talk to the system
-- `docs/configuration.md` — configuration layout and knobs
+---
 
-<Info>
-These pages are still evolving; this Mintlify section will become the canonical producer reference over time.
-</Info>
+## Extended Reading
 
-## Full Reference
+These files live in the repo but are not yet part of the Mintlify nav:
 
-For the complete producer reference including per-producer tuning knobs and sample configs, see [producers.md](../producers.md).
+| File | Description |
+|------|-------------|
+| [`docs/tutorial-agent-producer.md`](../tutorial-agent-producer) | Step-by-step guide to building a custom agent producer |
+| [`docs/producer-intelligence.md`](../producer-intelligence) | Intelligence layer — how producer signals feed the synthesis engine |
+
+---
+
+## CLI Reference
+
+### Core producer commands
+
+```bash
+# List all registered producers and their health status
+b1e55ed producers list
+
+# List producers as JSON (for scripting)
+b1e55ed producers list --json | jq
+```
+
+### SPI management commands
+
+```bash
+# Register a new external producer
+b1e55ed spi register --producer-id yourname --name "Your Name"
+
+# Check producer status and karma
+b1e55ed spi status --producer-id yourname
+
+# Promote a producer from shadow → active (operator only)
+b1e55ed spi promote --producer-id yourname
+
+# Test an API key (verify it's valid without submitting a signal)
+b1e55ed spi test-key --producer-id yourname
+```
+
+### Related commands
+
+```bash
+# Full system status (includes producer health)
+b1e55ed status
+
+# Brain synthesis output (shows domain contributions)
+b1e55ed brain --full
+```

--- a/docs/producers/spi-adapter.mdx
+++ b/docs/producers/spi-adapter.mdx
@@ -1,8 +1,13 @@
+---
+title: "SPI Adapter Spec"
+description: "YAML spec format for configuring pull-mode (adapter) integrations — polling an external producer's API and normalizing signals into the SPI pipeline."
+---
+
 # SPI Adapter Spec Reference
 
 **Adapter-Mediated Producer Integration**
 
-This document is for **operators** configuring pull-mode (adapter) integrations. If you're a producer wanting to submit signals directly, see [README.md](./README.md).
+This document is for **operators** configuring pull-mode (adapter) integrations. If you're a producer wanting to submit signals directly, see [External Producers](./external-producers).
 
 ---
 

--- a/docs/producers/spi-interface.mdx
+++ b/docs/producers/spi-interface.mdx
@@ -1,3 +1,8 @@
+---
+title: "SPI Interface Specification"
+description: "Formal contract for the Standard Producer Interface v1 — signal schema, scoring rules, idempotency, and versioning."
+---
+
 # SPI Interface Specification
 
 **Standard Producer Interface v1 — Formal Contract**


### PR DESCRIPTION
Restructures producer documentation so SPI lives where it belongs — alongside native producer docs — not as a separate nav silo.

## Changes
- `docs/spi/*.md` → `docs/producers/external-producers.mdx`, `spi-interface.mdx`, `spi-adapter.mdx` (converted to MDX, content unchanged)
- `docs/producers/reference.mdx` — replaced useless stub with a real index page: links to all producer pages, extended reading, CLI reference
- `docs/docs.json` — merged "Signal Producers" group into "Producers" (7-page section, one coherent group)
- `docs/dependencies-docs.md` — updated stanzas, added `tutorial-agent-producer.md` and `producer-intelligence.md` (were orphaned)
- Deleted `docs/spi/` dir
- `validate_doc_deps.sh` passes (80 files, no broken links)

## Type of change
- [x] Documentation update