### PR TITLE
fix(kill-switch): telegram alert on escalation/reset + verify event persistence

### DIFF
--- a/api/routes/kill_switch.py
+++ b/api/routes/kill_switch.py
@@ -5,8 +5,9 @@ from pydantic import BaseModel, Field
 
 from api.auth_kill_switch import KillSwitchAuthDep
 from api.deps import get_db, get_kill_switch
-from engine.brain.kill_switch import KillSwitch
+from engine.brain.kill_switch import KillSwitch, KillSwitchLevel
 from engine.core.database import Database
+from engine.core.kill_switch_alerts import notify_kill_switch_escalated, notify_kill_switch_reset
 
 router = APIRouter(prefix="/kill-switch", dependencies=[KillSwitchAuthDep], tags=["brain"])
 
@@ -44,6 +45,17 @@ def set_level(
         },
         source="api.kill_switch",
     )
+
+    if level > prev:
+        level_name = KillSwitchLevel(level).name
+        notify_kill_switch_escalated(
+            previous_level=prev,
+            level=level,
+            level_name=level_name,
+            reason=str(payload.reason),
+        )
+    elif level < prev:
+        notify_kill_switch_reset(previous_level=prev, level=level, actor="api")
 
     import contextlib
 

--- a/engine/brain/kill_switch.py
+++ b/engine/brain/kill_switch.py
@@ -62,9 +62,11 @@ class KillSwitch:
         import json as _json
 
         try:
+            canonical_type = getattr(EventType.KILL_SWITCH_V1, "value", str(EventType.KILL_SWITCH_V1))
+            legacy_type = "KILL_SWITCH_V1"
             row = self.db.fetchone(
-                "SELECT payload FROM events WHERE type = ? ORDER BY created_at DESC, rowid DESC LIMIT 1",
-                (getattr(EventType.KILL_SWITCH_V1, "value", str(EventType.KILL_SWITCH_V1)),),
+                "SELECT payload FROM events WHERE type IN (?, ?) ORDER BY created_at DESC, rowid DESC LIMIT 1",
+                (canonical_type, legacy_type),
             )
             if row:
                 data = _json.loads(row[0])
@@ -111,7 +113,12 @@ class KillSwitch:
 
         if crisis_conditions is not None and crisis_conditions >= self.config.kill_switch.l3_crisis_threshold:
             target = max(target, KillSwitchLevel.LOCKDOWN)
-            why = why or f"crisis_conditions={crisis_conditions}"
+            crisis_reason = f"crisis_conditions={crisis_conditions}"
+            if why:
+                if crisis_reason not in why:
+                    why = f"{why};{crisis_reason}"
+            else:
+                why = crisis_reason
 
         if max_drawdown_pct is not None and max_drawdown_pct >= self.config.kill_switch.l4_max_drawdown_pct:
             target = max(target, KillSwitchLevel.EMERGENCY)

--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -46,6 +46,7 @@ from engine.brain.synthesis import SynthesisResult, VectorSynthesis
 from engine.core.config import Config
 from engine.core.database import Database
 from engine.core.events import EventType, canonical_json
+from engine.core.kill_switch_alerts import notify_kill_switch_escalated
 from engine.core.types import TradeIntent
 from engine.security.identity import NodeIdentity
 
@@ -380,7 +381,14 @@ class BrainOrchestrator:
                 q_mult[domain] = 0.0
 
             if degraded_domains and len(degraded_domains) >= len(domains) and len(domains) > 0:
-                self.kill_switch.evaluate(manual_level=KillSwitchLevel.CAUTION, reason="all_domains_degraded")
+                degraded_ks_dec = self.kill_switch.evaluate(manual_level=KillSwitchLevel.CAUTION, reason="all_domains_degraded")
+                if degraded_ks_dec is not None:
+                    notify_kill_switch_escalated(
+                        previous_level=int(degraded_ks_dec.previous_level),
+                        level=int(degraded_ks_dec.level),
+                        level_name=degraded_ks_dec.level.name,
+                        reason=degraded_ks_dec.reason,
+                    )
         except Exception:
             logging.getLogger("b1e55ed.orchestrator").warning("KS-4 degradation check failed", exc_info=True)
 
