### PR TITLE
feat: wire city memory layer — log heartbeats, signals, alerts to knowledge graph

### DIFF
--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -808,4 +808,12 @@ class BrainOrchestrator:
             logging.getLogger("b1e55ed.orchestrator").debug("SPI resolution skipped (non-fatal)", exc_info=True)
 
         self.hooks.post_cycle(PostCycleContext(config=self.config, db=self.db, cycle_id=cycle_id, result=result))
+
+        try:
+            from engine.core.city_memory import log_heartbeat
+
+            log_heartbeat(checks_run=["price_check", "position_monitor"], issues=[])
+        except Exception:
+            pass  # never block the brain
+
         return result

--- a/engine/core/city_memory.py
+++ b/engine/core/city_memory.py
@@ -1,0 +1,125 @@
+"""
+City memory client — writes task outcomes to alpha-co knowledge graph via SSH.
+Called from b1e55ed heartbeat/orchestrator after task completions.
+Non-blocking: runs in daemon thread, never raises to caller.
+"""
+
+import json
+import os
+import subprocess
+import threading
+import uuid
+
+ALPHA_CO_IP = "192.168.1.20"
+SSH_KEY = os.path.expanduser("~/.ssh/b1e55ed_city")
+CITY_REPO = "/home/ubuntu/city"
+DB_PATH = "/home/ubuntu/datasette-data/knowledge.db"
+
+
+def _ssh_write(python_code: str) -> bool:
+    """Run python3 on alpha-co to write to the knowledge DB. Returns True on success."""
+    try:
+        cmd = [
+            "ssh",
+            "-i",
+            SSH_KEY,
+            "-n",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "ConnectTimeout=5",
+            f"ubuntu@{ALPHA_CO_IP}",
+            f"cd {CITY_REPO} && CITY_MEMORY_DB={DB_PATH} python3 -c {json.dumps(python_code)}",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _write_async(python_code: str):
+    """Fire-and-forget SSH write in daemon thread."""
+    t = threading.Thread(target=_ssh_write, args=(python_code,), daemon=True)
+    t.start()
+
+
+def log_task(
+    agent_id: str,
+    task_type: str,
+    label: str,
+    outcome: str,
+    confidence: float = None,
+    duration_s: int = None,
+    metadata: dict = None,
+):
+    """
+    Log a completed task to the city knowledge graph.
+    Called after any significant b1e55ed operation completes.
+    Non-blocking — fire and forget.
+
+    Args:
+        agent_id: e.g. "b1e55ed", "worker-1", "clawteam-engineering"
+        task_type: e.g. "research", "trade_signal", "heartbeat_check", "alert"
+        label: short description of what was done
+        outcome: "success", "failure", "partial", "blocked"
+        confidence: optional float 0-1
+        duration_s: optional duration in seconds
+        metadata: optional extra context dict
+    """
+    task_id = f"task:{uuid.uuid4().hex[:8]}"
+    data = {
+        "task_type": task_type,
+        "outcome": outcome,
+        "agent_id": agent_id,
+    }
+    if confidence is not None:
+        data["confidence"] = confidence
+    if duration_s is not None:
+        data["duration_s"] = duration_s
+    if metadata:
+        data.update(metadata)
+
+    code = f"""
+import sys
+sys.path.insert(0, 'infra')
+from memory import init_db, write_node, write_edge, log_event, DB_PATH
+init_db()
+task_id = write_node("task", {json.dumps(label)}, {json.dumps(data)}, node_id={json.dumps(task_id)})
+write_edge({json.dumps(f"agent:{agent_id}")}, task_id, "completed")
+log_event({json.dumps(agent_id)}, "task_complete", {json.dumps({"task_id": task_id, "outcome": outcome, "task_type": task_type})})
+"""
+    _write_async(code)
+
+
+def log_signal(symbol: str, direction: str, confidence: float, source: str = "b1e55ed"):
+    """Log a trade signal emission."""
+    log_task(
+        agent_id=source,
+        task_type="trade_signal",
+        label=f"Signal: {direction} {symbol}",
+        outcome="emitted",
+        confidence=confidence,
+        metadata={"symbol": symbol, "direction": direction},
+    )
+
+
+def log_alert(alert_type: str, message: str, severity: str = "info"):
+    """Log an alert (kill switch, position alert, etc.)."""
+    log_task(
+        agent_id="b1e55ed",
+        task_type="alert",
+        label=f"Alert: {alert_type}",
+        outcome="triggered",
+        metadata={"alert_type": alert_type, "message": message[:200], "severity": severity},
+    )
+
+
+def log_heartbeat(checks_run: list, issues: list = None):
+    """Log a heartbeat cycle completion."""
+    log_task(
+        agent_id="b1e55ed",
+        task_type="heartbeat",
+        label=f"Heartbeat: {len(checks_run)} checks",
+        outcome="success" if not issues else "partial",
+        metadata={"checks": checks_run, "issues": issues or []},
+    )

--- a/engine/core/city_memory_test.py
+++ b/engine/core/city_memory_test.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from engine.core import city_memory
+
+
+class TestCityMemory(unittest.TestCase):
+    def test_log_task_constructs_correct_python_code_string(self):
+        captured: dict[str, str] = {}
+
+        with (
+            patch(
+                "engine.core.city_memory._write_async",
+                side_effect=lambda code: captured.setdefault("code", code),
+            ),
+            patch("engine.core.city_memory.uuid.uuid4", return_value=SimpleNamespace(hex="abc12345def67890")),
+        ):
+            city_memory.log_task(
+                agent_id="b1e55ed",
+                task_type="research",
+                label="Test task",
+                outcome="success",
+                confidence=0.9,
+                duration_s=12,
+                metadata={"symbol": "BTC"},
+            )
+
+        code = captured["code"]
+        self.assertIn("sys.path.insert(0, 'infra')", code)
+        self.assertIn('write_node("task", "Test task"', code)
+        self.assertIn('node_id="task:abc12345"', code)
+        self.assertIn('write_edge("agent:b1e55ed", task_id, "completed")', code)
+        self.assertIn(
+            'log_event("b1e55ed", "task_complete", {"task_id": "task:abc12345", "outcome": "success", "task_type": "research"})',
+            code,
+        )
+
+    def test_log_signal_calls_log_task_with_trade_signal(self):
+        with patch("engine.core.city_memory.log_task") as mock_log_task:
+            city_memory.log_signal(symbol="BTC", direction="long", confidence=0.77, source="alpha-agent")
+
+        mock_log_task.assert_called_once_with(
+            agent_id="alpha-agent",
+            task_type="trade_signal",
+            label="Signal: long BTC",
+            outcome="emitted",
+            confidence=0.77,
+            metadata={"symbol": "BTC", "direction": "long"},
+        )
+
+    def test_log_alert_calls_log_task_with_alert_type(self):
+        with patch("engine.core.city_memory.log_task") as mock_log_task:
+            city_memory.log_alert(alert_type="kill_switch", message="paused", severity="high")
+
+        mock_log_task.assert_called_once_with(
+            agent_id="b1e55ed",
+            task_type="alert",
+            label="Alert: kill_switch",
+            outcome="triggered",
+            metadata={"alert_type": "kill_switch", "message": "paused", "severity": "high"},
+        )
+
+    def test_log_heartbeat_no_issues_is_success(self):
+        with patch("engine.core.city_memory.log_task") as mock_log_task:
+            city_memory.log_heartbeat(checks_run=["price_check", "position_monitor"])
+
+        mock_log_task.assert_called_once_with(
+            agent_id="b1e55ed",
+            task_type="heartbeat",
+            label="Heartbeat: 2 checks",
+            outcome="success",
+            metadata={"checks": ["price_check", "position_monitor"], "issues": []},
+        )
+
+    def test_log_heartbeat_with_issues_is_partial(self):
+        with patch("engine.core.city_memory.log_task") as mock_log_task:
+            city_memory.log_heartbeat(checks_run=["price_check"], issues=["price feed stale"])
+
+        mock_log_task.assert_called_once_with(
+            agent_id="b1e55ed",
+            task_type="heartbeat",
+            label="Heartbeat: 1 checks",
+            outcome="partial",
+            metadata={"checks": ["price_check"], "issues": ["price feed stale"]},
+        )
+
+    def test_write_async_spawns_daemon_thread(self):
+        fake_thread = MagicMock()
+        with patch("engine.core.city_memory.threading.Thread", return_value=fake_thread) as mock_thread:
+            city_memory._write_async("print('ok')")
+
+        mock_thread.assert_called_once_with(target=city_memory._ssh_write, args=("print('ok')",), daemon=True)
+        fake_thread.start.assert_called_once()
+
+    def test_ssh_failure_is_caught_silently(self):
+        with patch("engine.core.city_memory.subprocess.run", side_effect=RuntimeError("ssh down")):
+            result = city_memory._ssh_write("print('ok')")
+
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `engine/core/city_memory.py` thin async SSH client to write task memory records to alpha-co knowledge DB
- add `engine/core/city_memory_test.py` coverage for task construction, signal/alert/heartbeat wrappers, async thread behavior, and SSH failure handling
- wire heartbeat logging hook in `engine/brain/orchestrator.py` (fail-open try/except) so brain cycle completion emits city memory heartbeat

## Validation
- `python3 engine/core/city_memory_test.py`