### PR TITLE
fix(ta,external): Yahoo Finance candle feed for equities; graceful degradation on endpoint unavailability

### DIFF
--- a/docs/b1e55ing-manifest.json
+++ b/docs/b1e55ing-manifest.json
@@ -1,0 +1,25 @@
+{
+  "version": "1",
+  "eggs": [
+    {
+      "id": "egg_ca3af7d9",
+      "file": "engine/producers/ta.py",
+      "anchor": "def _fetch_yahoo_candles(sym: str, interval: str = \"1h\", limit: int = 200) -> list[float]:",
+      "tradition": "chesterton-fence",
+      "content": "# Chesterton's Fence: Yahoo Finance has served free market data since 1996.\n# Before you call it legacy, ask why it still answers the call when every premium feed goes dark.",
+      "placement": "before_function",
+      "pr_number": 450,
+      "applied_at": "2026-03-17T23:35:15Z"
+    },
+    {
+      "id": "egg_5e1c0b99",
+      "file": "engine/external/base.py",
+      "anchor": "Provides the fetch",
+      "tradition": "type-i-error",
+      "content": "Type I error: treating a ConnectTimeout as a producer failure is a false positive.\nThe producer is healthy. The endpoint blinked. The system must know the difference.",
+      "placement": "module_docstring",
+      "pr_number": 450,
+      "applied_at": "2026-03-17T23:35:15Z"
+    }
+  ]
+}

--- a/engine/external/base.py
+++ b/engine/external/base.py
@@ -2,6 +2,9 @@
 
 Provides the fetch → normalize → policy-filter → emit pipeline for
 any external signal source wired via an adapter spec.
+
+Type I error: treating a ConnectTimeout as a producer failure is a false positive.
+The producer is healthy. The endpoint blinked. The system must know the difference.
 """
 
 from __future__ import annotations

--- a/engine/producers/ta.py
+++ b/engine/producers/ta.py
@@ -363,6 +363,8 @@ class TechnicalAnalysisProducer(BaseProducer):
         }
 
     @staticmethod
+    # Chesterton's Fence: Yahoo Finance has served free market data since 1996.
+    # Before you call it legacy, ask why it still answers the call when every premium feed goes dark.
     def _fetch_yahoo_candles(sym: str, interval: str = "1h", limit: int = 200) -> list[float]:
         """Fetch hourly close prices from Yahoo Finance for a given ticker.
 


### PR DESCRIPTION
## Summary

### Bug 1: TA producer — Yahoo Finance candle feed for equities

Symbols like `AAPL`, `TSLA`, `NVDA` from `hl-tradfi-perps` bundle were silently skipped (Binance returns 400, no fallback existed).

**Changes:**
- Extended `_BINANCE_MISSING` to include 11 individual equity tickers (AAPL, TSLA, NVDA, AMZN, GOOGL, META, MSFT, NFLX, AMD, COIN, MSTR, PLTR)
- Added `_fetch_yahoo_candles(sym, interval, limit)` static method — fetches hourly closes from Yahoo Finance v8 API, graceful `[]` on any failure
- Updated `_collect_free` routing: TradFiFeed for ETFs as before; Yahoo Finance fallback for individual equities (and when TradFiFeed fails); logs `ta_yahoo_symbol symbol={sym}` on success
- Requires ≥20 closes to compute TA (avoids noise on thin data)

### Bug 2: BaseExternalProducer — graceful degradation on endpoint unavailability

`ConnectError`/`ConnectTimeout`/`ReadTimeout` were counting toward consecutive_failures and triggering quarantine after 5 hits. This was wrong for optional external endpoints (post-fiat-signals, etc.) that may be temporarily down.

**Changes in `engine/external/base.py`:**
- Added `import httpx`
- `collect()`: catches `httpx.ConnectError`, `ConnectTimeout`, `ReadTimeout` specifically; logs at INFO as `no_source_available` and re-raises
- `run()`: catches those re-raised connection errors and returns `ProducerHealth.OK` (no failure counter increment)
- HTTP 4xx/5xx and parse errors still count as real failures

## Test Results
`1477 passed, 2 skipped` — all clean.