### PR TITLE
feat: public read-only positions endpoint for judges

### DIFF
--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -46,6 +46,7 @@ def get_api_router() -> APIRouter:
     router.include_router(events.router, tags=["events"])
     router.include_router(signals.router, tags=["signals"])
     router.include_router(signals_validate.router, tags=["signals"])
+    router.include_router(positions.public_router, tags=["positions"])
     router.include_router(positions.router, tags=["positions"])
     router.include_router(regime.router, tags=["regime"])
     router.include_router(producers.router, tags=["producers"])

--- a/api/routes/positions.py
+++ b/api/routes/positions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Path, Query
 from pydantic import BaseModel
@@ -8,10 +8,16 @@ from pydantic import BaseModel
 from api.auth import AuthDep
 from api.deps import get_config, get_db
 from api.errors import B1e55edError
-from api.schemas.positions import PositionResponse
+from api.schemas.positions import (
+    PositionResponse,
+    PublicPositionResponse,
+    PublicPositionsResponse,
+    PublicPositionsSummaryResponse,
+)
 from engine.core.config import Config
 from engine.core.database import Database
 
+public_router = APIRouter(prefix="/positions")
 router = APIRouter(prefix="/positions", dependencies=[AuthDep])
 
 
@@ -49,6 +55,55 @@ def _row_to_position(r) -> PositionResponse:
     )
 
 
+_OPEN_POSITION_STATUSES = {"open", "monitoring", "degrading", "closing"}
+
+
+def _to_utc(ts: datetime | None) -> datetime | None:
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts.astimezone(UTC)
+
+
+def _row_to_public_position(r) -> PublicPositionResponse:
+    opened_at = _to_utc(_parse_dt(str(r[7]))) or datetime.fromtimestamp(0, tz=UTC)
+    closed_at = _to_utc(_parse_dt(str(r[8]))) if r[8] is not None else None
+
+    return PublicPositionResponse(
+        id=str(r[0]),
+        asset=str(r[1]),
+        direction=str(r[2]),
+        entry_price=float(r[3]),
+        size_notional=float(r[4]),
+        stop_loss=float(r[5]) if r[5] is not None else None,
+        take_profit=float(r[6]) if r[6] is not None else None,
+        opened_at=opened_at,
+        closed_at=closed_at,
+        status=str(r[9]),
+        realized_pnl=float(r[10]) if r[10] is not None else None,
+        regime_at_entry=str(r[11]) if r[11] is not None else None,
+        pcs_at_entry=float(r[12]) if r[12] is not None else None,
+    )
+
+
+def _build_public_positions_summary(positions: list[PublicPositionResponse]) -> PublicPositionsSummaryResponse:
+    open_count = sum(1 for p in positions if p.status in _OPEN_POSITION_STATUSES)
+    closed_positions = [p for p in positions if p.status not in _OPEN_POSITION_STATUSES]
+
+    net_pnl = sum(float(p.realized_pnl or 0.0) for p in closed_positions)
+    wins = sum(1 for p in closed_positions if p.realized_pnl is not None and p.realized_pnl > 0)
+    closed_count = len(closed_positions)
+
+    return PublicPositionsSummaryResponse(
+        total_positions=len(positions),
+        open=open_count,
+        closed=closed_count,
+        net_pnl=float(net_pnl),
+        win_rate=float(wins / closed_count) if closed_count else 0.0,
+    )
+
+
 def _fetch_row(db: Database, position_id: str):
     return db.execute(
         """
@@ -61,6 +116,45 @@ def _fetch_row(db: Database, position_id: str):
         """,
         (position_id,),
     ).fetchone()
+
+
+@public_router.get("/public", response_model=PublicPositionsResponse)
+def list_public_positions(
+    db: Database = Depends(get_db),
+    config: Config = Depends(get_config),
+) -> PublicPositionsResponse:
+    """Read-only public view of paper-trading positions for external verification."""
+
+    rows = db.execute(
+        """
+        SELECT id, asset, direction, entry_price, size_notional,
+               stop_loss, take_profit, opened_at, closed_at,
+               status, realized_pnl, regime_at_entry, pcs_at_entry
+        FROM positions
+        WHERE platform = 'paper'
+        ORDER BY opened_at DESC
+        """
+    ).fetchall()
+
+    cutoff = datetime.now(tz=UTC) - timedelta(days=7)
+
+    public_positions: list[PublicPositionResponse] = []
+    for row in rows:
+        position = _row_to_public_position(row)
+        if position.status in _OPEN_POSITION_STATUSES:
+            public_positions.append(position)
+            continue
+
+        closed_at = _to_utc(position.closed_at)
+        if closed_at is not None and closed_at >= cutoff:
+            public_positions.append(position)
+
+    return PublicPositionsResponse(
+        mode="paper",
+        start_balance=float(config.execution.paper_start_balance),
+        positions=public_positions,
+        summary=_build_public_positions_summary(public_positions),
+    )
 
 
 @router.get("", response_model=list[PositionResponse])

