### PR TITLE
fix(execution): enforce paper max hold expiry

### DIFF
--- a/engine/cli/main.py
+++ b/engine/cli/main.py
@@ -2406,7 +2406,15 @@ def _cmd_monitor_positions(ctx: CliContext, args: argparse.Namespace) -> int:
     db = Database(_resolve_db_path(ctx.repo_root))
     config = _load_config(ctx)
 
-    result: dict = {"evaluated": 0, "closed_stop": 0, "closed_target": 0, "closed_time_stop": 0, "errors": 0}
+    result: dict = {
+        "evaluated": 0,
+        "closed_stop": 0,
+        "closed_target": 0,
+        "closed_time_stop": 0,
+        "closed_bias_flip": 0,
+        "closed_horizon_expiry": 0,
+        "errors": 0,
+    }
     try:
         result = monitor_positions(db, config)
     except Exception as exc:
@@ -2419,12 +2427,21 @@ def _cmd_monitor_positions(ctx: CliContext, args: argparse.Namespace) -> int:
     if bool(getattr(args, "json", False)):
         print(_json_dumps(result))
     else:
-        closed = result["closed_stop"] + result["closed_target"] + result["closed_time_stop"]
+        close_keys = (
+            "closed_stop",
+            "closed_target",
+            "closed_time_stop",
+            "closed_bias_flip",
+            "closed_horizon_expiry",
+        )
+        closed = sum(int(result.get(k, 0) or 0) for k in close_keys)
         print(
             f"position-monitor: evaluated={result['evaluated']} "
             f"closed_stop={result['closed_stop']} "
             f"closed_target={result['closed_target']} "
             f"closed_time_stop={result['closed_time_stop']} "
+            f"closed_bias_flip={result.get('closed_bias_flip', 0)} "
+            f"closed_horizon_expiry={result.get('closed_horizon_expiry', 0)} "
             f"errors={result['errors']}"
         )
         if closed:

--- a/engine/execution/oms.py
+++ b/engine/execution/oms.py
@@ -137,9 +137,14 @@ class OMS:
 
                 # Parse horizon string (e.g. "4h") to numeric hours for
                 # position_monitor bias-flip scoping + horizon-expiry close.
+                # If no horizon is supplied, fall back to paper_max_hold_hours
+                # so paper positions always have an expiry anchor and cannot
+                # become stale zombies with horizon_hours=NULL.
                 _horizon_hours = None
                 if intent.horizon:
                     _horizon_hours = _parse_horizon_to_hours(intent.horizon)
