### PR TITLE
fix(test): isolate config save test from real config

### DIFF
--- a/tests/unit/test_api_config.py
+++ b/tests/unit/test_api_config.py
@@ -13,10 +13,11 @@ from tests.unit._api_test_client import make_client
 async def test_config_read_validate_save(temp_dir, test_config, monkeypatch):
     test_config = test_config.model_copy(update={"api": test_config.api.model_copy(update={"auth_token": "secret"})})
 
-    # Ensure cwd is temp_dir so api routes write there
-    monkeypatch.chdir(temp_dir)
-    (temp_dir / "config").mkdir(parents=True, exist_ok=True)
-    (temp_dir / "config" / "default.yaml").write_text("preset: balanced\n")
+    # Redirect config_dir so the save endpoint writes to temp_dir, not ~/.b1e55ed
+    config_subdir = temp_dir / "config"
+    config_subdir.mkdir(parents=True, exist_ok=True)
+    (config_subdir / "default.yaml").write_text("preset: balanced\n")
+    monkeypatch.setattr("engine.core.paths.config_dir", lambda: config_subdir)
 
     app = create_app()
     app.state.config = test_config


### PR DESCRIPTION
## Summary
- `test_config_read_validate_save` was writing to the real `~/.b1e55ed/config/user.yaml` because `_config_path()` resolves via `engine.core.paths.config_dir()`, which ignores `monkeypatch.chdir()`
- This clobbered the operator's runtime config with test values: empty universe/bundles, pytest temp `data_dir`/`config_dir`
- Root cause of the April 8 signal outage — brain reported `UNIVERSE_EMPTY` because the config was overwritten by a test run
- Fix: monkeypatch `engine.core.paths.config_dir` to return the test's temp dir

## Test plan
- [x] `pytest tests/unit/test_api_config.py` passes
- [x] Verified real `~/.b1e55ed/config/user.yaml` is not modified after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)