@@ -474,6 +482,13 @@ class BrainOrchestrator:
         ks_dec = None
         if regime_res.state.regime == "CRISIS":
             ks_dec = self.kill_switch.evaluate(crisis_conditions=self.config.kill_switch.l3_crisis_threshold, reason="regime_crisis")
+            if ks_dec is not None:
+                notify_kill_switch_escalated(
+                    previous_level=int(ks_dec.previous_level),
+                    level=int(ks_dec.level),
+                    level_name=ks_dec.level.name,
+                    reason=ks_dec.reason,
+                )
 
         convictions: dict[str, ConvictionResult] = {}
         intents: list[dict] = []

--- a/engine/core/kill_switch_alerts.py
+++ b/engine/core/kill_switch_alerts.py
@@ -1,0 +1,74 @@
+"""Best-effort Telegram alerts for kill-switch state changes."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+try:
+    from datetime import UTC  # py311+
+except ImportError:  # pragma: no cover
+    from datetime import timezone as _tz  # noqa: PLC0415
+
+    UTC = _tz.utc  # noqa: N806, UP017
+
+_LOG = logging.getLogger("b1e55ed.kill_switch_alerts")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _send_sync(*, token: str, chat_id: str, text: str) -> None:
+    endpoint = f"https://api.telegram.org/bot{token}/sendMessage"
+    body = urlencode({"chat_id": chat_id, "text": text}).encode("utf-8")
+    req = Request(
+        endpoint,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with urlopen(req, timeout=4) as resp:
+        raw = resp.read()
+
+    if not raw:
+        return
+
+    payload = json.loads(raw.decode("utf-8"))
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        raise RuntimeError(str(payload.get("description") or "telegram sendMessage returned ok=false"))
+
+
+def send_telegram_kill_switch_message(text: str) -> None:
+    """Dispatch Telegram message asynchronously; never raises."""
+
+    token = str(os.getenv("TELEGRAM_BOT_TOKEN", "") or "").strip()
+    chat_id = str(os.getenv("TELEGRAM_CHAT_ID", "") or "").strip()
+    if not token or not chat_id:
+        return
+
+    def _worker() -> None:
+        try:
+            _send_sync(token=token, chat_id=chat_id, text=text)
+        except Exception:
+            _LOG.warning("Kill-switch Telegram notification failed", exc_info=True)
+
+    try:
+        threading.Thread(target=_worker, name="kill-switch-telegram-alert", daemon=True).start()
+    except Exception:
+        _LOG.warning("Failed to start kill-switch Telegram alert thread", exc_info=True)
+
+
+def notify_kill_switch_escalated(*, previous_level: int, level: int, level_name: str, reason: str) -> None:
+    message = f"🚨 Kill Switch Escalated\nLevel: {previous_level} → {level} ({level_name})\nReason: {reason or 'unspecified'}\nTime: {_utc_timestamp()}"
+    send_telegram_kill_switch_message(message)
+
+
+def notify_kill_switch_reset(*, previous_level: int, level: int, actor: str) -> None:
+    message = f"✅ Kill Switch Reset\nLevel: {previous_level} → {level}\nBy: {actor or 'unknown'}\nTime: {_utc_timestamp()}"
+    send_telegram_kill_switch_message(message)


### PR DESCRIPTION
## Problem

Kill switch reached L3 (LOCKDOWN/regime_crisis) on ~2026-03-29 and stayed there for 4 days with no notification. Trading was halted silently.

## Root cause

No Telegram alert on kill switch escalation. The `evaluate()` method escalates and persists to DB but never notifies the operator.

## Changes

- **`engine/core/kill_switch_alerts.py`** — new stdlib-only Telegram alert helper (daemon thread, best-effort, reads `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` from env)
- **`engine/brain/orchestrator.py`** — alert after both KS escalation callsites (`regime_crisis`, `all_domains_degraded`)
- **`api/routes/kill_switch.py`** — alert on manual set/reset via API
- **`engine/brain/kill_switch.py`** — richer reason strings, backward-compatible `_restore_from_db()` for both event type strings

## Deploy note

Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `/home/ubuntu/.b1e55ed/env` on blessed-patient-zero.

## Tests

8/8 passing (`test_kill_switch_auth.py`, `test_kill_switch_persistence.py`)