### PR TITLE
fix: run SPI signal resolution in brain cycle

### DIFF
--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -761,5 +761,20 @@ class BrainOrchestrator:
             intents=intents,
         )
 
+        # Resolve expired SPI signals
+        try:
+            from engine.spi.resolution import resolve_expired_signals
+
+            spi_outcomes = resolve_expired_signals(self.db)
+            if spi_outcomes:
+                logging.getLogger("b1e55ed.orchestrator").info(
+                    "SPI resolution: %d outcomes (%d resolved, %d expired)",
+                    len(spi_outcomes),
+                    sum(1 for o in spi_outcomes if o.status == "resolved"),
+                    sum(1 for o in spi_outcomes if o.status == "expired"),
+                )
+        except Exception:
+            logging.getLogger("b1e55ed.orchestrator").debug("SPI resolution skipped (non-fatal)", exc_info=True)
+
         self.hooks.post_cycle(PostCycleContext(config=self.config, db=self.db, cycle_id=cycle_id, result=result))
         return result

--- a/tests/test_spi_resolution_in_brain_cycle.py
+++ b/tests/test_spi_resolution_in_brain_cycle.py
@@ -1,0 +1,74 @@
+"""Test that SPI signal resolution runs inside the brain cycle."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from engine.brain.orchestrator import BrainOrchestrator  # noqa: E402
+
+
+def test_run_cycle_source_calls_resolve_expired_signals():
+    """Verify the orchestrator source code invokes resolve_expired_signals."""
+    source = inspect.getsource(BrainOrchestrator.run_cycle)
+    assert "resolve_expired_signals" in source, "run_cycle must call resolve_expired_signals from engine.spi.resolution"
+    # Wrapped in try/except so it never kills the cycle
+    assert "except Exception" in source
+
+
+def test_resolve_expired_signals_called_with_db(tmp_path):
+    """Full run_cycle invokes resolve_expired_signals(self.db)."""
+    from engine.brain.kill_switch import KillSwitchLevel
+    from engine.core.config import Config
+    from engine.core.database import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    config = Config.from_repo_defaults(repo_root=ROOT)
+    identity = MagicMock()
+    identity.node_id = "test-node"
+
+    orch = BrainOrchestrator(config=config, db=db, identity=identity)
+    # Force kill switch level to CLEAR so cycle proceeds
+    orch.kill_switch._level = KillSwitchLevel(0)
+
+    mock_resolve = MagicMock(
+        return_value=[
+            SimpleNamespace(status="resolved"),
+            SimpleNamespace(status="expired"),
+        ]
+    )
+    with patch("engine.spi.resolution.resolve_expired_signals", mock_resolve):
+        result = orch.run_cycle(symbols=["BTC"])
+
+    mock_resolve.assert_called_once_with(db)
+    assert result is not None
+
+
+def test_run_cycle_survives_spi_resolution_failure(tmp_path):
+    """If resolve_expired_signals raises, the cycle must still complete."""
+    from engine.brain.kill_switch import KillSwitchLevel
+    from engine.core.config import Config
+    from engine.core.database import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    config = Config.from_repo_defaults(repo_root=ROOT)
+    identity = MagicMock()
+    identity.node_id = "test-node"
+
+    orch = BrainOrchestrator(config=config, db=db, identity=identity)
+    orch.kill_switch._level = KillSwitchLevel(0)
+
+    mock_resolve = MagicMock(side_effect=RuntimeError("db exploded"))
+    with patch("engine.spi.resolution.resolve_expired_signals", mock_resolve):
+        result = orch.run_cycle(symbols=["BTC"])
+
+    # Cycle still completes
+    assert result is not None
+    assert result.cycle_id is not None


### PR DESCRIPTION
## Problem

SPI signals submitted via the API never get resolved unless someone manually runs `b1e55ed resolve-outcomes`. The brain daemon cycle (`run_cycle()`) does not call `resolve_expired_signals()`.

## Fix

Added `resolve_expired_signals(self.db)` at the end of `run_cycle()` in `engine/brain/orchestrator.py`, right before `post_cycle` hooks.

- Wrapped in `try/except` so SPI failures **never** kill the brain cycle
- Logs resolution results at INFO level (resolved + expired counts)
- Failures logged at DEBUG with traceback

## Tests

`tests/test_spi_resolution_in_brain_cycle.py` — 3 tests:
1. Source verification that `resolve_expired_signals` is present in `run_cycle`
2. Integration test confirming `resolve_expired_signals(self.db)` is called
3. Resilience test: failing resolver does not break the cycle