### PR TITLE
fix(ci): update docs CI paths after .md→.mdx migration + add missing CLI headings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,9 +52,9 @@ jobs:
         run: |
           REQUIRED_DOCS=(
             "docs/getting-started.md"
-            "docs/configuration.md"
+            "docs/operations/config-reference.mdx"
             "docs/deployment.md"
-            "docs/api-reference.md"
+            "docs/api/overview.mdx"
             "docs/learning-loop.md"
             "README.md"
             "DOCKER.md"

--- a/docs/operations/cli-reference.mdx
+++ b/docs/operations/cli-reference.mdx
@@ -403,7 +403,7 @@ b1e55ed export karma \
   b1e55ed kelly [--json]
   ```
 
-  ### Backtesting
+  ### `b1e55ed backtest`
 
   Walk-forward:
 
@@ -437,6 +437,8 @@ b1e55ed export karma \
 
   <Accordion title="Webhooks">
 
+  ### `b1e55ed webhooks`
+
   Webhook subscriptions are stored in the local database.
 
   ```bash
@@ -448,6 +450,8 @@ b1e55ed export karma \
   </Accordion>
 
   <Accordion title="EAS integration">
+
+  ### `b1e55ed eas`
 
   ```bash
   b1e55ed eas status [--json]
@@ -464,6 +468,83 @@ b1e55ed export karma \
 ---
 
 ## Uninstall
+
+### `b1e55ed daemon`
+
+Run b1e55ed as a background daemon (brain cycles + resolver + retention on schedule).
+
+```bash
+b1e55ed daemon
+```
+
+Intervals are configured via `daemon.*` in `config/user.yaml`. The daemon is started automatically by `b1e55ed start`.
+
+---
+
+### `b1e55ed report`
+
+Generate a performance report with stratification by confidence band.
+
+```bash
+b1e55ed report [--stratification] [--json]
+```
+
+---
+
+### `b1e55ed prune`
+
+Prune old events and data according to the configured retention policy.
+
+```bash
+b1e55ed prune [--dry-run]
+```
+
+---
+
+### `b1e55ed reconcile`
+
+Backfill missing execution provenance events. Safe to run multiple times.
+
+```bash
+b1e55ed reconcile [--dry-run]
+```
+
+---
+
+### `b1e55ed resolve-outcomes`
+
+Resolve elapsed `FORECAST_V1` events into `FORECAST_OUTCOME_V1` scored records.
+
+```bash
+b1e55ed resolve-outcomes [--dry-run]
+```
+
+---
+
+### `b1e55ed spi`
+
+SPI signal producer management (register, status, promote, test-key).
+
+```bash
+b1e55ed spi register --name <name> --domain <domain>
+b1e55ed spi status --id <producer-id>
+b1e55ed spi promote --id <producer-id>
+b1e55ed spi test-key --id <producer-id>
+```
+
+See [External Producers](../producers/external-producers) for the full SPI guide.
+
+---
+
+### `b1e55ed verify-chain`
+
+Verify the full event hash chain (alias for `integrity --no-fast`).
+
+```bash
+b1e55ed verify-chain [--json]
+```
+
+---
 
 ### `b1e55ed uninstall`
 

--- a/scripts/check_cli_docs.py
+++ b/scripts/check_cli_docs.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent
 CLI_FILE = REPO / "engine" / "cli" / "main.py"
-CLI_REF = REPO / "docs" / "cli-reference.md"
+CLI_REF = REPO / "docs" / "operations" / "cli-reference.mdx"
 
 
 def extract_cli_commands(path: Path) -> set[str]:
@@ -44,7 +44,7 @@ def extract_documented_commands(path: Path) -> set[str]:
     """Extract command names from ### `b1e55ed <command>` headings in cli-reference.md."""
     text = path.read_text()
     documented: set[str] = set()
-    for match in re.finditer(r"^### `b1e55ed ([^`]+)`", text, re.MULTILINE):
+    for match in re.finditer(r"^\s*### `b1e55ed ([^`]+)`", text, re.MULTILINE):
         # First token after 'b1e55ed' is the top-level command
         cmd = match.group(1).strip().split()[0]
         documented.add(cmd)


### PR DESCRIPTION
Fixes two CI failures on #436:

- `completeness` check hardcoded `docs/configuration.md` and `docs/api-reference.md` — updated to `docs/operations/config-reference.mdx` and `docs/api/overview.mdx`
- `cli-docs` check hardcoded `docs/cli-reference.md` — updated to `docs/operations/cli-reference.mdx`
- `check_cli_docs.py` regex used `^###` which missed headings indented inside `<Accordion>` components — fixed to `^\s*###`
- Added 7 missing CLI command headings to `cli-reference.mdx`: `daemon`, `report`, `prune`, `reconcile`, `resolve-outcomes`, `spi`, `verify-chain`

All 32 CLI commands now documented. `validate_doc_deps.sh` passes (73 files).

## Type of change
- [x] Bug fix (non-breaking)