### PR TITLE
fix: promote web3 to core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "jinja2>=3.1",
     "argon2-cffi>=25.1.0",
     "eth-account>=0.11",
+    "web3>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -249,6 +249,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "twelvedata" },
     { name = "uvicorn" },
+    { name = "web3" },
     { name = "yfinance" },
 ]
 
@@ -321,6 +322,7 @@ requires-dist = [
     { name = "twelvedata", marker = "extra == 'tradfi'", specifier = ">=1.2" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", specifier = ">=0.29" },
+    { name = "web3", specifier = ">=6.0" },
     { name = "web3", marker = "extra == 'oracle'", specifier = ">=6.0" },
     { name = "yfinance", specifier = ">=0.2" },
     { name = "yfinance", marker = "extra == 'tradfi'", specifier = ">=0.2" },


### PR DESCRIPTION
web3 was an optional `[oracle]` extra, requiring `--with web3>=6.0` on every install. Since on-chain karma writes are now a core feature, promote web3 to a default dependency so a plain `curl | bash` install just works.