+                if _horizon_hours is None:
+                    _horizon_hours = float(getattr(self.config.execution, "paper_max_hold_hours", 72) or 72)
 
                 fill = self.paper.execute_market(
                     symbol=intent.symbol,

--- a/engine/execution/position_monitor.py
+++ b/engine/execution/position_monitor.py
@@ -4,8 +4,8 @@ Standalone position monitor for paper trading Phase 0.
 
 Responsibilities:
 1. Evaluate stop_loss and take_profit for every open position each run.
-2. Time-based stop: close any paper position open > 72 hours that is also
-   losing > 5% (prevents stale positions blocking the trade count).
+2. Time-based stop: close any paper position open longer than the configured
+   paper max hold. A max hold is a hard exit, not a loss-only stop.
 3. Fetch mark prices from Binance (same logic as the dashboard / orchestrator).
 4. Call PnLTracker.close_position when a stop/target is triggered.
 5. Emit a clear audit event for every auto-close.
@@ -45,7 +45,7 @@ _log = logging.getLogger("b1e55ed.position_monitor")
 # ---------------------------------------------------------------------------
 
 PAPER_TIME_STOP_HOURS: float = 72.0
-PAPER_TIME_STOP_LOSS_PCT: float = 0.05  # 5 %
+
 
 # ---------------------------------------------------------------------------
 # Bias-flip: max age (seconds) for a conviction to count as "current"
@@ -208,31 +208,35 @@ def monitor_positions(db: Database, config: Config) -> dict:
                 close_reason = "take_profit"
 
         # --- time-based stop (paper mode only) ----------------------------
+        # paper_max_hold_hours is a hard maximum hold.  The old implementation
+        # only closed stale positions when they were down >= 5%, which let flat
+        # or profitable paper trades become zombies forever and block learning.
         if close_reason is None and is_paper and opened_at_raw and entry_price > 0:
             try:
                 opened_at = datetime.fromisoformat(opened_at_raw)
                 if opened_at.tzinfo is None:
                     opened_at = opened_at.replace(tzinfo=UTC)
                 age_hours = (now - opened_at).total_seconds() / 3600.0
+                max_hold_hours = float(getattr(getattr(config, "execution", None), "paper_max_hold_hours", PAPER_TIME_STOP_HOURS) or 0.0)
 
-                if age_hours >= PAPER_TIME_STOP_HOURS:
+                if max_hold_hours > 0 and age_hours >= max_hold_hours:
                     if direction == "long":
-                        loss_pct = (entry_price - mark) / entry_price
+                        pnl_pct = (mark - entry_price) / entry_price
                     else:  # short
-                        loss_pct = (mark - entry_price) / entry_price
+                        pnl_pct = (entry_price - mark) / entry_price
 
-                    if loss_pct >= PAPER_TIME_STOP_LOSS_PCT:
-                        close_reason = "time_stop"
-                        _log.info(
-                            "time-stop triggered: position %s %s %s open %.1fh loss=%.2f%% entry=%.4f mark=%.4f",
-                            pos_id,
-                            direction,
-                            asset,
-                            age_hours,
-                            loss_pct * 100,
-                            entry_price,
-                            mark,
-                        )
+                    close_reason = "time_stop"
+                    _log.info(
+                        "time-stop triggered: position %s %s %s open %.1fh >= max_hold %.1fh pnl=%.2f%% entry=%.4f mark=%.4f",
+                        pos_id,
+                        direction,
+                        asset,
+                        age_hours,
+                        max_hold_hours,
+                        pnl_pct * 100,
+                        entry_price,
+                        mark,
+                    )
             except Exception:
                 _log.debug("time-stop calculation failed for %s", pos_id, exc_info=True)
 

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -6,9 +6,9 @@ Tests:
 1. stop_loss triggers a position close (short: price rises above stop)
 2. take_profit triggers a position close (short: price falls below target)
 3. Long stop_loss triggers a position close (long: price falls below stop)
-4. Time-based stop: position open > 72h AND losing > 5% → close
-5. Time-based stop does NOT trigger when position is < 72h old
-6. Time-based stop does NOT trigger when position is not losing > 5%
+4. Time-based stop: position open > execution.paper_max_hold_hours → close
+5. Time-based stop does NOT trigger when position is younger than max hold
+6. Time-based stop closes old positions regardless of PnL
 7. No close when neither stop nor time-stop condition is met
 8. consecutive_loss_count = 2 does NOT block new trades (kill switch stays SAFE)
 9. Bias-flip close: conviction flips direction for same (symbol, horizon) → close
@@ -252,8 +252,8 @@ class TestTimeStop:
         assert row["status"] == "open", "Young position should NOT be time-stopped"
         assert stats["closed_time_stop"] == 0
 
-    def test_time_stop_does_not_trigger_when_small_loss(self, tmp_db: Database, paper_config: Config):
-        """Position > 72h but loss < 5% should NOT be time-stopped."""
+    def test_time_stop_triggers_when_old_even_with_small_loss(self, tmp_db: Database, paper_config: Config):
+        """paper_max_hold_hours is a hard max hold, not a loss-only stop."""
         old_open = datetime.now(tz=UTC) - timedelta(hours=100)
         pos_id = _insert_position(
             tmp_db,
@@ -264,13 +264,33 @@ class TestTimeStop:
             opened_at=old_open,
         )
 
-        mark_price = 89.23 * 1.03  # only 3% adverse — below 5% threshold
+        mark_price = 89.23 * 1.03  # only 3% adverse — still stale past max hold
         with _mark_price_side_effect(mark_price):
             stats = monitor_positions(tmp_db, paper_config)
 
         row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
-        assert row["status"] == "open", "Small-loss old position should NOT be time-stopped"
-        assert stats["closed_time_stop"] == 0
+        assert row["status"] == "closed", "Old paper position should close at max hold regardless of loss size"
+        assert stats["closed_time_stop"] == 1
+
+    def test_time_stop_triggers_when_old_and_profitable(self, tmp_db: Database, paper_config: Config):
+        """Profitable paper positions should not become zombies past max hold."""
+        old_open = datetime.now(tz=UTC) - timedelta(hours=100)
+        pos_id = _insert_position(
+            tmp_db,
+            direction="short",
+            entry_price=100.0,
+            stop_loss=120.0,
+            take_profit=80.0,
+            opened_at=old_open,
+        )
+
+        with _mark_price_side_effect(95.0):  # profitable short, no target hit
+            stats = monitor_positions(tmp_db, paper_config)
+
+        row = tmp_db.fetchone("SELECT status, realized_pnl FROM positions WHERE id = ?", (pos_id,))
+        assert row["status"] == "closed"
+        assert row["realized_pnl"] > 0
+        assert stats["closed_time_stop"] == 1
 
     def test_no_close_when_no_condition_met(self, tmp_db: Database, paper_config: Config):
         """Position with no stop/target/time-stop condition → stays open."""
@@ -569,8 +589,8 @@ class TestHorizonExpiryClose:
         assert row["status"] == "open", "Position younger than horizon should stay open"
         assert stats["closed_horizon_expiry"] == 0
 
-    def test_horizon_expiry_does_not_trigger_when_null(self, tmp_db: Database, paper_config: Config):
-        """Position with horizon_hours=NULL → no expiry, stays open."""
+    def test_null_horizon_old_position_falls_back_to_max_hold_close(self, tmp_db: Database, paper_config: Config):
+        """horizon_hours=NULL should not let an old paper position live forever."""
         pos_id = _insert_position(
             tmp_db,
             asset="ETH",
@@ -586,8 +606,9 @@ class TestHorizonExpiryClose:
             stats = monitor_positions(tmp_db, paper_config)
 
         row = tmp_db.fetchone("SELECT status FROM positions WHERE id = ?", (pos_id,))
-        assert row["status"] == "open"
+        assert row["status"] == "closed"
         assert stats["closed_horizon_expiry"] == 0
+        assert stats["closed_time_stop"] == 1
 
     def test_stop_loss_takes_priority_over_horizon_expiry(self, tmp_db: Database, paper_config: Config):
         """When both stop_loss and horizon_expiry would trigger, stop_loss wins."""

--- a/tests/unit/test_oms.py
+++ b/tests/unit/test_oms.py
@@ -48,6 +48,7 @@ def test_submit_intent_paper_creates_fill_and_events(temp_dir: Path, test_config
     pos = db.conn.execute("SELECT * FROM positions WHERE id = ?", (res.position_id,)).fetchone()
     assert pos is not None
     assert pos["status"] == "open"
+    assert float(pos["horizon_hours"]) == float(test_config.execution.paper_max_hold_hours)
 
     # execution events emitted
     # Note: trade_intent.v1 is now emitted by decision.py, not OMS


### PR DESCRIPTION
## Summary
- Enforces `execution.paper_max_hold_hours` as a hard expiry for paper positions
- Closes stale paper positions when age exceeds configured horizon, including stale marks / flat PnL cases
- Adds monitor/OMS counters and test coverage for horizon expiry

## Test Plan
- `pytest tests/test_position_monitor.py tests/unit/test_oms.py`
- ruff/mypy checks passed before push
