### PR TITLE
fix(conviction): single-domain coverage discount + PCS cap

### DIFF
--- a/engine/brain/conviction.py
+++ b/engine/brain/conviction.py
@@ -177,6 +177,13 @@ class ConvictionEngine:
 
         # PCS is 0..100
         pcs = float(_clamp(synthesis.weighted_score * 100.0, 0.0, 100.0))
+
+        # Hard cap: single-domain paths cannot enter High conviction.
+        n_domains = len(synthesis.domain_scores)
+        if n_domains <= 1:
+            cap = float(getattr(self.config.brain, "single_domain_max_pcs", 45.0))
+            pcs = min(pcs, cap)
+
         cts = float(self.counter_thesis.compute(synthesis=synthesis, pcs=pcs, regime=regime))
 
         # Final conviction: penalize PCS by up to 50% (cts=100 => -50%)
@@ -258,6 +265,12 @@ class ConvictionEngine:
 
         # Base PCS from synthesis
         base_pcs = float(_clamp(synthesis.weighted_score * 100.0, 0.0, 100.0))
+
+        # Hard cap: single-domain paths cannot enter High conviction.
+        n_domains = len(synthesis.domain_scores)
+        if n_domains <= 1:
+            cap = float(getattr(self.config.brain, "single_domain_max_pcs", 45.0))
+            base_pcs = min(base_pcs, cap)
 
         # CTS v2 contributes positively to PCS (0-35 range).
         # In v2, CTS measures "how interesting/actionable is the market" not "counter-evidence".

--- a/engine/brain/synthesis.py
+++ b/engine/brain/synthesis.py
@@ -483,6 +483,12 @@ class VectorSynthesis:
                 weighted_score = 0.0
                 for dom, s in domain_scores.items():
                     weighted_score += float(weights_effective.get(dom, 0.0)) * float(s)
+
+                # Coverage discount: fewer active domains → lower confidence.
+                # 1 domain → ×0.57, 2 → ×0.64, 3 → ×0.71, all → ×1.0.
+                n_possible = max(sum(1 for v in weights_used.values() if v > 0), len(domain_scores))
+                coverage = len(domain_scores) / max(n_possible, 1)
+                weighted_score = weighted_score * (0.5 + 0.5 * coverage)
             else:
                 # All scored domains were quality-gated to zero weight.
                 # Respect the gate and remain neutral.

--- a/engine/core/config.py
+++ b/engine/core/config.py
@@ -151,6 +151,10 @@ class BrainConfig(BaseModel):
     for testing.  Default: 5.0 (production-safe).
     Recommended testing range: 2.5–4.0."""
 
+    single_domain_max_pcs: float = 45.0
+    """Hard ceiling on PCS when only one domain contributed to synthesis.
+    Prevents single-domain paths from entering the High conviction cohort."""
+
     use_regime_v2: bool = False
     """Feature flag: enable continuous regime detector + CTS v2.
 

--- a/tests/unit/test_conviction.py
+++ b/tests/unit/test_conviction.py
@@ -26,6 +26,10 @@ def _build_engine(test_config, temp_dir, monkeypatch) -> ConvictionEngine:
 
 
 def _build_synthesis(*, weighted_score: float, features: dict[str, dict[str, float]]):
