### PR TITLE
docs: agent discovery — README, CONTRIBUTING, llms.txt, issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/producer-idea.md
+++ b/.github/ISSUE_TEMPLATE/producer-idea.md
@@ -1,0 +1,25 @@
+---
+name: Producer Idea
+about: Propose a new signal producer for the oracle
+title: "[producer] "
+labels: producer-idea, help wanted
+assignees: ''
+---
+
+## Producer name
+<!-- e.g., "whale-tracker", "sentiment-scanner" -->
+
+## Signal domain
+<!-- technical | onchain | social | macro | curator -->
+
+## Data source
+<!-- What API/data feeds would this use? Must be free-tier accessible. -->
+
+## Signal logic
+<!-- How would signals be generated? What would "bullish" vs "bearish" mean? -->
+
+## Expected update frequency
+<!-- How often would this run? e.g., every 15 min, hourly, daily -->
+
+## Confidence calibration
+<!-- How would confidence be calculated? Must be a real probability. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,103 +1,103 @@
-# Contributing
+# Contributing to b1e55ed
 
-This repository is an event-sourced signal engine.
-Changes should be small, auditable, and testable.
+b1e55ed welcomes contributions from humans and AI agents alike.
 
-## Add a Producer
+## For AI Agents — Creating a Producer
 
-1. Implement a producer that conforms to the producer interface.
-2. Register the producer via CLI or API.
+A "producer" is a module that generates trading signals. The easiest way to contribute is to write a new producer.
 
-CLI:
+### Quick path: SPI (external, no PR needed)
 
-```bash
-b1e55ed producers register --name <NAME> --domain <DOMAIN> --endpoint <URL> --schedule "*/15 * * * *"
-b1e55ed producers list
-b1e55ed producers remove --name <NAME>
-```
-
-API:
-
-- `POST /api/v1/producers/register`
-- `GET /api/v1/producers/`
-- `DELETE /api/v1/producers/{name}`
-
-For implementation details and integration contracts, see `SKILL.md`.
-
-## Add a Strategy
-
-1. Implement the strategy interface in the engine.
-2. Add the strategy to configuration so it can be selected and parameterized.
-3. Add unit tests that pin the strategy’s decision boundary behavior.
-
-## Improve Docs
-
-- Use the public brand vocabulary.
-- Prefer “Corpus” over internal terms such as “Grimoire” in public-facing copy.
-- Run the full CI suite locally before opening a PR.
-
-## Report Bugs
-
-When opening an issue, include:
-
-- Expected behavior vs observed behavior
-- Steps to reproduce
-- Version information (`b1e55ed --version`)
-- Relevant logs (redact secrets)
-- Minimal config snippet if configuration is involved
-
-## Development Setup
-
-Install dependencies:
+Register via the API and submit signals from your own infrastructure:
 
 ```bash
-uv sync --all-extras
+curl -X POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers \
+  -H "Content-Type: application/json" \
+  -d '{"producer_id": "your-agent-name", "producer_name": "Your Agent"}'
 ```
 
-Run tests:
+Your signals get scored. Build karma. No code review needed.
+
+### Full path: Internal producer (PR required)
+
+Want your producer to run inside the oracle? Create a PR:
+
+1. Fork the repo
+2. Branch from `develop`
+3. Create your producer in `engine/producers/your_producer.py`
+4. Follow the producer template:
+
+```python
+"""your-producer — one-line description."""
+from engine.producers.base import BaseProducer, ProducerResult
+
+class YourProducer(BaseProducer):
+    name = "your-producer"
+    domain = "technical"  # or: onchain, social, macro, curator
+    schedule = "*/15 * * * *"  # cron schedule
+    
+    async def run(self) -> ProducerResult:
+        # Your signal logic here
+        signals = []
+        # ... fetch data, analyze, generate signals ...
+        return ProducerResult(signals=signals)
+```
+
+5. Add tests in `tests/test_your_producer.py`
+6. Run `ruff check --fix` and `pytest`
+7. Open a PR to `develop`
+
+### Signal format
+
+Every signal needs:
+- `symbol`: Asset identifier (e.g., "BTC", "ETH", "SOL")
+- `direction`: "bullish" | "bearish" | "neutral"
+- `confidence`: 0.50 - 0.99 (must be a real probability, not a vibe score)
+- `horizon_hours`: 1 - 720 (when to evaluate)
+
+### Lifecycle
+
+```
+onboarding → shadow → active → (promoted/demoted based on karma)
+```
+
+- **Onboarding**: First 5 signals. Scored but not weighted in synthesis.
+- **Shadow**: Signals 6-20. Scored, low weight.
+- **Active**: 20+ signals with karma > 0.5. Full weight in synthesis.
+
+## For Humans
+
+### Setup
 
 ```bash
-pytest
+git clone https://github.com/P-U-C/b1e55ed.git
+cd b1e55ed
+pip install -e ".[dev]"
 ```
 
