### PR TITLE
feat(brain): add PauseGate — lightweight single-cycle interrupt without kill switch escalation

### DIFF
--- a/docs/operations/cli-reference.mdx
+++ b/docs/operations/cli-reference.mdx
@@ -70,6 +70,26 @@ b1e55ed brain [--full] [--json]
 | `--full` | Include slower producers / more expensive work |
 | `--json` | Emit JSON summary (cron/automation friendly) |
 
+### `b1e55ed pause`
+
+Pause the trading engine for one cycle (soft gate).
+
+```bash
+b1e55ed pause --reason "<reason>"
+```
+
+| Flag | Description |
+|---|---|
+| `--reason` | Required human-readable reason recorded with the pause gate |
+
+### `b1e55ed resume`
+
+Clear the pause gate and allow normal engine execution to continue.
+
+```bash
+b1e55ed resume
+```
+
 ### `b1e55ed signal`
 
 Inject operator intel as a **curator** signal.

--- a/engine/brain/kill_switch.py
+++ b/engine/brain/kill_switch.py
@@ -9,6 +9,7 @@ Auto-escalate, never auto-de-escalate.
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from enum import IntEnum
 
@@ -42,6 +43,62 @@ class KillSwitchDecision:
     previous_level: KillSwitchLevel
     reason: str
     auto: bool
+
+
+class PauseGate:
+    """Single-cycle pause gate with immutable event-log semantics.
+
+    Pause is active when the latest ``system.pause.v1`` event is newer than
+    the latest ``system.pause.consumed.v1`` event.
+
+    Consuming a pause writes ``system.pause.consumed.v1`` and never mutates
+    existing events.
+    """
+
+    def __init__(self, db: Database):
+        self.db = db
+
+    def is_paused(self) -> tuple[bool, str | None]:
+        """Return ``(paused, reason)`` for the current pause gate state."""
+        import json as _json
+
+        try:
+            pause_row = self.db.fetchone(
+                "SELECT rowid, payload FROM events WHERE type = ? ORDER BY rowid DESC LIMIT 1",
+                (EventType.PAUSE_V1.value,),
+            )
+            if not pause_row:
+                return False, None
+
+            pause_rowid = int(pause_row[0])
+            pause_payload = pause_row[1]
+
+            consumed_row = self.db.fetchone(
+                "SELECT rowid FROM events WHERE type = ? ORDER BY rowid DESC LIMIT 1",
+                (EventType.PAUSE_CONSUMED_V1.value,),
+            )
+            if consumed_row is not None and int(consumed_row[0]) >= pause_rowid:
+                return False, None
+
+            data = _json.loads(pause_payload) if isinstance(pause_payload, str) else pause_payload
+            if not isinstance(data, dict):
+                return True, "operator pause"
+
+            reason = data.get("reason")
+            if reason is None or str(reason).strip() == "":
+                return True, "operator pause"
+            return True, str(reason)
+        except Exception:
+            return False, None
+
+    def consume(self) -> None:
+        """Write a consumed marker for the active pause (best effort)."""
+        with contextlib.suppress(Exception):
+            self.db.append_event(
+                event_type=EventType.PAUSE_CONSUMED_V1,
+                payload={"consumed_by": "orchestrator", "auto": True},
+                source="brain.orchestrator",
+            )
 
 
 class KillSwitch:

--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -39,7 +39,7 @@ from engine.brain.conviction import ConvictionEngine, ConvictionResult
 from engine.brain.data_quality import DataQualityMonitor, DataQualityResult
 from engine.brain.decision import DecisionEngine
 from engine.brain.hooks import BrainHooks, PostCycleContext, PreCycleContext
-from engine.brain.kill_switch import KillSwitch, KillSwitchDecision, KillSwitchLevel
+from engine.brain.kill_switch import KillSwitch, KillSwitchDecision, KillSwitchLevel, PauseGate
 from engine.brain.learning import StratificationTracker
 from engine.brain.regime import RegimeDetector, RegimeResult
 from engine.brain.synthesis import SynthesisResult, VectorSynthesis
@@ -87,6 +87,7 @@ class BrainOrchestrator:
         self.synthesis = VectorSynthesis(config, db)
         self.regime = RegimeDetector(db)
         self.kill_switch = KillSwitch(config, db)
+        self.pause_gate = PauseGate(db)
         self.conviction = ConvictionEngine(config, db, node_id=identity.node_id)
         self.decision = DecisionEngine(config, db)
         self.stratification = StratificationTracker(db)
@@ -350,6 +351,14 @@ class BrainOrchestrator:
         if int(ks_level) >= int(KillSwitchLevel.DEFENSIVE):
             logging.getLogger("b1e55ed.orchestrator").warning("Brain cycle aborted: kill switch level %s is active", ks_level)
             raise RuntimeError(f"Brain cycle blocked by kill switch (level={ks_level})")
