### PR TITLE
feat: auto-close on bias flip and horizon expiry

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -72,8 +72,15 @@ Identity forging and attestations are optional for a local-first setup, but they
 
 b1e55ed is registered as [Agent #28362](https://basescan.org/nft/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432/28362) on the ERC-8004 Identity Registry (Base mainnet). Signal producers build portable, verifiable reputation on-chain:
 
-- **ReputationRegistry** — karma scores (hit rate, calibration, consistency) anchored on-chain
-- **ValidationRegistry** — independent verification of signal outcomes against market data
+- **ReputationRegistry** [`0xb1E55ED5...`](https://basescan.org/address/0xb1E55ED55ac94dB9a725D6263b15B286a82f0f46) — karma scores (hit rate, calibration, consistency) anchored on-chain
+- **ValidationRegistry** [`0xB1e55EDC...`](https://basescan.org/address/0xB1e55EDC8fFdd6f16e6600dEb05d364a88152D3A) — independent verification of signal outcomes against market data
+
+| Contract | Address | Chain |
+|----------|---------|-------|
+| Identity Registry (ERC-8004) | [`0x8004A169...`](https://basescan.org/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) | Base mainnet |
+| ReputationRegistry | [`0xb1E55ED5...`](https://basescan.org/address/0xb1E55ED55ac94dB9a725D6263b15B286a82f0f46) | Base mainnet |
+| ValidationRegistry | [`0xB1e55EDC...`](https://basescan.org/address/0xB1e55EDC8fFdd6f16e6600dEb05d364a88152D3A) | Base mainnet |
+| Oracle Wallet | [`0xB1e55EdD...`](https://basescan.org/address/0xB1e55EdD3176Ce9C9aF28F15b79e0c0eb8Fe51AA) | Base mainnet |
 
 This means "this agent is good at trading" becomes a verifiable claim, not marketing.
 

--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -775,6 +775,9 @@ class Database:
         self._ensure_column("contributors", "chain_tx_hash", "TEXT")
         # ERC-8004 E2 — karma chain queue for on-chain reputation writes
         self._ensure_table_exists("karma_chain_queue")
+        # Horizon-based auto-close: track which horizon a position was opened from.
+        # Also used for bias-flip scoping (same symbol + same horizon = same view).
+        self._ensure_column("positions", "horizon_hours", "REAL")
 
     def _ensure_table_exists(self, table: str) -> None:
         row = self.conn.execute(

--- a/engine/execution/oms.py
+++ b/engine/execution/oms.py
@@ -29,6 +29,7 @@ from engine.core.events import EventType, SignalAcceptedPayload
 from engine.core.policy import TradingPolicyEngine
 from engine.core.types import TradeIntent
 from engine.execution.paper import PaperBroker, PaperConfig
+from engine.execution.position_monitor import _parse_horizon_to_hours
 from engine.execution.position_sizer import CorrelationAwareSizer, PositionSizer, RiskLimits
 from engine.execution.preflight import Preflight
 
@@ -134,6 +135,12 @@ class OMS:
                     except Exception:
                         pass  # cts_at_entry remains None — non-critical
 
+                # Parse horizon string (e.g. "4h") to numeric hours for
+                # position_monitor bias-flip scoping + horizon-expiry close.
+                _horizon_hours = None
+                if intent.horizon:
+                    _horizon_hours = _parse_horizon_to_hours(intent.horizon)
+
                 fill = self.paper.execute_market(
                     symbol=intent.symbol,
                     direction=intent.direction,
@@ -147,6 +154,7 @@ class OMS:
                     regime_at_entry=str(intent.regime) if intent.regime else None,
                     pcs_at_entry=float(intent.conviction_score),
                     cts_at_entry=_cts_at_entry,
+                    horizon_hours=_horizon_hours,
                 )
             except ValueError as _e:
                 # Deduplication rejection: same symbol already has an open position.

--- a/engine/execution/paper.py
+++ b/engine/execution/paper.py
@@ -100,6 +100,7 @@ class PaperBroker:
         regime_at_entry: str | None = None,
         pcs_at_entry: float | None = None,
         cts_at_entry: float | None = None,
+        horizon_hours: float | None = None,
     ) -> PaperFill:
         sym = str(symbol).upper().strip()
         dirn = str(direction).lower().strip()
@@ -165,8 +166,8 @@ class PaperBroker:
                 INSERT INTO positions (
                   id, platform, asset, direction, entry_price, size_notional, leverage,
                   stop_loss, take_profit, opened_at, status, conviction_id,
-                  regime_at_entry, pcs_at_entry, cts_at_entry
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
+                  regime_at_entry, pcs_at_entry, cts_at_entry, horizon_hours
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?)
                 """,
                 (
                     position_id,
@@ -183,6 +184,7 @@ class PaperBroker:
                     str(regime_at_entry) if regime_at_entry is not None else None,
                     float(pcs_at_entry) if pcs_at_entry is not None else None,
                     float(cts_at_entry) if cts_at_entry is not None else None,
+                    float(horizon_hours) if horizon_hours is not None else None,
                 ),
             )
             self.db.execute(

--- a/engine/execution/position_monitor.py
+++ b/engine/execution/position_monitor.py
@@ -9,6 +9,10 @@ Responsibilities:
 3. Fetch mark prices from Binance (same logic as the dashboard / orchestrator).
 4. Call PnLTracker.close_position when a stop/target is triggered.
 5. Emit a clear audit event for every auto-close.
+6. Bias-flip close: when the latest conviction for the same (symbol, horizon)
+   flips direction, close the stale-side position.
+7. Horizon-expiry close: when a position's horizon_hours has elapsed since open,
+   close regardless of PnL.
 
 This module is intentionally free of orchestrator.py to satisfy the constraint
 that orchestrator.py must not be modified.  The daemon wires this as a dedicated
@@ -19,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import urllib.request
 from datetime import datetime
 
@@ -41,6 +46,41 @@ _log = logging.getLogger("b1e55ed.position_monitor")
 
 PAPER_TIME_STOP_HOURS: float = 72.0
 PAPER_TIME_STOP_LOSS_PCT: float = 0.05  # 5 %
+
+# ---------------------------------------------------------------------------
+# Bias-flip: max age (seconds) for a conviction to count as "current"
+# ---------------------------------------------------------------------------
+BIAS_FLIP_MAX_AGE_SECONDS: int = 3600  # 60 minutes
+
+
+def _horizon_hours_to_timeframe(hours: float) -> str:
+    """Convert numeric horizon_hours back to the timeframe label used in conviction_scores.
+
+    Examples: 4.0 → '4h', 24.0 → '24h', 0.5 → '30m', 48.0 → '2d'.
+    """
+    if hours >= 24.0 and hours % 24 == 0:
+        return f"{int(hours // 24)}d"
+    if hours >= 1.0 and hours == int(hours):
+        return f"{int(hours)}h"
+    # Sub-hour: express in minutes
+    minutes = int(hours * 60)
+    return f"{minutes}m"
+
+
+def _parse_horizon_to_hours(label: str) -> float | None:
+    """Parse a horizon string like '4h', '30m', '2d' into hours."""
+    m = re.fullmatch(r"\s*(\d+)\s*([mhd])\s*", str(label).strip().lower())
+    if not m:
+        return None
+    qty = int(m.group(1))
+    unit = m.group(2)
+    if unit == "m":
+        return qty / 60.0
+    if unit == "h":
+        return float(qty)
+    if unit == "d":
+        return qty * 24.0
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -127,10 +167,12 @@ def monitor_positions(db: Database, config: Config) -> dict:
         "closed_stop": 0,
         "closed_target": 0,
         "closed_time_stop": 0,
+        "closed_bias_flip": 0,
+        "closed_horizon_expiry": 0,
         "errors": 0,
     }
 
-    rows = db.fetchall("SELECT id, asset, direction, entry_price, stop_loss, take_profit, opened_at FROM positions WHERE status = 'open'")
+    rows = db.fetchall("SELECT id, asset, direction, entry_price, stop_loss, take_profit, opened_at, horizon_hours FROM positions WHERE status = 'open'")
 
     now = datetime.now(tz=UTC)
 
@@ -142,6 +184,7 @@ def monitor_positions(db: Database, config: Config) -> dict:
         stop_loss = float(row[4]) if row[4] is not None else None
         take_profit = float(row[5]) if row[5] is not None else None
         opened_at_raw = str(row[6]) if row[6] else None
+        horizon_hours = float(row[7]) if row[7] is not None else None
 
         stats["evaluated"] += 1
 
@@ -193,6 +236,65 @@ def monitor_positions(db: Database, config: Config) -> dict:
             except Exception:
                 _log.debug("time-stop calculation failed for %s", pos_id, exc_info=True)
 
+        # --- bias-flip close ----------------------------------------------
+        # If the latest conviction for the same (symbol, horizon) has flipped
+        # direction, close this position.  Scoped by horizon so a 4h-long and
+        # 1d-short for the same asset can coexist legitimately.
+        if close_reason is None and horizon_hours is not None:
+            try:
+                timeframe_label = _horizon_hours_to_timeframe(horizon_hours)
+                conv_row = db.fetchone(
+                    "SELECT direction, ts FROM conviction_scores WHERE symbol = ? AND timeframe = ? ORDER BY id DESC LIMIT 1",
+                    (asset, timeframe_label),
+                )
+                if conv_row is not None:
+                    conv_direction = str(conv_row[0]).lower()
+                    conv_ts_raw = str(conv_row[1]) if conv_row[1] else None
+                    # Only act on recent convictions (within BIAS_FLIP_MAX_AGE_SECONDS)
+                    recent_enough = False
+                    if conv_ts_raw:
+                        try:
+                            conv_ts = datetime.fromisoformat(conv_ts_raw)
+                            if conv_ts.tzinfo is None:
+                                conv_ts = conv_ts.replace(tzinfo=UTC)
+                            age_secs = (now - conv_ts).total_seconds()
+                            recent_enough = age_secs <= BIAS_FLIP_MAX_AGE_SECONDS
+                        except Exception:
+                            _log.debug("bias-flip ts parse failed for %s", pos_id, exc_info=True)
+                    if recent_enough and conv_direction in ("long", "short") and conv_direction != direction:
+                        close_reason = "bias_flip"
+                        _log.info(
+                            "bias-flip triggered: position %s %s %s (horizon=%s) — latest conviction is %s",
+                            pos_id,
+                            direction,
+                            asset,
+                            timeframe_label,
+                            conv_direction,
+                        )
+            except Exception:
+                _log.debug("bias-flip check failed for %s", pos_id, exc_info=True)
+
+        # --- horizon-expiry close -----------------------------------------
+        # Close when opened_at + horizon_hours has elapsed.
+        if close_reason is None and horizon_hours is not None and opened_at_raw:
+            try:
+                opened_at = datetime.fromisoformat(opened_at_raw)
+                if opened_at.tzinfo is None:
+                    opened_at = opened_at.replace(tzinfo=UTC)
+                age_hours_now = (now - opened_at).total_seconds() / 3600.0
+                if age_hours_now >= horizon_hours:
+                    close_reason = "horizon_expiry"
+                    _log.info(
+                        "horizon-expiry triggered: position %s %s %s open %.1fh >= horizon %.1fh",
+                        pos_id,
+                        direction,
+                        asset,
+                        age_hours_now,
+                        horizon_hours,
+                    )
+            except Exception:
+                _log.debug("horizon-expiry check failed for %s", pos_id, exc_info=True)
+
         if close_reason:
             try:
                 realized = pnl.close_position(position_id=pos_id, exit_price=mark, reason=close_reason)
@@ -225,6 +327,10 @@ def monitor_positions(db: Database, config: Config) -> dict:
                     stats["closed_stop"] += 1
                 elif close_reason == "take_profit":
                     stats["closed_target"] += 1
+                elif close_reason == "bias_flip":
+                    stats["closed_bias_flip"] += 1
+                elif close_reason == "horizon_expiry":
+                    stats["closed_horizon_expiry"] += 1
                 else:
                     stats["closed_time_stop"] += 1
             except Exception:

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -11,6 +11,13 @@ Tests:
 6. Time-based stop does NOT trigger when position is not losing > 5%
 7. No close when neither stop nor time-stop condition is met
 8. consecutive_loss_count = 2 does NOT block new trades (kill switch stays SAFE)
+9. Bias-flip close: conviction flips direction for same (symbol, horizon) → close
+10. Bias-flip does NOT trigger when conviction is stale (> 60 min)
+11. Bias-flip does NOT trigger when conviction is same direction
+12. Bias-flip does NOT trigger when conviction is for different horizon
+13. Horizon-expiry close: position open longer than horizon_hours → close
+14. Horizon-expiry does NOT trigger when position is younger than horizon
+15. Horizon-expiry does NOT trigger when horizon_hours is NULL
 """
 
 from __future__ import annotations
@@ -56,6 +63,7 @@ def _insert_position(
     take_profit: float | None = 84.82,
     opened_at: datetime | None = None,
     size_notional: float = 449.0,
+    horizon_hours: float | None = None,
 ) -> str:
     """Insert a fake open position directly and return its ID."""
     import uuid
@@ -67,8 +75,8 @@ def _insert_position(
             """
             INSERT INTO positions
               (id, asset, direction, entry_price, stop_loss, take_profit,
-               size_notional, status, opened_at, platform)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?, 'paper')
+               size_notional, status, opened_at, platform, horizon_hours)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?, 'paper', ?)
             """,
             (
                 pos_id,
@@ -79,9 +87,33 @@ def _insert_position(
                 take_profit,
                 size_notional,
                 opened_at_iso,
+                horizon_hours,
             ),
         )
     return pos_id
+
+
+def _insert_conviction(
+    db: Database,
+    *,
+    symbol: str = "BTC",
+    direction: str = "short",
+    timeframe: str = "4h",
+    ts: datetime | None = None,
+    magnitude: float = 7.0,
+) -> int:
+    """Insert a conviction_scores row and return its id."""
+    ts_iso = (ts or datetime.now(tz=UTC)).isoformat()
+    with db._lock, db.conn:
+        cursor = db.conn.execute(
+            """
+            INSERT INTO conviction_scores
+              (node_id, symbol, direction, magnitude, timeframe, ts, commitment_hash)
+            VALUES ('test-node', ?, ?, ?, ?, ?, 'test-hash')
+            """,
+            (symbol, direction, magnitude, timeframe, ts_iso),
+        )
+        return cursor.lastrowid
 
 
 def _mark_price_side_effect(price: float):
@@ -303,3 +335,278 @@ class TestConsecutiveLossGate:
         assert ks.level == KillSwitchLevel.SAFE, (
             "Paper mode with paper_ignore_consecutive_loss_gate=True should not escalate kill switch even after 3 consecutive losses"
         )
+
+
+class TestBiasFlipClose:
+    """Bias-flip close: when latest conviction for (symbol, horizon) flips, close."""
+
+    def test_bias_flip_closes_long_when_conviction_flips_short(self, tmp_db: Database, paper_config: Config):
+        """BTC long (4h horizon) open → latest conviction says short (4h) → close."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="BTC",
+            direction="long",
+            entry_price=100.0,
+            stop_loss=90.0,
+            take_profit=120.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=2),
+            horizon_hours=4.0,
+        )
+        # Insert a recent conviction that says SHORT for BTC on 4h timeframe
+        _insert_conviction(
+            tmp_db,
+            symbol="BTC",
+            direction="short",
+            timeframe="4h",
+            ts=datetime.now(tz=UTC) - timedelta(minutes=10),
+        )
+
+        with _mark_price_side_effect(102.0):  # price doesn't matter for bias flip
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "closed"
+        assert stats["closed_bias_flip"] == 1
+
+    def test_bias_flip_closes_short_when_conviction_flips_long(self, tmp_db: Database, paper_config: Config):
+        """BTC short (4h) open → latest conviction says long (4h) → close."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="BTC",
+            direction="short",
+            entry_price=100.0,
+            stop_loss=110.0,
+            take_profit=90.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            horizon_hours=4.0,
+        )
+        _insert_conviction(
+            tmp_db,
+            symbol="BTC",
+            direction="long",
+            timeframe="4h",
+            ts=datetime.now(tz=UTC) - timedelta(minutes=5),
+        )
+
+        with _mark_price_side_effect(99.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "closed"
+        assert stats["closed_bias_flip"] == 1
+
+    def test_bias_flip_does_not_trigger_on_stale_conviction(self, tmp_db: Database, paper_config: Config):
+        """Conviction > 60 min old should NOT trigger a bias flip close."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="BTC",
+            direction="long",
+            entry_price=100.0,
+            stop_loss=90.0,
+            take_profit=120.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=2),
+            horizon_hours=4.0,
+        )
+        # Stale conviction: 2 hours old
+        _insert_conviction(
+            tmp_db,
+            symbol="BTC",
+            direction="short",
+            timeframe="4h",
+            ts=datetime.now(tz=UTC) - timedelta(hours=2),
+        )
+
+        with _mark_price_side_effect(102.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "open", "Stale conviction should NOT trigger bias flip"
+        assert stats["closed_bias_flip"] == 0
+
+    def test_bias_flip_does_not_trigger_on_same_direction(self, tmp_db: Database, paper_config: Config):
+        """Conviction same direction as position → no flip, stay open."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="BTC",
+            direction="long",
+            entry_price=100.0,
+            stop_loss=90.0,
+            take_profit=120.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            horizon_hours=4.0,
+        )
+        _insert_conviction(
+            tmp_db,
+            symbol="BTC",
+            direction="long",  # same direction
+            timeframe="4h",
+            ts=datetime.now(tz=UTC) - timedelta(minutes=5),
+        )
+
+        with _mark_price_side_effect(102.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "open"
+        assert stats["closed_bias_flip"] == 0
+
+    def test_bias_flip_does_not_trigger_on_different_horizon(self, tmp_db: Database, paper_config: Config):
+        """BTC long on 4h horizon, conviction flips on 24h → different view, no close."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="BTC",
+            direction="long",
+            entry_price=100.0,
+            stop_loss=90.0,
+            take_profit=120.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            horizon_hours=4.0,  # position is 4h
+        )
+        _insert_conviction(
+            tmp_db,
+            symbol="BTC",
+            direction="short",
+            timeframe="24h",  # conviction is 24h — different view
+            ts=datetime.now(tz=UTC) - timedelta(minutes=5),
+        )
+
+        with _mark_price_side_effect(102.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "open", "Different horizon conviction should NOT trigger bias flip"
+        assert stats["closed_bias_flip"] == 0
+
+    def test_bias_flip_skipped_when_no_horizon(self, tmp_db: Database, paper_config: Config):
+        """Position without horizon_hours set → bias flip check is skipped entirely."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="BTC",
+            direction="long",
+            entry_price=100.0,
+            stop_loss=90.0,
+            take_profit=120.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            horizon_hours=None,
+        )
+        _insert_conviction(
+            tmp_db,
+            symbol="BTC",
+            direction="short",
+            timeframe="4h",
+            ts=datetime.now(tz=UTC) - timedelta(minutes=5),
+        )
+
+        with _mark_price_side_effect(102.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "open"
+        assert stats["closed_bias_flip"] == 0
+
+
+class TestHorizonExpiryClose:
+    """Horizon-expiry close: position open longer than its horizon_hours → close."""
+
+    def test_horizon_expiry_triggers_when_elapsed(self, tmp_db: Database, paper_config: Config):
+        """Position with horizon_hours=4 open for 5h → should be closed."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="ETH",
+            direction="long",
+            entry_price=3000.0,
+            stop_loss=2800.0,
+            take_profit=3500.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=5),
+            horizon_hours=4.0,
+        )
+
+        with _mark_price_side_effect(3100.0):  # in profit — doesn't matter
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "closed"
+        assert stats["closed_horizon_expiry"] == 1
+
+    def test_horizon_expiry_triggers_at_loss(self, tmp_db: Database, paper_config: Config):
+        """Horizon expiry closes regardless of PnL — even at a loss."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="ETH",
+            direction="long",
+            entry_price=3000.0,
+            stop_loss=2800.0,  # not triggered at 2900
+            take_profit=3500.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=25),
+            horizon_hours=24.0,
+        )
+
+        with _mark_price_side_effect(2900.0):  # at a loss but above stop
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status, realized_pnl FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "closed"
+        assert row["realized_pnl"] < 0, "Should close at a loss — horizon doesn't care about PnL"
+        assert stats["closed_horizon_expiry"] == 1
+
+    def test_horizon_expiry_does_not_trigger_when_young(self, tmp_db: Database, paper_config: Config):
+        """Position younger than horizon_hours → stays open."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="ETH",
+            direction="long",
+            entry_price=3000.0,
+            stop_loss=2800.0,
+            take_profit=3500.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=2),
+            horizon_hours=4.0,
+        )
+
+        with _mark_price_side_effect(3100.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "open", "Position younger than horizon should stay open"
+        assert stats["closed_horizon_expiry"] == 0
+
+    def test_horizon_expiry_does_not_trigger_when_null(self, tmp_db: Database, paper_config: Config):
+        """Position with horizon_hours=NULL → no expiry, stays open."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="ETH",
+            direction="long",
+            entry_price=3000.0,
+            stop_loss=2800.0,
+            take_profit=3500.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=100),
+            horizon_hours=None,
+        )
+
+        with _mark_price_side_effect(3100.0):
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "open"
+        assert stats["closed_horizon_expiry"] == 0
+
+    def test_stop_loss_takes_priority_over_horizon_expiry(self, tmp_db: Database, paper_config: Config):
+        """When both stop_loss and horizon_expiry would trigger, stop_loss wins."""
+        pos_id = _insert_position(
+            tmp_db,
+            asset="ETH",
+            direction="long",
+            entry_price=3000.0,
+            stop_loss=2800.0,
+            take_profit=3500.0,
+            opened_at=datetime.now(tz=UTC) - timedelta(hours=25),
+            horizon_hours=24.0,
+        )
+
+        with _mark_price_side_effect(2700.0):  # below stop_loss
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "closed"
+        # stop_loss is evaluated first, so it should win
+        assert stats["closed_stop"] == 1
+        assert stats["closed_horizon_expiry"] == 0


### PR DESCRIPTION
## Summary

Two new auto-close triggers for the paper position monitor.

### 1. Bias Flip Close
When the latest conviction for the **same (symbol, horizon)** flips direction, close the stale-side position.

- Scoped by horizon: a 4h-long and 1d-short for the same asset coexist — different views, not a flip
- Only acts on recent convictions (within 60 min)
- New stats key: `closed_bias_flip`

### 2. Horizon Expiry Close
When a position has `horizon_hours` set and `opened_at + horizon_hours < now`, close regardless of PnL.

- Positions without `horizon_hours` (NULL) are unaffected
- New stats key: `closed_horizon_expiry`

### Changes
- **position_monitor.py**: Both triggers with try/except guards, horizon string ↔ hours helpers
- **database.py**: `_ensure_column("positions", "horizon_hours", "REAL")` migration
- **paper.py**: `execute_market()` accepts and persists `horizon_hours`
- **oms.py**: Parses `TradeIntent.horizon` → numeric hours, passes to PaperBroker

### Tests (11 new, 21 total)
- Bias flip: close on flip, no close on stale/same-direction/different-horizon/no-horizon
- Horizon expiry: close when elapsed/at loss, no close when young/NULL, stop_loss priority

All 21 tests pass. No existing tests modified.