### PR TITLE
fix(cts): replace binary thresholds with continuous linear ramps

### DIFF
--- a/engine/brain/conviction.py
+++ b/engine/brain/conviction.py
@@ -78,35 +78,39 @@ class CounterThesis:
     high-confidence mistakes, not to find trades.
     """
 
+    @staticmethod
+    def _linear_ramp(value: float, lo: float, hi: float, max_score: float) -> float:
+        """Linear interpolation: 0 at *lo*, *max_score* at *hi*, clamped."""
+        if value <= lo:
+            return 0.0
+        if value >= hi:
+            return max_score
+        return max_score * (value - lo) / (hi - lo)
+
     def compute(self, *, synthesis: SynthesisResult, pcs: float, regime: str) -> float:
         # Return 0..100 (higher = more counter-evidence).
         snap = synthesis.snapshot
         tech = snap.features.get("technical", {})
         tradfi = snap.features.get("tradfi", {})
 
-        penalties: list[float] = []
+        score = 0.0
 
         rsi = tech.get("rsi_14")
-        if rsi is not None and float(rsi) >= 70.0:
-            penalties.append(25.0)
+        if rsi is not None:
+            score += self._linear_ramp(float(rsi), 55.0, 80.0, 25.0)
 
         funding = tradfi.get("funding_annualized")
-        if funding is not None and float(funding) >= 30.0:
-            penalties.append(25.0)
+        if funding is not None:
+            score += self._linear_ramp(float(funding), 10.0, 40.0, 25.0)
 
         basis = tradfi.get("basis_annualized")
-        if basis is not None and float(basis) >= 8.0:
-            penalties.append(20.0)
+        if basis is not None:
+            score += self._linear_ramp(float(basis), 4.0, 12.0, 20.0)
 
         if regime == "CRISIS":
-            penalties.append(30.0)
+            score += 30.0
 
-        # If we have any explicit contradictions, CTS ramps.
-        base = sum(penalties)
-        if base > 0:
-            base += 10.0
-
-        return float(_clamp(base, 0.0, 100.0))
+        return float(_clamp(score, 0.0, 100.0))
 
 
 class ConvictionEngine:

--- a/tests/unit/test_conviction.py
+++ b/tests/unit/test_conviction.py
@@ -270,9 +270,11 @@ class TestCounterThesisContinuousScoring:
 
     def test_total_clamped_to_100(self) -> None:
         """Even with all penalties maxed, CTS should not exceed 100."""
-        synth = self._synth({
-            "technical": {"rsi_14": 90.0},
-            "tradfi": {"funding_annualized": 50.0, "basis_annualized": 20.0},
-        })
+        synth = self._synth(
+            {
+                "technical": {"rsi_14": 90.0},
+                "tradfi": {"funding_annualized": 50.0, "basis_annualized": 20.0},
+            }
+        )
         cts = self.ct.compute(synthesis=synth, pcs=80.0, regime="CRISIS")
         assert cts == pytest.approx(100.0)

--- a/tests/unit/test_conviction.py
+++ b/tests/unit/test_conviction.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
 
 import pytest
 
-from engine.brain.conviction import ConvictionEngine, _confidence_v1
+from engine.brain.conviction import ConvictionEngine, CounterThesis, _confidence_v1
 from engine.core.database import Database
 from engine.core.types import FeatureSnapshot
 from engine.security.identity import generate_node_identity
@@ -200,3 +200,79 @@ def test_confidence_always_clamped_to_contract_bounds(regime: str | None) -> Non
         for cts in range(-100, 401, 25):
             confidence = _confidence_v1(pcs=float(pcs), cts=float(cts), regime=regime)
             assert 0.1 <= confidence <= 0.95
+
+
+# --- CTS continuous scoring tests ---
+
+
+class TestCounterThesisContinuousScoring:
+    """Verify that CTS uses continuous ramps instead of binary thresholds."""
+
+    ct = CounterThesis()
+
+    def _synth(self, features: dict[str, dict[str, float]]):
+        return _build_synthesis(weighted_score=0.8, features=features)
+
+    def test_rsi_gradient(self) -> None:
+        """RSI penalty should increase continuously between 55 and 80."""
+        scores = []
+        for rsi in [50, 55, 60, 67.5, 75, 80, 90]:
+            synth = self._synth({"technical": {"rsi_14": float(rsi)}})
+            cts = self.ct.compute(synthesis=synth, pcs=80.0, regime="BULL")
+            scores.append(cts)
+
+        # Below 55: zero
+        assert scores[0] == 0.0
+        assert scores[1] == 0.0
+        # Midpoint (67.5) should give 12.5
+        assert scores[3] == pytest.approx(12.5)
+        # At 80: full 25
+        assert scores[4] < scores[5]
+        assert scores[5] == pytest.approx(25.0)
+        # Above 80: still capped at 25
+        assert scores[6] == pytest.approx(25.0)
+        # Monotonically non-decreasing
+        for i in range(1, len(scores)):
+            assert scores[i] >= scores[i - 1]
+
+    def test_funding_gradient(self) -> None:
+        """Funding penalty should ramp from 0 at 10 to 25 at 40."""
+        synth_lo = self._synth({"tradfi": {"funding_annualized": 10.0}})
+        synth_mid = self._synth({"tradfi": {"funding_annualized": 25.0}})
+        synth_hi = self._synth({"tradfi": {"funding_annualized": 40.0}})
+
+        assert self.ct.compute(synthesis=synth_lo, pcs=80.0, regime="BULL") == 0.0
+        assert self.ct.compute(synthesis=synth_mid, pcs=80.0, regime="BULL") == pytest.approx(12.5)
+        assert self.ct.compute(synthesis=synth_hi, pcs=80.0, regime="BULL") == pytest.approx(25.0)
+
+    def test_basis_gradient(self) -> None:
+        """Basis penalty should ramp from 0 at 4 to 20 at 12."""
+        synth_lo = self._synth({"tradfi": {"basis_annualized": 4.0}})
+        synth_mid = self._synth({"tradfi": {"basis_annualized": 8.0}})
+        synth_hi = self._synth({"tradfi": {"basis_annualized": 12.0}})
+
+        assert self.ct.compute(synthesis=synth_lo, pcs=80.0, regime="BULL") == 0.0
+        assert self.ct.compute(synthesis=synth_mid, pcs=80.0, regime="BULL") == pytest.approx(10.0)
+        assert self.ct.compute(synthesis=synth_hi, pcs=80.0, regime="BULL") == pytest.approx(20.0)
+
+    def test_crisis_still_binary(self) -> None:
+        """CRISIS regime should still add a flat +30."""
+        synth = self._synth({"technical": {"rsi_14": 50.0}})
+        cts = self.ct.compute(synthesis=synth, pcs=80.0, regime="CRISIS")
+        assert cts == pytest.approx(30.0)
+
+    def test_no_base_penalty(self) -> None:
+        """No extra +10 base penalty -- continuous scoring makes it unnecessary."""
+        synth = self._synth({"technical": {"rsi_14": 56.0}})
+        cts = self.ct.compute(synthesis=synth, pcs=80.0, regime="BULL")
+        # RSI=56 => ramp = 25 * (56-55)/(80-55) = 1.0; no +10 base
+        assert cts == pytest.approx(1.0)
+
+    def test_total_clamped_to_100(self) -> None:
+        """Even with all penalties maxed, CTS should not exceed 100."""
+        synth = self._synth({
+            "technical": {"rsi_14": 90.0},
+            "tradfi": {"funding_annualized": 50.0, "basis_annualized": 20.0},
+        })
+        cts = self.ct.compute(synthesis=synth, pcs=80.0, regime="CRISIS")
+        assert cts == pytest.approx(100.0)


### PR DESCRIPTION
## Summary
- Replace binary CTS thresholds (RSI>=70, funding>=30, basis>=8) with continuous linear ramps that produce a gradient score instead of 0-or-jump behavior
- RSI: ramps 0->25 over [55,80]; funding: 0->25 over [10,40]; basis: 0->20 over [4,12]
- Keep CRISIS regime as binary +30 (discrete state); remove the +10 base penalty
- Add 6 new tests covering gradient behavior, boundary values, and clamp to 0-100

## Test plan
- [x] All 18 existing conviction tests pass unchanged
- [x] 6 new `TestCounterThesisContinuousScoring` tests validate ramp behavior at boundaries, midpoints, and extremes

🤖 Generated with [Claude Code](https://claude.com/claude-code)