### PR TITLE
fix: price feed coverage for bundle-only symbols + direction-level position dedup

### DIFF
--- a/engine/execution/paper.py
+++ b/engine/execution/paper.py
@@ -84,6 +84,18 @@ class PaperBroker:
         )
         return int(row[0]) if row else 0
 
+    def _has_open_position_for_direction(self, symbol: str, direction: str) -> bool:
+        """Return True if there is already an open position for *symbol* in the same *direction*.
+
+        This prevents the brain from double-firing identical trades on consecutive
+        cycles (e.g. two DOGE shorts opened seconds apart with identical parameters).
+        """
+        row = self.db.fetchone(
+            "SELECT 1 FROM positions WHERE asset = ? AND direction = ? AND status = 'open' LIMIT 1",
+            (symbol, direction),
+        )
+        return row is not None
+
     def execute_market(
         self,
         *,
@@ -145,6 +157,15 @@ class PaperBroker:
                 notional_usd=float(n_usd),
                 fee_usd=float(fee),
                 realized_pnl_usd=None,
+            )
+
+        # Direction-level deduplication: reject if the same asset+direction is
+        # already open.  This prevents the brain from double-firing identical
+        # trades on consecutive cycles (e.g. two DOGE shorts seconds apart).
+        # A conviction-flip (long -> short or vice-versa) is still allowed.
+        if self._has_open_position_for_direction(sym, dirn):
+            raise ValueError(
+                f"duplicate_open_position: {sym} already has an open {dirn} position"
             )
 
         # Deduplication: reject if open positions for this symbol exceed the limit.

--- a/engine/execution/paper.py
+++ b/engine/execution/paper.py
@@ -164,9 +164,7 @@ class PaperBroker:
         # trades on consecutive cycles (e.g. two DOGE shorts seconds apart).
         # A conviction-flip (long -> short or vice-versa) is still allowed.
         if self._has_open_position_for_direction(sym, dirn):
-            raise ValueError(
-                f"duplicate_open_position: {sym} already has an open {dirn} position"
-            )
+            raise ValueError(f"duplicate_open_position: {sym} already has an open {dirn} position")
 
         # Deduplication: reject if open positions for this symbol exceed the limit.
         # In paper mode paper_max_positions_per_symbol (default 2) allows a second

--- a/engine/producers/price_ws.py
+++ b/engine/producers/price_ws.py
@@ -67,9 +67,18 @@ class PriceAlertsProducer(BaseProducer):
         """Optional custom/paid data endpoint override."""
         return os.getenv("B1E55ED_PRICE_WS_URL") or os.getenv("PRICE_WS_URL")
 
+    def _all_subscribed_symbols(self) -> list[str]:
+        """Return deduplicated symbol list from universe.symbols AND bundle symbols.
+
+        Uses ``active_symbols()`` which merges enabled bundle symbols with
+        explicit ``universe.symbols`` — ensures assets like DOGE that live only
+        in a bundle still receive price data.
+        """
+        return [s.upper().strip() for s in self.ctx.config.universe.active_symbols()]
+
     def _collect_from_custom(self, url: str) -> list[dict[str, Any]]:
         """Fetch from a custom POST endpoint (original behaviour)."""
-        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        symbols = self._all_subscribed_symbols()
         data: Any = asyncio.run(self.ctx.client.request_json("POST", url, expected=(list, dict), json={"symbols": symbols}))
         if isinstance(data, dict) and "data" in data:
             data = data["data"]
@@ -92,7 +101,7 @@ class PriceAlertsProducer(BaseProducer):
 
     def _collect_free(self) -> list[dict[str, Any]]:
         """Free public API fallback (Binance Ticker). Always available."""
-        symbols = [s.upper().strip() for s in self.ctx.config.universe.symbols]
+        symbols = self._all_subscribed_symbols()
         results: list[dict[str, Any]] = []
 
         _cap = getattr(self.ctx.config.universe, "max_symbols", 0)

--- a/tests/unit/test_paper.py
+++ b/tests/unit/test_paper.py
@@ -95,6 +95,61 @@ def test_paper_multi_position_same_symbol(temp_dir: Path) -> None:
         )
 
 
