### PR TITLE
fix(external): SPEC_INLINE support for binary installs; inline post-fiat-signals spec

### DIFF
--- a/engine/external/base.py
+++ b/engine/external/base.py
@@ -24,7 +24,7 @@ from engine.external.confidence import normalize_confidence
 from engine.external.connector_http import HttpConnector
 from engine.external.models import ExternalObservation, RawExternalRecord
 from engine.external.policy import AdapterPolicy
-from engine.external.spec import AdapterSpec, load_spec
+from engine.external.spec import AdapterSpec, load_spec, load_spec_inline
 from engine.producers.base import BaseProducer
 
 _DIRECTION_MAP: dict[str, str] = {
@@ -51,6 +51,9 @@ class BaseExternalProducer(BaseProducer):
     #: Subclasses override with the path to their YAML spec.
     SPEC_PATH: str = ""
 
+    #: Alternative to SPEC_PATH — provide spec as an inline dict (works in binary installs)
+    SPEC_INLINE: dict | None = None
+
     # Lazily initialised.
     _spec: AdapterSpec | None = None
     _connector: HttpConnector | None = None
@@ -58,7 +61,10 @@ class BaseExternalProducer(BaseProducer):
 
     def _get_spec(self) -> AdapterSpec:
         if self._spec is None:
-            self._spec = load_spec(self.SPEC_PATH)
+            if self.SPEC_INLINE is not None:
+                self._spec = load_spec_inline(self.SPEC_INLINE)
+            else:
+                self._spec = load_spec(self.SPEC_PATH)
         return self._spec
 
     def _get_connector(self) -> HttpConnector:

--- a/engine/external/spec.py
+++ b/engine/external/spec.py
@@ -61,6 +61,25 @@ def _expand_env(value: str) -> str:
     return re.sub(r"\$\{([^}]+)\}", _replace, value)
 
 
+def _resolve_env_vars(data: Any) -> Any:
+    """Recursively expand ``${VAR}`` and ``${VAR:-default}`` in string values."""
+    if isinstance(data, dict):
+        return {k: _resolve_env_vars(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_resolve_env_vars(item) for item in data]
+    if isinstance(data, str):
+
+        def _replace(match: re.Match[str]) -> str:
+            expr = match.group(1)
+            if ":-" in expr:
+                var, default = expr.split(":-", 1)
+                return os.getenv(var, default)
+            return os.getenv(expr, match.group(0))
+
+        return re.sub(r"\$\{([^}]+)\}", _replace, data)
+    return data
+
+
 def _parse_endpoint(data: dict[str, Any] | None) -> EndpointSpec | None:
     if data is None:
         return None
@@ -119,6 +138,36 @@ def load_spec(path: str | Path) -> AdapterSpec:
         version=str(data["version"]),
         domain=data["domain"],
         base_url=base_url,
+        signals_endpoint=signals_endpoint,
+        health_endpoint=health_endpoint,
+        field_mapping=field_mapping,
+        min_confidence=float(data.get("min_confidence", 0.55)),
+        stale_threshold_sec=int(data.get("stale_threshold_sec", 300)),
+        poll_interval_sec=int(data.get("poll_interval_sec", 60)),
+        items_path=str(data.get("items_path", "")),
+    )
+
+
+def load_spec_inline(data: dict) -> AdapterSpec:
+    """Load an AdapterSpec from an inline dict (no file I/O — works in binary installs)."""
+    # Resolve env vars in string values (same as load_spec does).
+    data = _resolve_env_vars(data)
+
+    signals_ep_data = data.get("signals_endpoint")
+    if signals_ep_data is None:
+        raise ValueError("spec missing required 'signals_endpoint'")
+
+    signals_endpoint = _parse_endpoint(signals_ep_data)
+    assert signals_endpoint is not None  # noqa: S101
+
+    health_endpoint = _parse_endpoint(data.get("health_endpoint"))
+    field_mapping = _parse_field_mapping(data["field_mapping"])
+
+    return AdapterSpec(
+        name=data["name"],
+        version=str(data["version"]),
+        domain=data["domain"],
+        base_url=str(data["base_url"]),
         signals_endpoint=signals_endpoint,
         health_endpoint=health_endpoint,
         field_mapping=field_mapping,

--- a/engine/producers/post_fiat_signals.py
+++ b/engine/producers/post_fiat_signals.py
@@ -27,7 +27,41 @@ class PostFiatSignalsProducer(BaseExternalProducer):
     domain = "tradfi"
     schedule = "* * * * *"  # poll every minute; controlled by poll_interval_sec in spec
 
-    SPEC_PATH = "engine/external/specs/post_fiat_signals.yaml"
+    SPEC_PATH = ""  # not used — see SPEC_INLINE
+    SPEC_INLINE = {
+        "name": "post-fiat-signals",
+        "version": "1.0.0",
+        "domain": "tradfi",
+        "base_url": "${POST_FIAT_SIGNALS_URL:-http://84.32.34.46:8080}",
+        "poll_interval_sec": 60,
+        "min_confidence": 0.55,
+        "stale_threshold_sec": 300,
+        "health_endpoint": {
+            "path": "/health",
+            "method": "GET",
+            "timeout_sec": 5,
+        },
+        "signals_endpoint": {
+            "path": "/signals/filtered",
+            "method": "GET",
+            "params": {"filter": "ACTIONABLE"},
+            "timeout_sec": 10,
+        },
+        "items_path": "signals",
+        "field_mapping": {
+            "symbol": "ticker",
+            "direction": "action",
+            "confidence": "confidence",
+            "horizon_hours": "168",
+            "observed_at": "timestamp",
+            "regime": "regime",
+            "signal_type": "signal_type",
+            "hit_rate": "hit_rate",
+            "avg_return": "avg_return",
+            "is_stale": "is_stale",
+            "source_assertion": "action",
+        },
+    }
 
     def normalize(self, raw: RawExternalRecord) -> list[ExternalObservation]:  # type: ignore[override]
         """Parse post-fiat-signals response into ExternalObservations.


### PR DESCRIPTION
## Summary

Adds `SPEC_INLINE` dict support to `BaseExternalProducer` so producers work without filesystem YAML files (binary installs, packed distributions).

## Changes

### `engine/external/spec.py`
- Add `_resolve_env_vars(data)` — recursive helper that expands `${VAR}` and `${VAR:-default}` patterns via `os.getenv`
- Add `load_spec_inline(data: dict) -> AdapterSpec` — builds an `AdapterSpec` from an inline dict with env-var expansion; no file I/O

### `engine/external/base.py`
- Add class variable `SPEC_INLINE: dict | None = None`
- Update `_get_spec()` to prefer `load_spec_inline(self.SPEC_INLINE)` when set, falling back to `load_spec(self.SPEC_PATH)`

### `engine/producers/post_fiat_signals.py`
- Replace `SPEC_PATH = "engine/external/specs/post_fiat_signals.yaml"` with an inline dict via `SPEC_INLINE`
- Base URL respects `${POST_FIAT_SIGNALS_URL:-http://84.32.34.46:8080}` env override

## Tests
1477 passed, 2 skipped — no regressions.