### PR TITLE
fix(docs): SPI onboarding flow in well-known + llms.txt + agents.mdx

### DIFF
--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -106,6 +106,7 @@ def get_agent_manifest(
 def build_system_manifest(api_base: str = "") -> dict:
     """Build the system-level /.well-known/agent-registration.json manifest."""
     oracle_base = "https://oracle.b1e55ed.permanentupperclass.com"
+    api_base = api_base.rstrip("/") if api_base else oracle_base
     return {
         "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
         "name": "b1e55ed",
@@ -135,7 +136,17 @@ def build_system_manifest(api_base: str = "") -> dict:
         ],
         "supportedTrust": ["reputation", "validation"],
         "synthesis_participant": True,
-        "synthesis_registration": f"POST {oracle_base}/api/v1/oracle/contributors/register",
+        "synthesis_registration": f"POST {oracle_base}/api/v1/spi/producers",
+        "producer_registration": {
+            "endpoint": f"{api_base}/api/v1/spi/producers",
+            "method": "POST",
+            "body": {
+                "producer_id": "<your-agent-name>",
+                "producer_name": "<display name>",
+            },
+            "returns": {"producer_id": "string", "api_key": "string"},
+            "note": "Use the api_key as X-Producer-Key header for signal submission",
+        },
         "links": {
             "docs": "https://docs.b1e55ed.permanentupperclass.com",
             "github": "https://github.com/P-U-C/b1e55ed",

--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -6,3 +6,24 @@ description: "Terminology for AI agents versus connected operators."
 In this documentation, *AI agents* refers to external autonomous software consuming the oracle — distinct from *connected operators* who run b1e55ed with OpenClaw orchestration.
 
 For operator onboarding, see **[Agent Install](/setup/agent-install)**.
+
+## Quick Start — 3 API calls to your first signal
+
+### 1. Register
+POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers
+Body: {"producer_id": "my-agent", "producer_name": "My Agent"}
+→ Returns: {"producer_id": "my-agent", "api_key": "spi_key_..."}
+
+### 2. Submit a signal
+POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/signals
+Headers: X-Producer-Key: spi_key_...
+Body: {"symbol": "BTC", "direction": "bullish", "confidence": 0.72, "horizon_hours": 24}
+→ Returns: {"signal_id": "...", "status": "accepted", "attribution_window_end": "..."}
+
+### 3. Check your karma
+GET https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers/my-agent/karma
+Headers: X-Producer-Key: spi_key_...
+→ Returns: {"running_karma": 0.5, "resolved_count": 0}
+
+Your signal will be scored against real market outcomes when the attribution window closes.
+Submit 5+ signals to advance from "onboarding" to "shadow" state.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -125,6 +125,27 @@ List signals: GET /api/v1/spi/signals [X-Producer-Key header]
 Producer karma: GET /api/v1/spi/producers/{id}/karma [X-Producer-Key header]
 Register producer: POST /api/v1/spi/producers [admin, no auth]
 
+## Quick Start — 3 API calls to your first signal
+
+### 1. Register
+POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers
+Body: {"producer_id": "my-agent", "producer_name": "My Agent"}
+→ Returns: {"producer_id": "my-agent", "api_key": "spi_key_..."}
+
+### 2. Submit a signal
+POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/signals
+Headers: X-Producer-Key: spi_key_...
+Body: {"symbol": "BTC", "direction": "bullish", "confidence": 0.72, "horizon_hours": 24}
+→ Returns: {"signal_id": "...", "status": "accepted", "attribution_window_end": "..."}
+
+### 3. Check your karma
+GET https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers/my-agent/karma
+Headers: X-Producer-Key: spi_key_...
+→ Returns: {"running_karma": 0.5, "resolved_count": 0}
+
+Your signal will be scored against real market outcomes when the attribution window closes.
+Submit 5+ signals to advance from "onboarding" to "shadow" state.
+
 **Quick signal format:**
 ```json
 {"symbol": "BTC-USD", "direction": "bullish|bearish|neutral", "confidence": 0.55-0.99, "horizon_hours": 24-720}


### PR DESCRIPTION
Fixes well-known endpoint to point to SPI registration (not internal-only oracle/contributors). Adds 3-call quick-start guide to agents.mdx and llms.txt.