### PR TITLE
fix: use pending nonce to prevent replacement transaction underpriced on batch karma writes

### DIFF
--- a/engine/oracle/chain.py
+++ b/engine/oracle/chain.py
@@ -148,7 +148,7 @@ class ChainClient:
             tx = fn.build_transaction(
                 {
                     "from": self._account.address,
-                    "nonce": self._w3.eth.get_transaction_count(self._account.address),
+                    "nonce": self._w3.eth.get_transaction_count(self._account.address, "pending"),
                     "gas": 300_000,
                     "gasPrice": self._w3.eth.gas_price,
                 }


### PR DESCRIPTION
When flushing a batch of karma writes, all txs were built with the same confirmed nonce — causing every tx after the first to fail with `replacement transaction underpriced`.

Fix: use `"pending"` as the block parameter for `get_transaction_count` so each tx in the batch gets an incrementing nonce.