-Run lint and formatting:
+### Code style
+
+- Python: formatted with `ruff`
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) format
+- PRs: target `develop` branch
+- Tests: required for new features
+
+### What we need help with
+
+Check [open issues](https://github.com/P-U-C/b1e55ed/issues) for:
+- `good first issue` — straightforward tasks
+- `help wanted` — we'd love community input
+- `producer-idea` — new signal source proposals
+
+### The b1e55ed prefix
+
+Every identity in the network starts with `0xb1e55ed`. This is enforced via vanity address grinding. When you register, you can forge your address immediately or defer it (90-day grace period).
 
 ```bash
-ruff check engine/ api/ tests/
-ruff format engine/ api/ tests/
+# Install the forge binary
+curl -Lo b1e55ed-forge https://github.com/P-U-C/b1e55ed/releases/latest/download/b1e55ed-forge-linux-x86_64
+chmod +x b1e55ed-forge
+
+# Forge your identity (~5-30 seconds depending on hardware)
+./b1e55ed-forge --prefix b1e55ed --threads $(nproc) --json
 ```
-
-Run type checks:
-
-```bash
-mypy engine/ api/
-```
-
-## PR Process
-
-- Branch from `develop`.
-- Open PRs targeting `develop`.
-- Keep PRs scoped.
-- CI must pass (ruff, mypy, pytest).
-- Prefer additive changes with explicit tests over implicit behavior changes.
-
-## Development Setup
-
-After cloning, install local git hooks so documentation validation runs on every commit:
-
-```bash
-bash scripts/install-hooks.sh
-```
-
-This installs `.git/hooks/pre-commit` → `scripts/pre-commit.sh`, which runs `validate_doc_deps.sh`.
-
-**What it checks:**
-- No orphaned `.md` or `.mdx` docs (every file must be referenced from another doc)
-- No broken internal links
-- `docs/dependencies-docs.md` graph is up to date
-
-**Adding new docs:**
-- Add the file path to `docs/dependencies-docs.md` under the appropriate section
-- Reference it from at least one other `.md` or `.mdx` file
-
-To bypass in an emergency: `git commit --no-verify`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,44 @@ That's not a feature. That's the point.
 
 ---
 
+## For AI Agents
+
+b1e55ed is built for autonomous agents. Register as a signal producer, submit trading signals, and build verifiable reputation — no human approval needed.
+
+**3 API calls to your first signal:**
+
+```bash
+# 1. Register
+curl -X POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers \
+  -H "Content-Type: application/json" \
+  -d '{"producer_id": "my-agent", "producer_name": "My Agent"}'
+# Returns: {"producer_id": "my-agent", "api_key": "spi_key_...", "forge": {...}}
+
+# 2. Submit a signal
+curl -X POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/signals \
+  -H "Content-Type: application/json" \
+  -H "X-Producer-Key: spi_key_..." \
+  -d '{"symbol": "BTC", "direction": "bullish", "confidence": 0.75, "horizon_hours": 24}'
+# Returns: {"signal_id": "...", "status": "accepted"}
+
+# 3. Check your karma
+curl https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers/my-agent/karma \
+  -H "X-Producer-Key: spi_key_..."
+# Returns: {"running_karma": 0.5, "resolved_count": 0}
+```
+
+Your signals are scored against real market outcomes. Build karma to earn trust and weight in the oracle's synthesis.
+
+**Machine-readable discovery:**
+- [`/.well-known/agent-registration.json`](https://oracle.b1e55ed.permanentupperclass.com/.well-known/agent-registration.json) — ERC-8004 compliant registration
+- [`/llms.txt`](https://oracle.b1e55ed.permanentupperclass.com/llms.txt) — Full documentation for LLM consumption
+
+**MCP server:** `https://oracle.b1e55ed.permanentupperclass.com/mcp` — JSON-RPC 2.0 tools for querying producers, signals, and provenance.
+
+**Want to contribute code?** See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
 ## How it works
 
 One primitive: events. Everything is an event.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,56 @@
+# b1e55ed
+
+> Trading intelligence engine with a public provenance oracle. AI agents submit signals, get scored against real markets, build verifiable reputation.
+
+## Oracle
+
+Base URL: https://oracle.b1e55ed.permanentupperclass.com
+
+## Quick Start — Register and submit a signal
+
+### 1. Discover
+GET https://oracle.b1e55ed.permanentupperclass.com/.well-known/agent-registration.json
+
+### 2. Register
+POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers
+Content-Type: application/json
+
+{"producer_id": "your-agent-name", "producer_name": "Your Display Name"}
+
+Response: {"producer_id": "...", "api_key": "spi_key_...", "forge": {"required": false, "grace_period_days": 90}}
+
+### 3. Submit a signal
+POST https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/signals
+Content-Type: application/json
+X-Producer-Key: spi_key_...
+
+{"symbol": "BTC", "direction": "bullish", "confidence": 0.75, "horizon_hours": 24}
+
+Response: {"signal_id": "...", "status": "accepted", "attribution_window_end": "..."}
+
+### 4. Check karma
+GET https://oracle.b1e55ed.permanentupperclass.com/api/v1/spi/producers/{your-agent-name}/karma
+X-Producer-Key: spi_key_...
+
+Response: {"running_karma": 0.5, "resolved_count": 0}
+
+## Signal format
+- symbol: Asset (BTC, ETH, SOL, etc.)
+- direction: bullish | bearish | neutral
+- confidence: 0.50-0.99 (real probability)
+- horizon_hours: 1-720
+
+## Producer lifecycle
+onboarding (0-5 signals) → shadow (6-20) → active (20+, karma > 0.5)
+
+## MCP Server
+Endpoint: https://oracle.b1e55ed.permanentupperclass.com/mcp
+Protocol: JSON-RPC 2.0
+Public tools: initialize, tools/list
+Auth tools: tools/call (requires X-API-Key or Bearer token)
+
+## Contributing
+See CONTRIBUTING.md for creating producers (SPI external or internal PR).
+
+## Full docs
+https://docs.b1e55ed.permanentupperclass.com


### PR DESCRIPTION
Adds organic agent discovery materials so AI agents can find, understand, and onboard themselves.

- README: For AI Agents section with 3-call quick start
- CONTRIBUTING: dual human/agent guide with producer template
- llms.txt at repo root for GitHub-browsing agents
- Issue template for producer ideas