### PR TITLE
fix(regime): unblock detector deadlock with lower threshold + tiebreaker

### DIFF
--- a/engine/brain/regime.py
+++ b/engine/brain/regime.py
@@ -114,10 +114,18 @@ class RegimeDetector:
 
         if crisis >= 2:
             regime = "CRISIS"
-        elif bull >= 3:
+        elif bull >= 2 and bull > bear:
             regime = "BULL"
-        elif bear >= 3:
+        elif bear >= 2 and bear > bull:
             regime = "BEAR"
+        elif bull >= 2 and bull == bear:
+            # Tiebreaker: fear_greed sentiment breaks the deadlock.
+            if fng is not None and fng < 25.0:
+                regime = "BEAR"
+            elif fng is not None and fng > 40.0:
+                regime = "BULL"
+            else:
+                regime = "TRANSITION"
         else:
             regime = "TRANSITION"
 

--- a/tests/unit/test_regime.py
+++ b/tests/unit/test_regime.py
@@ -63,3 +63,53 @@ def test_regime_classifies_bull_bear_crisis_transition(temp_dir):
     transition = _snap({"technical": {"rsi_14": 50.0}})
     r4 = det.detect(as_of=datetime.now(tz=UTC), btc_snapshot=transition)
     assert r4.state.regime == "TRANSITION"
+
+
+def test_regime_tiebreaker_bear(temp_dir):
+    """2 bull + 2 bear with fear_greed < 25 should break tie to BEAR."""
+    db = Database(temp_dir / "brain.db")
+    det = RegimeDetector(db)
+
+    # funding+RSI vote BULL(2), basis+fear_greed vote BEAR(2)
+    deadlock = _snap(
+        {
+            "technical": {"rsi_14": 55.0},
+            "tradfi": {"funding_annualized": 10.0, "basis_annualized": 1.5},
+            "social": {"fear_greed": 8.36},
+        }
+    )
+    r = det.detect(as_of=datetime.now(tz=UTC), btc_snapshot=deadlock)
+    assert r.state.regime == "BEAR"
+
+
+def test_regime_tiebreaker_bull(temp_dir):
+    """2 bull + 2 bear with fear_greed > 40 should break tie to BULL."""
+    db = Database(temp_dir / "brain.db")
+    det = RegimeDetector(db)
+
+    # rsi < 30 + basis < 2 vote BEAR(2), funding + fng vote BULL(2)
+    deadlock = _snap(
+        {
+            "technical": {"rsi_14": 25.0},
+            "tradfi": {"funding_annualized": 10.0, "basis_annualized": 1.5},
+            "social": {"fear_greed": 50.0},
+        }
+    )
+    r = det.detect(as_of=datetime.now(tz=UTC), btc_snapshot=deadlock)
+    assert r.state.regime == "BULL"
+
+
+def test_regime_majority_bull_without_full_consensus(temp_dir):
+    """2 bull > 1 bear should classify BULL (no longer needs 3/4)."""
+    db = Database(temp_dir / "brain.db")
+    det = RegimeDetector(db)
+
+    snap = _snap(
+        {
+            "technical": {"rsi_14": 55.0},
+            "tradfi": {"funding_annualized": 10.0, "basis_annualized": 1.5},
+            "social": {"fear_greed": 30.0},
+        }
+    )
+    r = det.detect(as_of=datetime.now(tz=UTC), btc_snapshot=snap)
+    assert r.state.regime == "BULL"


### PR DESCRIPTION
## Summary
- Lower BULL/BEAR vote threshold from 3/4 to 2/4 with majority-wins semantics
- Add fear_greed tiebreaker when bull == bear (2-2 deadlock): fng < 25 -> BEAR, fng > 40 -> BULL, else TRANSITION
- Unblocks the current BTC regime deadlock where funding+RSI vote BULL and basis+fear_greed vote BEAR

## Context
The regime detector was stuck on TRANSITION because it required 3/4 indicators to agree for BULL or BEAR. With current BTC features (funding+RSI bullish, basis+fear_greed bearish), a 2-2 deadlock was unbreakable. Fear & Greed at 8.36 (extreme fear) should resolve to BEAR but couldn't under the old threshold.

The fix mirrors the `detect_for_asset()` method which already uses `>= 2 and bull > bear` logic, plus adds a tiebreaker for the global `detect()` path.

## Test plan
- [x] Existing `test_regime_classifies_bull_bear_crisis_transition` passes (all original classifications preserved)
- [x] New `test_regime_tiebreaker_bear` — 2-2 deadlock with fng=8.36 resolves to BEAR
- [x] New `test_regime_tiebreaker_bull` — 2-2 deadlock with fng=50 resolves to BULL
- [x] New `test_regime_majority_bull_without_full_consensus` — 2 bull > 1 bear classifies BULL
- [x] Per-asset regime tests unaffected (10/10 pass)
- [x] Full suite: 1582 passed, 18 failed (all pre-existing infra failures)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)