--- a/api/schemas/positions.py
+++ b/api/schemas/positions.py
@@ -24,3 +24,36 @@ class PositionResponse(BaseModel):
     regime_at_entry: str | None = None
     pcs_at_entry: float | None = None
     cts_at_entry: float | None = None
+
+
+class PublicPositionResponse(BaseModel):
+    """Redacted, read-only view used by the public judges endpoint."""
+
+    id: str
+    asset: str
+    direction: str
+    entry_price: float
+    size_notional: float
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    opened_at: datetime
+    closed_at: datetime | None = None
+    status: str
+    realized_pnl: float | None = None
+    regime_at_entry: str | None = None
+    pcs_at_entry: float | None = None
+
+
+class PublicPositionsSummaryResponse(BaseModel):
+    total_positions: int
+    open: int
+    closed: int
+    net_pnl: float
+    win_rate: float
+
+
+class PublicPositionsResponse(BaseModel):
+    mode: str
+    start_balance: float
+    positions: list[PublicPositionResponse]
+    summary: PublicPositionsSummaryResponse

--- a/tests/unit/test_api_positions.py
+++ b/tests/unit/test_api_positions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from api.main import create_app
@@ -30,6 +32,50 @@ def _insert_position(db: Database, pos_id: str = "pos-1", status: str = "open", 
         )
 
 
+def _insert_public_position(
+    db: Database,
+    pos_id: str,
+    *,
+    status: str,
+    closed_days_ago: int | None = None,
+    realized_pnl: float | None = None,
+    platform: str = "paper",
+) -> None:
+    now = datetime.now(tz=UTC)
+    opened_at = now - timedelta(days=1)
+    closed_at = now - timedelta(days=closed_days_ago) if closed_days_ago is not None else None
+
+    with db.conn:
+        db.conn.execute(
+            """
+            INSERT INTO positions (
+                id, platform, asset, direction, entry_price, size_notional, leverage, margin_type,
+                stop_loss, take_profit, opened_at, closed_at, status, realized_pnl,
+                regime_at_entry, pcs_at_entry
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                pos_id,
+                platform,
+                "ETH",
+                "long",
+                2184.28,
+                604.85,
+                1.0,
+                "isolated",
+                2074.03,
+                2401.51,
+                opened_at.isoformat(),
+                closed_at.isoformat() if closed_at is not None else None,
+                status,
+                realized_pnl,
+                "BEAR",
+                58.83,
+            ),
+        )
+
+
 @pytest.mark.anyio
 async def test_positions_list_and_get(temp_dir, test_config):
     app, db = _make_app(temp_dir, test_config)
@@ -45,6 +91,54 @@ async def test_positions_list_and_get(temp_dir, test_config):
         r2 = await ac.get("/api/v1/positions/pos-1", headers=HEADERS)
         assert r2.status_code == 200
         assert r2.json()["asset"] == "BTC"
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_public_positions_endpoint_returns_200_without_auth(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_public_position(db, "open-1", status="open")
+    _insert_public_position(db, "closed-recent", status="closed", closed_days_ago=2, realized_pnl=-30.5)
+    _insert_public_position(db, "closed-old", status="closed", closed_days_ago=8, realized_pnl=5.0)
+    _insert_public_position(db, "live-open", status="open", platform="live")
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/positions/public")
+        assert r.status_code == 200
+        data = r.json()
+
+    assert data["mode"] == "paper"
+    assert data["start_balance"] == pytest.approx(test_config.execution.paper_start_balance)
+
+    ids = {item["id"] for item in data["positions"]}
+    assert ids == {"open-1", "closed-recent"}
+
+    for item in data["positions"]:
+        assert "platform" not in item
+        assert "leverage" not in item
+        assert "margin_type" not in item
+
+    db.close()
+
+
+@pytest.mark.anyio
+async def test_public_positions_summary_stats_are_computed(temp_dir, test_config):
+    app, db = _make_app(temp_dir, test_config)
+    _insert_public_position(db, "open-1", status="open")
+    _insert_public_position(db, "win-1", status="closed", closed_days_ago=1, realized_pnl=50.0)
+    _insert_public_position(db, "loss-1", status="closed", closed_days_ago=2, realized_pnl=-20.0)
+
+    async with make_client(app) as ac:
+        r = await ac.get("/api/v1/positions/public")
+        assert r.status_code == 200
+        summary = r.json()["summary"]
+
+    assert summary["total_positions"] == 3
+    assert summary["open"] == 1
+    assert summary["closed"] == 2
+    assert summary["net_pnl"] == pytest.approx(30.0)
+    assert summary["win_rate"] == pytest.approx(0.5)
 
     db.close()
 


### PR DESCRIPTION
## Summary
- add a new unauthenticated `GET /api/v1/positions/public` endpoint for hackathon verification
- return paper-mode positions (open + recently closed within 7 days) using a redacted public schema
- compute and return summary stats: total/open/closed/net_pnl/win_rate
- register the public positions router before authenticated positions routes

## Testing
- `pytest tests/unit/test_api_positions.py`
- `pytest tests/unit/test_api_auth.py`
- `ruff check api/routes/positions.py api/schemas/positions.py tests/unit/test_api_positions.py api/routes/__init__.py`