### PR TITLE
docs: add vanity contract addresses to introduction

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -72,8 +72,15 @@ Identity forging and attestations are optional for a local-first setup, but they
 
 b1e55ed is registered as [Agent #28362](https://basescan.org/nft/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432/28362) on the ERC-8004 Identity Registry (Base mainnet). Signal producers build portable, verifiable reputation on-chain:
 
-- **ReputationRegistry** — karma scores (hit rate, calibration, consistency) anchored on-chain
-- **ValidationRegistry** — independent verification of signal outcomes against market data
+- **ReputationRegistry** [`0xb1E55ED5...`](https://basescan.org/address/0xb1E55ED55ac94dB9a725D6263b15B286a82f0f46) — karma scores (hit rate, calibration, consistency) anchored on-chain
+- **ValidationRegistry** [`0xB1e55EDC...`](https://basescan.org/address/0xB1e55EDC8fFdd6f16e6600dEb05d364a88152D3A) — independent verification of signal outcomes against market data
+
+| Contract | Address | Chain |
+|----------|---------|-------|
+| Identity Registry (ERC-8004) | [`0x8004A169...`](https://basescan.org/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) | Base mainnet |
+| ReputationRegistry | [`0xb1E55ED5...`](https://basescan.org/address/0xb1E55ED55ac94dB9a725D6263b15B286a82f0f46) | Base mainnet |
+| ValidationRegistry | [`0xB1e55EDC...`](https://basescan.org/address/0xB1e55EDC8fFdd6f16e6600dEb05d364a88152D3A) | Base mainnet |
+| Oracle Wallet | [`0xB1e55EdD...`](https://basescan.org/address/0xB1e55EdD3176Ce9C9aF28F15b79e0c0eb8Fe51AA) | Base mainnet |
 
 This means "this agent is good at trading" becomes a verifiable claim, not marketing.
 


### PR DESCRIPTION
Adds contract address table to the ERC-8004 section in the introduction docs.

All four addresses now start with `0xb1e55ed`:
- ReputationRegistry: `0xb1E55ED55ac94dB9a725D6263b15B286a82f0f46`
- ValidationRegistry: `0xB1e55EDC8fFdd6f16e6600dEb05d364a88152D3A`
- Oracle Wallet: `0xB1e55EdD3176Ce9C9aF28F15b79e0c0eb8Fe51AA`