### PR TITLE
fix(horizon): wire signal timeframe through to position horizon_hours

### DIFF
--- a/engine/brain/decision.py
+++ b/engine/brain/decision.py
@@ -29,6 +29,7 @@ class DecisionContext:
     regime: str
     kill_level: KillSwitchLevel
     source_event_ids: list[str] = field(default_factory=list)
+    horizon: str | None = None
 
 
 @runtime_checkable
@@ -91,6 +92,7 @@ class DefaultDecisionPolicy:
             rationale=rationale,
             stop_loss_pct=0.05,
             take_profit_pct=0.10,
+            horizon=ctx.horizon,
             source_event_ids=list(ctx.source_event_ids),
         )
 
@@ -117,6 +119,7 @@ class DecisionEngine:
         source: str = "brain.decision",
         trace_id: str | None = None,
         source_event_ids: list[str] | None = None,
+        horizon: str | None = None,
     ) -> TradeIntent | None:
         ctx = DecisionContext(
             symbol=str(symbol).upper(),
@@ -124,6 +127,7 @@ class DecisionEngine:
             regime=str(regime),
             kill_level=kill_level,
             source_event_ids=list(source_event_ids or []),
+            horizon=horizon,
         )
         intent = self.policy.decide(ctx)
         if intent is None:

--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -514,10 +514,29 @@ class BrainOrchestrator:
             cal_dict = cal.model_dump() if cal is not None else None
             v2 = compute_v2_overrides(_regime_v2_result, synth.snapshot.features, cal_dict)
 
+            # Extract dominant horizon from contributing forecast events.
+            # Most recent/frequent horizon wins; default to "4h" if none found.
+            _dominant_horizon = "4h"
+            try:
+                _src_ids = list(synth.snapshot.source_event_ids or [])
+                if _src_ids:
+                    _ph = ",".join("?" * len(_src_ids))
+                    _h_rows = self.db.fetchall(
+                        f"SELECT json_extract(payload, '$.horizon') as h FROM events WHERE id IN ({_ph}) AND h IS NOT NULL",
+                        tuple(_src_ids),
+                    )
+                    _horizons = [str(r[0]) for r in _h_rows if r[0]]
+                    if _horizons:
+                        from collections import Counter
+                        _dominant_horizon = Counter(_horizons).most_common(1)[0][0]
+            except Exception:
+                pass  # fall back to "4h"
+
             conv = self.conviction.compute(
                 synthesis=synth,
                 regime=v2.regime_label if v2 else regime_res.state.regime,
                 as_of=now,
+                timeframe=_dominant_horizon,
                 regime_multiplier_v2=v2.regime_multiplier if v2 else None,
                 cts_v2=v2.cts if v2 else None,
             )
@@ -540,6 +559,7 @@ class BrainOrchestrator:
                 kill_level=self.kill_switch.level,
                 trace_id=cycle_id,
                 source_event_ids=list(synth.snapshot.source_event_ids or []),
+                horizon=conv.score.timeframe,
             )
             if intent is not None:
                 # TradeIntent is a frozen slots dataclass.
@@ -632,6 +652,7 @@ class BrainOrchestrator:
                             rationale="auto_paper_trade:high_confidence",
                             stop_loss_pct=0.05,
                             take_profit_pct=0.10,
+                            horizon=conv.score.timeframe,  # signal-driven hold duration
                             intended_price=mid_price,
                             conviction_id=_conv_id,
                             source_event_ids=list(synth_results[sym].snapshot.source_event_ids or []),

--- a/engine/brain/orchestrator.py
+++ b/engine/brain/orchestrator.py
@@ -528,6 +528,7 @@ class BrainOrchestrator:
                     _horizons = [str(r[0]) for r in _h_rows if r[0]]
                     if _horizons:
                         from collections import Counter
+
                         _dominant_horizon = Counter(_horizons).most_common(1)[0][0]
             except Exception:
                 pass  # fall back to "4h"


### PR DESCRIPTION
## Summary
Positions were always created with `horizon_hours=NULL` despite the full pipeline being built. This PR connects the dots:

- **Orchestrator**: extracts dominant horizon from contributing forecast events (most frequent wins, default "4h")
- **Decision engine**: passes horizon from conviction score through to TradeIntent
- **Auto-paper-trade**: sets `horizon=conv.score.timeframe` on TradeIntent

Now `position_monitor`'s existing `horizon_expiry_close` will auto-close positions when their signal's timeframe elapses.

## Data Flow (before → after)
```
Producers emit horizon → Synthesis → Conviction (timeframe="4h" always) → TradeIntent (horizon=None) → DB (NULL)
Producers emit horizon → Synthesis → Conviction (timeframe=dominant) → TradeIntent (horizon="24h") → DB (24.0)
```

## Test plan
- [ ] Run brain cycle, verify new positions have `horizon_hours` set: `SELECT asset, horizon_hours FROM positions ORDER BY opened_at DESC LIMIT 5`
- [ ] Verify position_monitor logs `horizon_expiry` closes after the horizon elapses
- [ ] Existing tests pass (horizon field is optional, defaults maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)