### PR TITLE
fix(database): use BEGIN EXCLUSIVE to prevent hash chain forks

### DIFF
--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -1071,25 +1071,36 @@ class Database:
                     getattr(event_type, "value", str(event_type)),
                 )
 
-        with self._lock, self.conn:
-            ev = self._append_event_inner(
-                event_type=event_type,
-                payload=payload,
-                event_id=event_id,
-                observed_at=observed_at,
-                source=source,
-                contributor_id=contributor_id,
-                trace_id=trace_id,
-                schema_version=schema_version,
-                dedupe_key=dedupe_key,
-                ts=ts,
-            )
-            # Periodic cleanup of stale api_rate_limits records (every 500 appends).
-            # Runs inside the existing transaction to avoid an extra round-trip.
-            self._cleanup_counter += 1
-            if self._cleanup_counter >= 500:
-                self._cleanup_counter = 0
-                self.conn.execute("DELETE FROM api_rate_limits WHERE window_start < (strftime('%s', 'now') - 3600)")
+        with self._lock:
+            # Use BEGIN EXCLUSIVE to prevent concurrent connections (other
+            # processes sharing this WAL-mode database) from reading last_hash
+            # between our read and insert — the default BEGIN DEFERRED only
+            # acquires a shared lock on read, allowing two writers to fork
+            # the hash chain.
+            self.conn.execute("BEGIN EXCLUSIVE")
+            try:
+                ev = self._append_event_inner(
+                    event_type=event_type,
+                    payload=payload,
+                    event_id=event_id,
+                    observed_at=observed_at,
+                    source=source,
+                    contributor_id=contributor_id,
+                    trace_id=trace_id,
+                    schema_version=schema_version,
+                    dedupe_key=dedupe_key,
+                    ts=ts,
+                )
+                # Periodic cleanup of stale api_rate_limits records (every 500 appends).
+                # Runs inside the existing transaction to avoid an extra round-trip.
+                self._cleanup_counter += 1
+                if self._cleanup_counter >= 500:
+                    self._cleanup_counter = 0
+                    self.conn.execute("DELETE FROM api_rate_limits WHERE window_start < (strftime('%s', 'now') - 3600)")
+                self.conn.execute("COMMIT")
+            except BaseException:
+                self.conn.execute("ROLLBACK")
+                raise
 
         # Side effects (best-effort): outbound webhooks.
         try:
@@ -1124,19 +1135,23 @@ class Database:
         with self._lock:
             # Save state for rollback on failure.
             saved_hash = self._last_hash
+            # Use BEGIN EXCLUSIVE so concurrent connections (other processes)
+            # cannot read last_hash while we are building the batch chain.
+            self.conn.execute("BEGIN EXCLUSIVE")
             try:
-                with self.conn:
-                    for et, payload, dedupe_key in event_list:
-                        ev = self._append_event_inner(
-                            event_type=et,
-                            payload=payload,
-                            dedupe_key=dedupe_key,
-                            source=source,
-                        )
-                        out.append(ev)
-            except Exception:
+                for et, payload, dedupe_key in event_list:
+                    ev = self._append_event_inner(
+                        event_type=et,
+                        payload=payload,
+                        dedupe_key=dedupe_key,
+                        source=source,
+                    )
+                    out.append(ev)
+                self.conn.execute("COMMIT")
+            except BaseException:
                 # Restore cached hash on failure — the transaction rolled back.
                 self._last_hash = saved_hash
+                self.conn.execute("ROLLBACK")
                 raise
         return out
 

--- a/engine/core/database.py
+++ b/engine/core/database.py
@@ -680,7 +680,7 @@ class Database:
     def __post_init__(self) -> None:
         self.db_path = Path(self.db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False, isolation_level=None)
         # Set connection-level pragmas before any other DB operations.
         # These MUST run before _init_schema() and outside any transaction:
         # journal_mode=WAL cannot be changed inside a transaction, and
@@ -1077,6 +1077,9 @@ class Database:
             # between our read and insert — the default BEGIN DEFERRED only
             # acquires a shared lock on read, allowing two writers to fork
             # the hash chain.
+            # Commit any implicit transaction from Python's sqlite3
+            # auto-transaction (isolation_level="") before starting ours.
+            self.conn.commit()
             self.conn.execute("BEGIN EXCLUSIVE")
             try:
                 ev = self._append_event_inner(
@@ -1137,6 +1140,7 @@ class Database:
             saved_hash = self._last_hash
             # Use BEGIN EXCLUSIVE so concurrent connections (other processes)
             # cannot read last_hash while we are building the batch chain.
+            self.conn.commit()
             self.conn.execute("BEGIN EXCLUSIVE")
             try:
                 for et, payload, dedupe_key in event_list:
@@ -1169,7 +1173,8 @@ class Database:
 
         deleted: dict[str, int] = {}
         with self._lock:
-            with self.conn:
+            self.conn.execute("BEGIN")
+            try:
                 # Events: keep last N days.
                 # Bug fix: must delete from event_dedup (FK child) BEFORE events (FK parent)
                 # to avoid FOREIGN KEY constraint violations when foreign_keys=ON.
@@ -1214,6 +1219,11 @@ class Database:
                     (retention.api_rate_limits_keep_hours,),
                 )
                 deleted["api_rate_limits"] = cursor.rowcount
+
+                self.conn.execute("COMMIT")
+            except BaseException:
+                self.conn.execute("ROLLBACK")
+                raise
 
             # VACUUM must run outside the transaction block
             if getattr(retention, "vacuum_on_prune", True) and any(v > 0 for v in deleted.values()):


### PR DESCRIPTION
## Summary

- Replaces default `BEGIN DEFERRED` transactions with `BEGIN EXCLUSIVE` in `append_event` and `append_events_batch` to prevent concurrent SQLite connections (from separate processes) from reading the same `last_hash` and forking the hash chain.
- The existing `threading.RLock` is preserved for in-process thread safety; `BEGIN EXCLUSIVE` adds cross-process serialization at the SQLite level.
- Root cause: WAL mode allows concurrent readers under `BEGIN DEFERRED`, so two writers could both read the same `prev_hash`, compute different hashes, and both insert — creating fork points (4,305 forks affecting 17,192 events observed in production).

## Test plan

- [x] `tests/unit/test_database.py` — 5 passed
- [x] `tests/e2e/test_hash_chain_integrity.py` — 11 passed
- [x] `tests/test_karma_chain.py` — 13 passed
- [ ] Monitor production for hash chain fork warnings after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)