### PR TITLE
fix: enable SQLite WAL mode and busy timeout to prevent database locked errors

### DIFF
--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -682,8 +682,11 @@ class Database:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         # Set connection-level pragmas before any other DB operations.
-        # busy_timeout: retry for 5s on SQLITE_BUSY instead of failing immediately.
-        # WAL + synchronous are set in _init_schema via executescript.
+        # These MUST run before _init_schema() and outside any transaction:
+        # journal_mode=WAL cannot be changed inside a transaction, and
+        # executescript() in _init_schema has unpredictable transaction state.
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA synchronous=NORMAL")
         self.conn.execute("PRAGMA busy_timeout=5000")
         self.conn.row_factory = sqlite3.Row
         self._lock = threading.RLock()
@@ -714,8 +717,8 @@ class Database:
     def _init_schema(self) -> None:
         with self.conn:
             self.conn.executescript(SCHEMA)
-            self.conn.execute("PRAGMA journal_mode=WAL")
-            self.conn.execute("PRAGMA synchronous=NORMAL")
+            # WAL + synchronous are now set in __post_init__ before this method
+            # runs, so they apply before any schema operations.
             self.conn.execute("PRAGMA foreign_keys=ON")
 
         # Lightweight migrations for additive columns (SQLite-friendly).

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -60,3 +60,21 @@ def test_batch_append(temp_dir: Path) -> None:
         assert out[0].source == "unit"
     finally:
         db.close()
+
+
+def test_wal_mode_and_busy_timeout_set_on_new_connections(temp_dir: Path) -> None:
+    """WAL mode and busy_timeout must be set on every new connection to prevent
+    'database is locked' errors when multiple processes share the same DB file."""
+    db = Database(temp_dir / "brain.db")
+    try:
+        journal = db.conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert journal == "wal", f"Expected WAL journal mode, got {journal}"
+
+        timeout = db.conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout == 5000, f"Expected busy_timeout=5000, got {timeout}"
+
+        sync = db.conn.execute("PRAGMA synchronous").fetchone()[0]
+        # synchronous=NORMAL is 1 in SQLite's integer representation
+        assert sync == 1, f"Expected synchronous=NORMAL (1), got {sync}"
+    finally:
+        db.close()


### PR DESCRIPTION
## Problem

The API server, brain daemon, and rate limiter middleware all share one SQLite database file. When the brain cycle writes at the same time as an API request, SQLite throws `sqlite3.OperationalError: database is locked`.

## Root Cause

`PRAGMA journal_mode=WAL` was set inside `_init_schema()` after `executescript(SCHEMA)` within a `with self.conn:` block. WAL mode cannot be changed inside a transaction, and `executescript()` leaves the transaction state ambiguous — causing WAL to silently fail to apply.

## Fix

Move all connection-level PRAGMAs to `__post_init__()`, immediately after `sqlite3.connect()` and before any schema operations:

1. `PRAGMA journal_mode=WAL` — concurrent readers while one writer is active
2. `PRAGMA synchronous=NORMAL` — safe with WAL, better write performance
3. `PRAGMA busy_timeout=5000` — wait up to 5s for locks instead of failing

## Tests

- All 13 existing tests pass
- Added `test_wal_mode_and_busy_timeout_set_on_new_connections`