### PR TITLE
feat: wire ERC-8004 ValidationRegistry writes + fix ABI + add /health root alias

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -33,7 +33,7 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
 class ApiRateLimitMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         # Allow health/docs without rate limiting
-        if request.url.path in ("/api/v1/health", "/docs", "/openapi.json", "/api/v1/openapi.json"):
+        if request.url.path in ("/health", "/api/v1/health", "/docs", "/openapi.json", "/api/v1/openapi.json"):
             return await call_next(request)
 
         # Key by bearer token if present, else by client IP.
@@ -78,7 +78,7 @@ class IdentityGateMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         # Allow health/docs without identity (monitoring + introspection)
-        if request.url.path in ("/api/v1/health", "/docs", "/openapi.json", "/api/v1/openapi.json"):
+        if request.url.path in ("/health", "/api/v1/health", "/docs", "/openapi.json", "/api/v1/openapi.json"):
             return await call_next(request)
 
         from engine.core.identity_gate import load_identity
@@ -421,6 +421,13 @@ def create_app() -> FastAPI:
     from api.routes.mcp import router as mcp_router
 
     app.include_router(mcp_router)
+
+    # Root /health alias — shortcut for judges and external monitors
+    from starlette.responses import RedirectResponse  # noqa: PLC0415
+
+    @app.get("/health", include_in_schema=False)
+    async def health_root():
+        return RedirectResponse(url="/api/v1/health", status_code=302)
 
     # Well-known agent registration (mounted at root, not under /api/v1)
     from api.routes.agents import build_system_manifest

--- a/engine/oracle/chain.py
+++ b/engine/oracle/chain.py
@@ -56,9 +56,10 @@ _VALIDATION_REGISTRY_ABI: list[dict[str, Any]] = [
     {
         "inputs": [
             {"internalType": "uint256", "name": "agentId", "type": "uint256"},
-            {"internalType": "string", "name": "verdict", "type": "string"},
-            {"internalType": "string", "name": "resultURI", "type": "string"},
-            {"internalType": "bytes32", "name": "resultHash", "type": "bytes32"},
+            {"internalType": "string", "name": "verdictStr", "type": "string"},
+            {"internalType": "string", "name": "context", "type": "string"},
+            {"internalType": "string", "name": "validationURI", "type": "string"},
+            {"internalType": "bytes32", "name": "verdictHash", "type": "bytes32"},
         ],
         "name": "postValidation",
         "outputs": [],
@@ -263,8 +264,12 @@ class ChainClient:
         verdict: str,
         result_uri: str = "",
         result_hash: bytes = b"",
+        context: str = "",
     ) -> str | None:
-        """Post council verdict to Validation Registry.  Returns tx_hash or None."""
+        """Post council verdict to Validation Registry.  Returns tx_hash or None.
+
+        Maps to: postValidation(agentId, verdictStr, context, validationURI, verdictHash)
+        """
         if self._validation_contract is None:
             logger.debug("post_validation: validation registry not configured — skipping")
             return None
@@ -274,7 +279,8 @@ class ChainClient:
             fn = self._validation_contract.functions.postValidation(
                 agent_id,
                 verdict,
-                result_uri,
+                context or result_uri,  # context field — PR URL or signal reference
+                result_uri,  # validationURI — full outcome link
                 padded_hash,
             )
             tx_hash = self._send_tx(fn)

--- a/engine/spi/resolution.py
+++ b/engine/spi/resolution.py
@@ -79,6 +79,28 @@ def resolve_expired_signals(  # noqa: ANN001
                 karma_delta=None,
             )
             outcomes.append(outcome)
+
+            # On-chain validation write for expired signals (fail-open)
+            if chain_client is not None and system_agent_id:
+                try:
+                    import hashlib  # noqa: PLC0415
+
+                    validation_uri = f"https://oracle.b1e55ed.permanentupperclass.com/api/v1/outcomes/{signal_id}"
+                    verdict_hash = hashlib.sha3_256(signal_id.encode()).digest()[:32]
+                    chain_client.post_validation(
+                        agent_id=system_agent_id,
+                        verdict="concern",
+                        result_uri=validation_uri,
+                        result_hash=verdict_hash,
+                        context=f"signal:{signal_id} expired (no price data)",
+                    )
+                except Exception:  # noqa: BLE001
+                    import logging  # noqa: PLC0415
+
+                    logging.getLogger("b1e55ed.spi.resolution").warning(
+                        "on-chain validation write failed for expired signal %s (non-fatal)", signal_id, exc_info=True
+                    )
+
             continue
 
         price_change_pct = ((exit_price - entry_price) / entry_price) * 100
@@ -107,24 +129,36 @@ def resolve_expired_signals(  # noqa: ANN001
         )
         outcomes.append(outcome)
 
-        # On-chain karma write (fail-open)
-        if chain_client is not None and system_agent_id and karma_delta is not None:
+        # On-chain karma + validation writes (fail-open)
+        if chain_client is not None and system_agent_id:
             try:
                 import hashlib  # noqa: PLC0415
 
                 file_uri = f"https://oracle.b1e55ed.permanentupperclass.com/api/v1/outcomes/{signal_id}"
                 file_hash = hashlib.sha3_256(signal_id.encode()).digest()[:32]
-                chain_client.post_karma_feedback(
+
+                if karma_delta is not None:
+                    chain_client.post_karma_feedback(
+                        agent_id=system_agent_id,
+                        karma_delta=karma_delta,
+                        tag="spi_karma",
+                        file_uri=file_uri,
+                        file_hash=file_hash,
+                    )
+
+                # Validation write: "pass" for correct, "concern" for incorrect
+                verdict = "pass" if direction_correct else "concern"
+                chain_client.post_validation(
                     agent_id=system_agent_id,
-                    karma_delta=karma_delta,
-                    tag="spi_karma",
-                    file_uri=file_uri,
-                    file_hash=file_hash,
+                    verdict=verdict,
+                    result_uri=file_uri,
+                    result_hash=file_hash,
+                    context=f"signal:{signal_id} direction={'correct' if direction_correct else 'incorrect'} brier={brier:.4f}",
                 )
             except Exception:  # noqa: BLE001
                 import logging  # noqa: PLC0415
 
-                logging.getLogger("b1e55ed.spi.resolution").warning("on-chain karma write failed for signal %s (non-fatal)", signal_id, exc_info=True)
+                logging.getLogger("b1e55ed.spi.resolution").warning("on-chain write failed for signal %s (non-fatal)", signal_id, exc_info=True)
 
         # Phase 2B: check slash conditions after karma update and apply if triggered
         try:


### PR DESCRIPTION
Three fixes to close ERC-8004 compliance gaps before hackathon deadline:

## 1. ValidationRegistry ABI fix
The deployed contract has `postValidation(agentId, verdictStr, context, validationURI, verdictHash)` — 5 params. Our ABI only had 4 (missing `context`), causing every validation write to revert. Fixed.

## 2. Wire ValidationRegistry to SPI resolution
Every resolved SPI signal now posts an on-chain validation verdict:
- Correct prediction → `"pass"`
- Incorrect prediction → `"concern"`
- Expired (no price data) → `"concern"`

This activates the second of three ERC-8004 registries (Identity + Reputation were already live). All three registries now have on-chain writes.

## 3. `/health` root alias
`https://oracle.b1e55ed.permanentupperclass.com/health` was returning 404. Judges hitting this directly got a broken response. Added redirect to `/api/v1/health`. Also added `/health` to the auth bypass list.