+def test_paper_same_direction_dedup_blocks_duplicate(temp_dir: Path) -> None:
+    """Same symbol + same direction must be rejected even when max_positions_per_symbol=2."""
+    db = Database(temp_dir / "brain.db")
+    cfg = PaperConfig(max_positions_per_symbol=2)
+    broker = PaperBroker(db, config=cfg)
+
+    broker.execute_market(
+        symbol="DOGE",
+        direction="short",
+        notional_usd=500.0,
+        leverage=1.0,
+        mid_price=0.15,
+        idempotency_key="doge-short-1",
+    )
+
+    # Second short on same symbol must be rejected (direction-level dedup)
+    with pytest.raises(ValueError, match="duplicate_open_position.*open short"):
+        broker.execute_market(
+            symbol="DOGE",
+            direction="short",
+            notional_usd=500.0,
+            leverage=1.0,
+            mid_price=0.15,
+            idempotency_key="doge-short-2",
+        )
+
+
+def test_paper_conviction_flip_allowed(temp_dir: Path) -> None:
+    """Opposite direction (conviction flip) must still be allowed."""
+    db = Database(temp_dir / "brain.db")
+    cfg = PaperConfig(max_positions_per_symbol=2)
+    broker = PaperBroker(db, config=cfg)
+
+    fill1 = broker.execute_market(
+        symbol="BTC",
+        direction="long",
+        notional_usd=1000.0,
+        leverage=1.0,
+        mid_price=50_000.0,
+        idempotency_key="btc-long-1",
+    )
+
+    # Short on same symbol must succeed (different direction)
+    fill2 = broker.execute_market(
+        symbol="BTC",
+        direction="short",
+        notional_usd=1000.0,
+        leverage=1.0,
+        mid_price=50_000.0,
+        idempotency_key="btc-short-1",
+    )
+
+    assert fill1.position_id != fill2.position_id
+
+
 def test_paper_single_position_legacy_blocks_duplicate(temp_dir: Path) -> None:
     """max_positions_per_symbol=1 (legacy default) still blocks a second position."""
     db = Database(temp_dir / "brain.db")

--- a/tests/unit/test_price_ws.py
+++ b/tests/unit/test_price_ws.py
@@ -1,0 +1,76 @@
+"""Tests for engine.producers.price_ws — symbol subscription coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from engine.core.config import Config, UniverseBundle, UniverseConfig
+from engine.producers.price_ws import PriceAlertsProducer
+
+
+def _make_producer_with_config(config: Config) -> PriceAlertsProducer:
+    """Create a PriceAlertsProducer with a mocked context carrying *config*."""
+    ctx = MagicMock()
+    ctx.config = config
+    ctx.logger = MagicMock()
+    producer = PriceAlertsProducer.__new__(PriceAlertsProducer)
+    producer.ctx = ctx
+    return producer
+
+
+def test_all_subscribed_symbols_includes_bundle_symbols() -> None:
+    """Bundle-only symbols (e.g. DOGE in crypto-core) must appear in the subscription list."""
+    universe = UniverseConfig(
+        symbols=["BTC", "ETH"],
+        bundles=[
+            UniverseBundle(
+                id="crypto-core",
+                name="Crypto Core",
+                symbols=["BTC", "ETH", "SOL", "DOGE"],
+                enabled=True,
+            ),
+        ],
+    )
+    cfg = Config(universe=universe)
+    producer = _make_producer_with_config(cfg)
+
+    syms = producer._all_subscribed_symbols()
+
+    # DOGE is only in the bundle, not in universe.symbols — must still be included
+    assert "DOGE" in syms
+    assert "SOL" in syms
+    # No duplicates
+    assert len(syms) == len(set(syms))
+
+
+def test_all_subscribed_symbols_empty_bundles_uses_explicit() -> None:
+    """When no bundles are configured, explicit universe.symbols are used."""
+    universe = UniverseConfig(symbols=["BTC", "ETH"])
+    cfg = Config(universe=universe)
+    producer = _make_producer_with_config(cfg)
+
+    syms = producer._all_subscribed_symbols()
+    assert syms == ["BTC", "ETH"]
+
+
+def test_all_subscribed_symbols_disabled_bundle_excluded() -> None:
+    """Disabled bundles must not contribute symbols."""
+    universe = UniverseConfig(
+        symbols=["BTC"],
+        bundles=[
+            UniverseBundle(
+                id="disabled-bundle",
+                name="Disabled",
+                symbols=["XRP", "ADA"],
+                enabled=False,
+            ),
+        ],
+    )
+    cfg = Config(universe=universe)
+    producer = _make_producer_with_config(cfg)
+
+    syms = producer._all_subscribed_symbols()
+    assert "XRP" not in syms
+    assert "ADA" not in syms
+    assert "BTC" in syms

--- a/tests/unit/test_price_ws.py
+++ b/tests/unit/test_price_ws.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 from engine.core.config import Config, UniverseBundle, UniverseConfig


### PR DESCRIPTION
## Summary

- **Price feed gap**: The price websocket producer (`price_ws.py`) only subscribed to `universe.symbols`, missing assets like DOGE that exist only in bundles (e.g. `crypto-core`). Now uses `active_symbols()` which merges both bundle and explicit symbols. Fixes DOGE positions having no mark price for 235+ hours.
- **Duplicate positions**: Added direction-level deduplication in `PaperBroker.execute_market()` — rejects a new position if one already exists for the same asset+direction. Conviction flips (long to short) remain allowed. Prevents the brain from double-firing identical trades on consecutive cycles.

## Test plan

- [x] Existing tests pass (6/6 in test_oms + test_paper)
- [x] New test: `test_paper_same_direction_dedup_blocks_duplicate` — verifies same-direction rejection
- [x] New test: `test_paper_conviction_flip_allowed` — verifies opposite-direction still works
- [x] New test: `test_all_subscribed_symbols_includes_bundle_symbols` — verifies DOGE-like bundle-only symbols are included
- [x] New test: `test_all_subscribed_symbols_disabled_bundle_excluded` — verifies disabled bundles are excluded
- [x] New test: `test_all_subscribed_symbols_empty_bundles_uses_explicit` — verifies fallback to explicit symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)