+
+        paused, pause_reason = self.pause_gate.is_paused()
+        if paused:
+            reason = str(pause_reason or "operator pause")
+            _log = logging.getLogger("b1e55ed.orchestrator")
+            _log.warning("Brain cycle paused by operator: %s", reason)
+            self.pause_gate.consume()
+            raise RuntimeError(f"Brain cycle paused: {reason}")
 
         cycle_id = str(uuid.uuid4())
         cycle_started_at = datetime.now(tz=UTC)

--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -421,6 +421,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit machine-readable JSON.",
     )
 
+    p_pause = sub.add_parser("pause", help="Pause the next brain cycle")
+    p_pause.add_argument(
+        "--reason",
+        default="operator pause",
+        help="Reason written to system.pause.v1.",
+    )
+    p_pause.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+
+    p_resume = sub.add_parser("resume", help="Clear active pause gate")
+    p_resume.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+
     p_health = sub.add_parser("health", help="System health check")
     p_health.add_argument(
         "--json",
@@ -1816,6 +1835,49 @@ def _cmd_kill_switch(ctx: CliContext, args: argparse.Namespace) -> int:
         print(_json_dumps(state))
     else:
         print(f"kill switch: L{state['level']}\nreason: {state['reason']}")
+    return 0
+
+
+def _cmd_pause(ctx: CliContext, args: argparse.Namespace) -> int:
+    from engine.core.database import Database
+    from engine.core.events import EventType
+
+    repo_root = ctx.repo_root
+    db = Database(_resolve_db_path(repo_root))
+
+    reason = str(getattr(args, "reason", "operator pause") or "").strip() or "operator pause"
+    payload = {
+        "reason": reason,
+        "actor": "operator",
+    }
+    ev = db.append_event(event_type=EventType.PAUSE_V1, payload=payload, source="cli.pause")
+
+    out = {"status": "ok", "event_id": ev.id, "payload": payload}
+    if bool(getattr(args, "json", False)):
+        print(_json_dumps(out))
+    else:
+        print(f"pause requested: {reason} (event {ev.id})")
+    return 0
+
+
+def _cmd_resume(ctx: CliContext, args: argparse.Namespace) -> int:
+    from engine.core.database import Database
+    from engine.core.events import EventType
+
+    repo_root = ctx.repo_root
+    db = Database(_resolve_db_path(repo_root))
+
+    payload = {
+        "consumed_by": "operator",
+        "auto": False,
+    }
+    ev = db.append_event(event_type=EventType.PAUSE_CONSUMED_V1, payload=payload, source="cli.resume")
+
+    out = {"status": "ok", "event_id": ev.id, "payload": payload}
+    if bool(getattr(args, "json", False)):
+        print(_json_dumps(out))
+    else:
+        print(f"pause cleared (event {ev.id})")
     return 0
 
 
@@ -4223,6 +4285,8 @@ def main(argv: list[str] | None = None) -> int:
         "eas": _cmd_eas,
         "webhooks": _cmd_webhooks,
         "kill-switch": _cmd_kill_switch,
+        "pause": _cmd_pause,
+        "resume": _cmd_resume,
         "health": _cmd_health,
         "resolve-outcomes": _cmd_resolve_outcomes,
         "resolve-spi": _cmd_resolve_spi,

--- a/engine/core/events.py
+++ b/engine/core/events.py
@@ -60,8 +60,10 @@ class EventType(StrEnum):
     POSITION_CLOSED_V1 = "execution.position_closed.v1"
     POSITION_UPDATED_V1 = "execution.position_updated.v1"
 
-    # Kill switch
+    # Kill switch and cycle pause controls
     KILL_SWITCH_V1 = "system.kill_switch.v1"
+    PAUSE_V1 = "system.pause.v1"
+    PAUSE_CONSUMED_V1 = "system.pause.consumed.v1"
 
     # Karma
     KARMA_INTENT_V1 = "karma.intent.v1"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,6 +72,8 @@ def test_cli_help_includes_subcommands(capsys: pytest.CaptureFixture[str]) -> No
     assert "positions" in out
     assert "webhooks" in out
     assert "kill-switch" in out
+    assert "pause" in out
+    assert "resume" in out
     assert "health" in out
     assert "api" in out
     assert "dashboard" in out
@@ -106,6 +108,8 @@ def test_cli_unknown_command_errors(capsys: pytest.CaptureFixture[str]) -> None:
         "positions",
         "webhooks",
         "kill-switch",
+        "pause",
+        "resume",
         "health",
         "api",
         "dashboard",
@@ -217,6 +221,28 @@ def test_cli_kill_switch_set_and_show(tmp_path: Path, monkeypatch: pytest.Monkey
     assert rc == 0
     show_payload = json.loads(capsys.readouterr().out)
     assert show_payload["level"] == 3
+
+
+def test_cli_pause_and_resume_emit_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    repo_root = _scaffold_repo(tmp_path, monkeypatch)
+    monkeypatch.chdir(repo_root)
+
+    rc = main(["pause", "--reason", "reviewing signals", "--json"])
+    assert rc == 0
+    pause_payload = json.loads(capsys.readouterr().out)
+    assert pause_payload["payload"]["reason"] == "reviewing signals"
+
+    rc = main(["resume", "--json"])
+    assert rc == 0
+    resume_payload = json.loads(capsys.readouterr().out)
+    assert resume_payload["payload"]["consumed_by"] == "operator"
+
+    db = Database(tmp_path / "home" / ".b1e55ed" / "data" / "brain.db")
+    pause_events = db.get_events(event_type=EventType.PAUSE_V1, limit=1)
+    consumed_events = db.get_events(event_type=EventType.PAUSE_CONSUMED_V1, limit=1)
+
+    assert pause_events
+    assert consumed_events
 
 
 def test_cli_alerts_and_positions_json_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_kill_switch.py
+++ b/tests/unit/test_kill_switch.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from engine.brain.kill_switch import KillSwitch, KillSwitchLevel
+import pytest
+
+from engine.brain.kill_switch import KillSwitch, KillSwitchLevel, PauseGate
+from engine.brain.orchestrator import BrainOrchestrator
 from engine.core.database import Database
+from engine.core.events import EventType
+from engine.security.identity import generate_node_identity
 
 
 def test_kill_switch_5_levels_escalates_and_never_auto_deescalates(test_config, temp_dir):
@@ -28,3 +33,80 @@ def test_kill_switch_5_levels_escalates_and_never_auto_deescalates(test_config, 
     d5 = ks.evaluate(manual_level=KillSwitchLevel.SHUTDOWN, reason="manual_test")
     assert d5 is not None
     assert ks.level == KillSwitchLevel.SHUTDOWN
+
+
+def test_pause_gate_not_paused_by_default(temp_dir):
+    db = Database(temp_dir / "brain.db")
+    gate = PauseGate(db)
+
+    paused, reason = gate.is_paused()
+
+    assert paused is False
+    assert reason is None
+
+
+def test_pause_gate_active_after_pause_event(temp_dir):
+    db = Database(temp_dir / "brain.db")
+    gate = PauseGate(db)
+
+    db.append_event(
+        event_type=EventType.PAUSE_V1,
+        payload={"reason": "reviewing signals"},
+        source="test.pause",
+    )
+
+    paused, reason = gate.is_paused()
+
+    assert paused is True
+    assert reason == "reviewing signals"
+
+
+def test_pause_gate_consumed_after_orchestrator_reads(test_config, temp_dir, monkeypatch):
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+
+    db = Database(temp_dir / "brain.db")
+    db.append_event(
+        event_type=EventType.PAUSE_V1,
+        payload={"reason": "manual interject"},
+        source="test.pause",
+    )
+
+    ident = generate_node_identity()
+    orch = BrainOrchestrator(test_config, db, ident)
+
+    with pytest.raises(RuntimeError, match="Brain cycle paused: manual interject"):
+        orch.run_cycle(["BTC"])
+
+    consumed = db.get_events(event_type=EventType.PAUSE_CONSUMED_V1, limit=1)
+    assert consumed
+
+    gate = PauseGate(db)
+    paused, reason = gate.is_paused()
+
+    assert paused is False
+    assert reason is None
+
+
+def test_resume_clears_pause(temp_dir):
+    db = Database(temp_dir / "brain.db")
+    gate = PauseGate(db)
+
+    db.append_event(
+        event_type=EventType.PAUSE_V1,
+        payload={"reason": "operator pause"},
+        source="test.pause",
+    )
+    paused, reason = gate.is_paused()
+    assert paused is True
+    assert reason == "operator pause"
+
+    db.append_event(
+        event_type=EventType.PAUSE_CONSUMED_V1,
+        payload={"consumed_by": "operator", "auto": False},
+        source="test.resume",
+    )
+
+    paused, reason = gate.is_paused()
+
+    assert paused is False
+    assert reason is None


### PR DESCRIPTION
## Problem
Today there is no lightweight way to interject mid-run in the brain cycle:

- `systemctl stop b1e55ed` is a hard stop (not graceful)
- Raising kill-switch to `DEFENSIVE+` blocks trading until manually reset

That makes operator pauses heavier than they need to be.

## Solution
This PR adds a dedicated pause gate backed by immutable events:

- New event types:
  - `system.pause.v1`
  - `system.pause.consumed.v1`
- New `PauseGate` in `engine/brain/kill_switch.py`
  - Pause is active when latest `system.pause.v1` is newer than latest `system.pause.consumed.v1`
  - Consuming a pause writes a `system.pause.consumed.v1` marker (no event mutation)
- `BrainOrchestrator` wiring:
  - At the top of `run_cycle()`, after kill-switch check, pause is evaluated
  - If paused, cycle logs warning, consumes pause marker, and raises `RuntimeError` for that cycle

## CLI usage
Added operator helpers:

```bash
b1e55ed pause --reason "reviewing signals"
b1e55ed resume
```

- `pause` writes `system.pause.v1`
- `resume` writes `system.pause.consumed.v1`

## Tests
Added/updated tests covering:

- `test_pause_gate_not_paused_by_default`
- `test_pause_gate_active_after_pause_event`
- `test_pause_gate_consumed_after_orchestrator_reads`
- `test_resume_clears_pause`
- CLI pause/resume command behavior

Also verified with targeted unit suite for kill switch, orchestrator, and CLI.
