### PR TITLE
fix(attribution): graceful None return when conviction_id missing

### DIFF
--- a/engine/brain/learning.py
+++ b/engine/brain/learning.py
@@ -75,7 +75,7 @@ class LearningLoop:
     # 1) Outcome attribution
     # ---------------------------------------------------------------------
 
-    def attribute_outcome(self, position_id: str, realized_pnl: float) -> OutcomeAttribution:
+    def attribute_outcome(self, position_id: str, realized_pnl: float) -> OutcomeAttribution | None:
         row = self.db.fetchone(
             "SELECT * FROM positions WHERE id = ?",
             (str(position_id),),
@@ -85,7 +85,15 @@ class LearningLoop:
 
         conviction_id = row["conviction_id"]
         if conviction_id is None:
-            raise ValueError(f"Position {position_id} missing conviction_id")
+            # No conviction_id — position was opened outside the brain cycle (e.g. manual/test).
+            # Log and skip attribution rather than crashing; this is a soft gap not a hard error.
+            import logging as _logging
+
+            _logging.getLogger(__name__).warning(
+                "Position %s has no conviction_id — attribution skipped (ATTRIBUTION_GAP_V1)",
+                position_id,
+            )
+            return None
 
         opened_at = _parse_iso(row["opened_at"]) or utc_now()
         closed_at = _parse_iso(row["closed_at"]) or utc_now()
@@ -476,6 +484,8 @@ class LearningLoop:
 
         for r in rows:
             attr = self.attribute_outcome(str(r["position_id"]), float(r["realized_pnl"]))
+            if attr is None:
+                continue  # No conviction_id — gap already logged in attribute_outcome
             attributions.append(attr)
             # Write outcome back to conviction_scores.
             with self.db._lock, self.db.conn:

--- a/engine/integration/outcome_writer.py
+++ b/engine/integration/outcome_writer.py
@@ -37,7 +37,7 @@ def write_outcome_for_closed_position(
     db: Database,
     config: Config,
     position_id: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Compute and persist outcome attribution for a closed position."""
 
     row = db.fetchone("SELECT * FROM positions WHERE id = ?", (str(position_id),))
@@ -53,6 +53,8 @@ def write_outcome_for_closed_position(
 
     loop = LearningLoop(db=db, config=config)
     attribution = loop.attribute_outcome(position_id=str(position_id), realized_pnl=float(realized_pnl))
+    if attribution is None:
+        return None  # No conviction_id — attribution gap already logged
 
     # Write outcome back to conviction score.
     with db._lock, db.conn:


### PR DESCRIPTION
## What

Graceful handling when `conviction_id` is None (positions opened outside brain cycle).

## Changes
- `attribute_outcome()` returns `None` instead of raising `ValueError`
- `outcome_writer` propagates `None` gracefully
- Backfill loop skips attributions with no conviction_id

## Type of change
- [x] Bug fix

Supersedes #438 (clean rebase after conflict cascade from #439-#443 merges)