### PR TITLE
fix(kill-switch): allow GET /status without kill_switch_token

### DIFF
--- a/api/routes/kill_switch.py
+++ b/api/routes/kill_switch.py
@@ -9,7 +9,7 @@ from engine.brain.kill_switch import KillSwitch, KillSwitchLevel
 from engine.core.database import Database
 from engine.core.kill_switch_alerts import notify_kill_switch_escalated, notify_kill_switch_reset
 
-router = APIRouter(prefix="/kill-switch", dependencies=[KillSwitchAuthDep], tags=["brain"])
+router = APIRouter(prefix="/kill-switch", tags=["brain"])
 
 
 class KillSwitchSetRequest(BaseModel):
@@ -22,7 +22,7 @@ def status(ks: KillSwitch = Depends(get_kill_switch)) -> dict:
     return {"level": int(ks.level)}
 
 
-@router.post("/set")
+@router.post("/set", dependencies=[KillSwitchAuthDep])
 def set_level(
     payload: KillSwitchSetRequest,
     db: Database = Depends(get_db),


### PR DESCRIPTION
## Summary
- GET `/api/v1/kill-switch/status` was returning HTTP 500 ("Kill switch auth token is not configured") because the `KillSwitchAuthDep` was applied at the router level, affecting all endpoints
- Moved the auth dependency from the router to only the POST `/set` endpoint, so the read-only status check works without `kill_switch_token`
- POST `/set` still requires the kill switch auth token as before

## Test plan
- [x] Existing kill switch tests pass (22 tests across 5 test files)
- [ ] Verify GET `/api/v1/kill-switch/status` returns 200 without kill_switch_token configured
- [ ] Verify POST `/api/v1/kill-switch/set` still requires kill_switch_token

🤖 Generated with [Claude Code](https://claude.com/claude-code)