### PR TITLE
feat: signal clustering and first-mover weighting for deduplication

### DIFF
--- a/engine/spi/admission.py
+++ b/engine/spi/admission.py
@@ -27,6 +27,91 @@ from engine.spi.models import AcceptedSignal
 _TABLES_ENSURED: weakref.WeakSet = weakref.WeakSet()
 
 
+def _horizon_matches(h1: int, h2: int) -> bool:
+    """Check if two horizon values are in the same bucket or within ±2h."""
+    buckets = [(0, 2), (3, 5), (6, 18), (19, 48)]
+    for lo, hi in buckets:
+        if lo <= h1 <= hi and lo <= h2 <= hi:
+            return True
+    return abs(h1 - h2) <= 2
+
+
+def find_or_create_cluster(
+    db,
+    *,
+    signal_id: str,
+    producer_id: str,
+    symbol: str,
+    direction: str,
+    confidence: float,
+    horizon_hours: int,
+    now_iso: str,
+) -> tuple[str, int, float]:
+    """Find an existing cluster or create a new one.
+
+    Returns (cluster_id, position, cluster_weight).
+    """
+    # Look for recent clusters matching symbol + direction
+    lookback_minutes = max(horizon_hours * 15, 15)
+    cutoff = (datetime.fromisoformat(now_iso) - timedelta(minutes=lookback_minutes)).isoformat()
+
+    rows = (
+        db.fetchall(
+            """
+        SELECT cluster_id, avg_confidence, horizon_hours, signal_count
+        FROM spi_signal_clusters
+        WHERE symbol = ? AND direction = ?
+          AND datetime(substr(created_at, 1, 19)) >= datetime(?)
+        ORDER BY created_at DESC
+        """,
+            (symbol, direction, cutoff[:19]),
+        )
+        if hasattr(db, "fetchall")
+        else db.execute(
+            """
+        SELECT cluster_id, avg_confidence, horizon_hours, signal_count
+        FROM spi_signal_clusters
+        WHERE symbol = ? AND direction = ?
+          AND datetime(substr(created_at, 1, 19)) >= datetime(?)
+        ORDER BY created_at DESC
+        """,
+            (symbol, direction, cutoff[:19]),
+        ).fetchall()
+    )
+
+    for row in rows:
+        c_id, c_conf, c_horizon, c_count = row
+        if abs(confidence - c_conf) <= 0.10 and _horizon_matches(horizon_hours, c_horizon):
+            # Match found — join this cluster
+            new_count = c_count + 1
+            position = new_count
+            weight = 1.0 / (position**1.5)
+            # Update cluster stats
+            new_avg_conf = (c_conf * c_count + confidence) / new_count
+            db.execute(
+                """
+                UPDATE spi_signal_clusters
+                SET signal_count = ?, avg_confidence = ?, updated_at = ?
+                WHERE cluster_id = ?
+                """,
+                (new_count, new_avg_conf, now_iso, c_id),
+            )
+            return c_id, position, weight
+
+    # No match — create new cluster
+    cluster_id = str(uuid.uuid4())
+    db.execute(
+        """
+        INSERT INTO spi_signal_clusters (
+            cluster_id, symbol, direction, avg_confidence, horizon_hours,
+            first_signal_id, first_producer_id, signal_count, created_at, updated_at
+        ) VALUES (?,?,?,?,?,?,?,1,?,?)
+        """,
+        (cluster_id, symbol, direction, confidence, horizon_hours, signal_id, producer_id, now_iso, now_iso),
+    )
+    return cluster_id, 1, 1.0
+
+
 def accept_signal(
     *,
     producer_id: str,
@@ -93,14 +178,32 @@ def accept_signal(
 
     # Ensure tables exist then write the record.
     _ensure_tables(db)
+
+    # Clustering: find or create a cluster for deduplication
+    cluster_id, cluster_position, cluster_weight = find_or_create_cluster(
+        db,
+        signal_id=signal_id,
+        producer_id=producer_id,
+        symbol=symbol,
+        direction=direction,
+        confidence=confidence,
+        horizon_hours=horizon_hours,
+        now_iso=now.isoformat(),
+    )
+    accepted.cluster_id = cluster_id
+    accepted.cluster_position = cluster_position
+    accepted.cluster_weight = cluster_weight
+
     db.execute(
         """
         INSERT OR IGNORE INTO spi_signals (
             signal_id, signal_client_id, submission_id, producer_id,
             ingress_mode, symbol, direction, confidence, horizon_hours,
             submitted_at, attribution_window_start, attribution_window_end,
-            status, event_id, signal_payload_json, created_at, updated_at
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            status, event_id, signal_payload_json,
+            cluster_id, cluster_position, cluster_weight,
+            created_at, updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             accepted.signal_id,
@@ -118,6 +221,9 @@ def accept_signal(
             accepted.status,
             accepted.event_id,
             accepted.signal_payload_json,
+            accepted.cluster_id,
+            accepted.cluster_position,
+            accepted.cluster_weight,
             accepted.created_at,
             accepted.updated_at,
         ),
@@ -130,7 +236,8 @@ def accept_signal(
         "SELECT signal_id, signal_client_id, submission_id, producer_id, ingress_mode, "
         "symbol, direction, confidence, horizon_hours, submitted_at, "
         "attribution_window_start, attribution_window_end, status, event_id, "
-        "signal_payload_json, created_at, updated_at "
+        "signal_payload_json, cluster_id, cluster_position, cluster_weight, "
+        "created_at, updated_at "
         "FROM spi_signals WHERE signal_client_id = ? AND submission_id = ?",
         (signal_client_id, submission_id),
     ).fetchone()
@@ -153,8 +260,11 @@ def accept_signal(
             status=existing[12],
             event_id=existing[13],
             signal_payload_json=existing[14],
-            created_at=existing[15],
-            updated_at=existing[16],
+            cluster_id=existing[15],
+            cluster_position=existing[16],
+            cluster_weight=existing[17],
+            created_at=existing[18],
+            updated_at=existing[19],
         )
         # Phase 2B: auto-promote producer after signal acceptance
         try:
@@ -250,5 +360,31 @@ def _ensure_tables(db) -> None:  # noqa: ANN001
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
     )""")
+
+    # Signal clustering table
+    db.execute("""CREATE TABLE IF NOT EXISTS spi_signal_clusters (
+        cluster_id TEXT PRIMARY KEY,
+        symbol TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        avg_confidence REAL NOT NULL,
+        horizon_hours INTEGER NOT NULL,
+        first_signal_id TEXT NOT NULL,
+        first_producer_id TEXT NOT NULL,
+        signal_count INTEGER DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )""")
+    db.execute("CREATE INDEX IF NOT EXISTS idx_spi_clusters_symbol_dir ON spi_signal_clusters(symbol, direction)")
+
+    # Add cluster columns to spi_signals (idempotent via try/except)
+    import contextlib  # noqa: PLC0415
+
+    for col_sql in [
+        "ALTER TABLE spi_signals ADD COLUMN cluster_id TEXT",
+        "ALTER TABLE spi_signals ADD COLUMN cluster_position INTEGER DEFAULT 1",
+        "ALTER TABLE spi_signals ADD COLUMN cluster_weight REAL DEFAULT 1.0",
+    ]:
+        with contextlib.suppress(Exception):
+            db.execute(col_sql)
 
     _TABLES_ENSURED.add(db)

--- a/engine/spi/models.py
+++ b/engine/spi/models.py
@@ -24,6 +24,25 @@ class AcceptedSignal:
     status: str = "accepted"
     event_id: str | None = None  # native b1e55ed event_id (from emit_observation)
     signal_payload_json: str | None = None
+    cluster_id: str | None = None
+    cluster_position: int = 1
+    cluster_weight: float = 1.0
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class SignalCluster:
+    """A cluster of semantically similar signals."""
+
+    cluster_id: str
+    symbol: str
+    direction: str
+    avg_confidence: float
+    horizon_hours: int
+    first_signal_id: str
+    first_producer_id: str
+    signal_count: int = 1
     created_at: str = ""
     updated_at: str = ""
 

--- a/engine/spi/resolution.py
+++ b/engine/spi/resolution.py
@@ -77,9 +77,10 @@ def resolve_expired_signals(db, current_epoch: int = 0) -> list[SignalOutcome]: 
         direction_correct = determine_direction_correct(direction, price_change_pct)
         brier = compute_brier(confidence, direction_correct)
 
-        # Update karma.
+        # Update karma (apply cluster weight for dedup).
+        cluster_weight = _get_cluster_weight(db, signal_id)
         current_karma = _get_running_karma(db, producer_id)
-        karma_delta = compute_karma_delta(current_karma, brier)
+        karma_delta = compute_karma_delta(current_karma, brier) * cluster_weight
         _update_karma(db, producer_id, current_epoch, brier, current_karma + karma_delta)
 
         outcome = _write_outcome(
@@ -113,6 +114,17 @@ def resolve_expired_signals(db, current_epoch: int = 0) -> list[SignalOutcome]: 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _get_cluster_weight(db, signal_id: str) -> float:  # noqa: ANN001
+    """Get cluster_weight for a signal; defaults to 1.0 (grandfathered)."""
+    row = db.fetchone(
+        "SELECT cluster_weight FROM spi_signals WHERE signal_id = ?",
+        (signal_id,),
+    )
+    if row and row[0] is not None:
+        return float(row[0])
+    return 1.0
 
 
 def _get_entry_price(db, signal_id: str) -> float | None:  # noqa: ANN001

--- a/tests/unit/test_signal_clustering.py
+++ b/tests/unit/test_signal_clustering.py
@@ -1,0 +1,177 @@
+"""Tests for signal clustering and first-mover weighting."""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from engine.spi.admission import _ensure_tables, _horizon_matches, accept_signal
+
+
+class FakeDB:
+    """Minimal DB wrapper matching engine.core.database.Database interface."""
+
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute("PRAGMA journal_mode=WAL")
+
+    def execute(self, sql, params=()):
+        return self.conn.execute(sql, params)
+
+    def fetchone(self, sql, params=()):
+        return self.conn.execute(sql, params).fetchone()
+
+    def fetchall(self, sql, params=()):
+        return self.conn.execute(sql, params).fetchall()
+
+    def __hash__(self):
+        return id(self)
+
+
+@pytest.fixture
+def db():
+    d = FakeDB()
+    _ensure_tables(d)
+    return d
+
+
+def _make_signal(db, producer_id="prod-1", signal_client_id="cli-1", submission_id="sub-1", symbol="BTC", direction="bullish", confidence=0.8, horizon_hours=4):
+    with patch("engine.spi.price_feeds.fetch_price_usd", return_value=50000.0), patch("engine.spi.lifecycle.maybe_auto_promote"):
+        return accept_signal(
+            producer_id=producer_id,
+            signal_client_id=signal_client_id,
+            submission_id=submission_id,
+            symbol=symbol,
+            direction=direction,
+            confidence=confidence,
+            horizon_hours=horizon_hours,
+            db=db,
+        )
+
+
+def test_two_identical_signals_get_clustered(db):
+    """Two signals with same symbol+direction+confidence should cluster."""
+    s1 = _make_signal(db, producer_id="prod-1", signal_client_id="c1", submission_id="s1")
+    s2 = _make_signal(db, producer_id="prod-2", signal_client_id="c2", submission_id="s2")
+
+    assert s1.cluster_id is not None
+    assert s1.cluster_id == s2.cluster_id
+    assert s1.cluster_position == 1
+    assert s2.cluster_position == 2
+
+
+def test_first_mover_weight(db):
+    """First mover gets 1.0, second gets 1/(2^1.5) ≈ 0.354."""
+    s1 = _make_signal(db, producer_id="prod-1", signal_client_id="c1", submission_id="s1")
+    s2 = _make_signal(db, producer_id="prod-2", signal_client_id="c2", submission_id="s2")
+
+    assert s1.cluster_weight == 1.0
+    assert abs(s2.cluster_weight - 1.0 / (2**1.5)) < 0.001
+
+
+def test_different_symbol_not_clustered(db):
+    """Different symbols should NOT be clustered together."""
+    s1 = _make_signal(db, producer_id="prod-1", signal_client_id="c1", submission_id="s1", symbol="BTC")
+    s2 = _make_signal(db, producer_id="prod-2", signal_client_id="c2", submission_id="s2", symbol="ETH")
+
+    assert s1.cluster_id != s2.cluster_id
+
+
+def test_different_direction_not_clustered(db):
+    """Different directions should NOT be clustered together."""
+    s1 = _make_signal(db, producer_id="prod-1", signal_client_id="c1", submission_id="s1", direction="bullish")
+    s2 = _make_signal(db, producer_id="prod-2", signal_client_id="c2", submission_id="s2", direction="bearish")
+
+    assert s1.cluster_id != s2.cluster_id
+
+
+def test_karma_resolution_applies_cluster_weight(db):
+    """Resolution should multiply karma_delta by cluster_weight."""
+    from engine.spi.resolution import _get_cluster_weight
+
+    # Insert a signal with cluster_weight=0.5
+    _ensure_tables(db)
+    db.execute(
+        """INSERT INTO spi_signals (
+            signal_id, signal_client_id, submission_id, producer_id,
+            ingress_mode, symbol, direction, confidence, horizon_hours,
+            submitted_at, attribution_window_start, attribution_window_end,
+            status, cluster_weight, created_at, updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "sig-test",
+            "c-test",
+            "s-test",
+            "p-test",
+            "adapter",
+            "BTC",
+            "bullish",
+            0.8,
+            4,
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+            "accepted",
+            0.354,
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+
+    weight = _get_cluster_weight(db, "sig-test")
+    assert abs(weight - 0.354) < 0.001
+
+
+def test_cluster_weight_default_for_old_signals(db):
+    """Signals without cluster_weight should default to 1.0."""
+    from engine.spi.resolution import _get_cluster_weight
+
+    _ensure_tables(db)
+    db.execute(
+        """INSERT INTO spi_signals (
+            signal_id, signal_client_id, submission_id, producer_id,
+            ingress_mode, symbol, direction, confidence, horizon_hours,
+            submitted_at, attribution_window_start, attribution_window_end,
+            status, created_at, updated_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (
+            "sig-old",
+            "c-old",
+            "s-old",
+            "p-old",
+            "adapter",
+            "BTC",
+            "bullish",
+            0.8,
+            4,
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+            "accepted",
+            "2026-01-01T00:00:00",
+            "2026-01-01T00:00:00",
+        ),
+    )
+
+    weight = _get_cluster_weight(db, "sig-old")
+    assert weight == 1.0
+
+
+def test_schema_migration_idempotent(db):
+    """Running _ensure_tables twice should not error."""
+    from engine.spi.admission import _TABLES_ENSURED
+
+    _TABLES_ENSURED.discard(db)
+    _ensure_tables(db)  # second call — should be fine
+
+
+def test_horizon_matching():
+    """Test horizon bucket matching."""
+    assert _horizon_matches(1, 2) is True
+    assert _horizon_matches(4, 4) is True
+    assert _horizon_matches(1, 4) is False  # different buckets, >2h apart
+    assert _horizon_matches(1, 24) is False
+    assert _horizon_matches(12, 12) is True
+    assert _horizon_matches(23, 24) is True  # within ±2h


### PR DESCRIPTION
## What

Signal clustering/deduplication at the SPI admission layer. When multiple producers submit semantically similar signals (same symbol, same direction, similar confidence/horizon, within a time window), they get clustered. First submitter gets full karma credit, subsequent duplicates get diminishing returns.

## Changes

- **New table**: `spi_signal_clusters` tracks clusters of similar signals
- **New columns on `spi_signals`**: `cluster_id`, `cluster_position`, `cluster_weight`
- **Clustering logic**: `find_or_create_cluster()` in `admission.py`
- **First-mover weighting**: position 1 = weight 1.0, position N = `1/(N^1.5)`
- **Resolution integration**: `karma_delta *= cluster_weight`
- **Grandfathered**: existing signals default to `cluster_weight=1.0`
- **8 new tests**, all existing tests pass