+    # Ensure at least 2 domains so single-domain PCS cap doesn't interfere.
+    # Add a minimal second domain with neutral values that won't affect CTS.
+    if len(features) < 2:
+        features = {**features, "events": {"event_count": 0.0}}
     snap = FeatureSnapshot(
         cycle_id="c",
         symbol="BTC",

--- a/tests/unit/test_conviction_attribution.py
+++ b/tests/unit/test_conviction_attribution.py
@@ -222,3 +222,64 @@ def test_primary_feature_is_max_absolute_value(test_config, temp_dir, monkeypatc
     assert row is not None
     assert str(row["feature_key"]) == "ema"
     assert float(row["feature_value"]) == pytest.approx(-0.9)
+
+
+def test_single_domain_pcs_capped(test_config, temp_dir, monkeypatch):
+    """Single-domain trades should have PCS capped at single_domain_max_pcs."""
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    # Single domain: social only, high score
+    snapshot = FeatureSnapshot(
+        cycle_id="cycle-cap",
+        symbol="HYPE",
+        ts=datetime.now(tz=UTC),
+        features={"social": {"fear_greed": 80.0, "score": 0.9}},
+        source_event_ids=["evt-1"],
+        regime="BULL",
+        version="v2",
+    )
+    synthesis = SimpleNamespace(
+        snapshot=snapshot,
+        domain_scores={"social": 0.75},
+        weights_used={"social": 0.15, "technical": 0.10, "tradfi": 0.20},
+        weighted_score=0.75,  # would give PCS=75 uncapped
+    )
+
+    result = eng.compute(synthesis=synthesis, regime="BULL", as_of=datetime.now(tz=UTC))
+    assert result.pcs <= test_config.brain.single_domain_max_pcs
+
+
+def test_multi_domain_pcs_not_capped(test_config, temp_dir, monkeypatch):
+    """Multi-domain trades should not be capped by single_domain_max_pcs."""
+    monkeypatch.setenv("B1E55ED_MASTER_PASSWORD", "test")
+    ident = generate_node_identity()
+
+    db = Database(temp_dir / "brain.db")
+    eng = ConvictionEngine(test_config, db, node_id=ident.node_id)
+
+    snapshot = FeatureSnapshot(
+        cycle_id="cycle-multi",
+        symbol="BTC",
+        ts=datetime.now(tz=UTC),
+        features={
+            "tradfi": {"funding_annualized": 20.0},
+            "technical": {"rsi_14": 70.0},
+        },
+        source_event_ids=["evt-1"],
+        regime="BULL",
+        version="v2",
+    )
+    synthesis = SimpleNamespace(
+        snapshot=snapshot,
+        domain_scores={"tradfi": 0.8, "technical": 0.7},
+        weights_used={"tradfi": 0.6, "technical": 0.4},
+        weighted_score=0.76,
+    )
+
+    result = eng.compute(synthesis=synthesis, regime="BULL", as_of=datetime.now(tz=UTC))
+    # Multi-domain should not be capped at 45
+    assert result.pcs > test_config.brain.single_domain_max_pcs

--- a/tests/unit/test_synthesis.py
+++ b/tests/unit/test_synthesis.py
@@ -116,7 +116,10 @@ def test_synthesis_sparse_domains_do_not_default_bearish(test_config, temp_dir):
 
     assert set(res.domain_scores) == {"social"}
     assert res.weights_used["social"] == pytest.approx(1.0)
-    assert res.weighted_score == pytest.approx(res.domain_scores["social"])
+    # Coverage discount: 1 domain active → score is discounted (not 1:1 with domain score).
+    # Key invariant: single-domain should NOT default to bearish.
+    assert res.weighted_score > 0.0
+    assert res.weighted_score < res.domain_scores["social"]  # discounted
 
 
 def test_synthesis_no_domain_evidence_stays_neutral(test_config, temp_dir):


### PR DESCRIPTION
## Summary
Calibration fix based on [conviction inversion postmortem](conviction-inversion-memo.md). The [social]-only domain path was scoring PCS=74.83 for all HYPE trades (22 trades, 100% of High cohort), creating a false inverse signal in stratification.

Two changes:
- **Coverage discount** (synthesis.py): fewer active domains → lower weighted score. Formula: `score × (0.5 + 0.5 × coverage)` where coverage = active_domains / possible_domains
- **Hard PCS cap** (conviction.py): single-domain trades capped at `brain.single_domain_max_pcs` (default 45). Configurable in user.yaml

Expected impact: HYPE trades move from High (PCS 74.83) to Low (~43). High cohort reserved for genuine multi-domain agreement.

## Test plan
- [x] `test_single_domain_pcs_capped` — verifies cap applied for 1-domain trades
- [x] `test_multi_domain_pcs_not_capped` — verifies multi-domain trades unaffected
- [x] All 8 conviction attribution tests pass
- [x] Deployed to blessed-patient-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)